### PR TITLE
Merging updates . PR message will haev more details

### DIFF
--- a/common/source/host/kernel_interrupt.cpp
+++ b/common/source/host/kernel_interrupt.cpp
@@ -197,7 +197,7 @@ void KernelInterrupt::wait_for_event() {
     uint64_t val = 0;
     ssize_t bytes_read = read(pfd.fd, &val, sizeof(val));
     if (bytes_read < 0) {
-      std::string err(num_events < 0 ? strerror(errno) : "timed out");
+      std::string err(strerror(errno));
       std::string err_str("read: ");
       debug_print(err_str.append(err), 1);
     }

--- a/common/source/host/zlib_inflate.c
+++ b/common/source/host/zlib_inflate.c
@@ -76,6 +76,8 @@ int inf(void *in_data, size_t in_size, void **out_data, size_t *out_size) {
   strm.opaque = Z_NULL;
   strm.avail_in = 0;
   strm.next_in = Z_NULL;
+  strm.total_in = 0;
+  strm.total_out = 0;
   // notes from zlib.h
   // The default value is 15 if inflateInit is used
   // Add 32 to windowBits to enable zlib and gzip decoding with automatic header

--- a/common/source/util/diagnostic/main.cpp
+++ b/common/source/util/diagnostic/main.cpp
@@ -153,18 +153,32 @@ int scan_devices(const char *device_name) {
 
     // found a working supported device
     o_list_stream << "\n";
-    aocl_mmd_get_info(handle, AOCL_MMD_BOARD_NAME, sizeof(board_name),
+    try {
+      aocl_mmd_get_info(handle, AOCL_MMD_BOARD_NAME, sizeof(board_name),
                       board_name, NULL);
+    } catch(...) {
+      return -1;
+    }
+
     o_list_stream << std::left << std::setw(20) << dev_name << std::left
                   << std::setw(18) << "Passed   " << board_name << "\n";
 
-    aocl_mmd_get_info(handle, AOCL_MMD_PCIE_INFO, sizeof(pcie_info), pcie_info,
+    try {
+      aocl_mmd_get_info(handle, AOCL_MMD_PCIE_INFO, sizeof(pcie_info), pcie_info,
                       NULL);
+    } catch(...) {
+      return -1;
+    }
+
     o_list_stream << std::left << std::setw(38) << " "
                   << "PCIe " << pcie_info << "\n";
 
-    aocl_mmd_get_info(handle, AOCL_MMD_TEMPERATURE, sizeof(float), &temperature,
+    try {
+      aocl_mmd_get_info(handle, AOCL_MMD_TEMPERATURE, sizeof(float), &temperature,
                       NULL);
+    } catch(...) {
+      return -1;
+    }
 
     // There is a bug with Darby Creek where temperature is reported as 0.
     // If this happens skip printing temperature
@@ -264,7 +278,7 @@ int main(int argc, char *argv[]) {
   int maxbytes = DEFAULT_MAXNUMBYTES;
   if (argc >= 3) {
     maxbytes = atoi(argv[2]);
-    if (maxbytes < 0 || maxbytes > std::numeric_limits<int>::max())
+    if ((atol(argv[2]) < std::numeric_limits<int>::min()) || (atol(argv[2]) > std::numeric_limits<int>::max()))
       maxbytes = DEFAULT_MAXNUMBYTES;
   }
 

--- a/common/source/util/diagnostic/ocl.cpp
+++ b/common/source/util/diagnostic/ocl.cpp
@@ -158,7 +158,10 @@ void ocl_device_init(int maxbytes, char *device_name) {
     dump_error("Failed clCreateContext.", status);
 
   // create a command queue
-  const cl_queue_properties *properties=NULL;
+  const cl_queue_properties properties[] = {
+    CL_QUEUE_PROPERTIES, CL_QUEUE_PROFILING_ENABLE,
+    0
+  };
   queue =
       clCreateCommandQueueWithProperties(context, device, properties, &status);
   if (status != CL_SUCCESS)

--- a/common/source/util/reprogram/reprogram.cpp
+++ b/common/source/util/reprogram/reprogram.cpp
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 
 #include "aocl_mmd.h"
 #include "mmd.h"
@@ -40,6 +41,11 @@ unsigned char *acl_loadFileIntoMemory(const char *in_file,
 
   // get file size
   fseek(f, 0, SEEK_END);
+  if(ftell(f) == -1){
+    fprintf(stderr, "Error determining file size, Error Number : %d\n", errno);    
+    fclose(f);
+    return NULL;
+  }
   file_size = (size_t)ftell(f);
   rewind(f);
 

--- a/d5005/board_env.xml
+++ b/d5005/board_env.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
-<<<<<<< HEAD
-<board_env version="22.1" name="ofs_d5005_shim">
-=======
 <board_env version="22.3" name="ofs_d5005_shim">
->>>>>>> master
+
   <hardware dir="hardware" default="ofs_d5005"></hardware>
   <platform name="linux64">
     <mmdlib>libopae-c.so,%b/linux64/lib/libMPF.so,%b/linux64/lib/libintel_opae_mmd.so</mmdlib>

--- a/d5005/hardware/ofs_d5005/board_spec.xml
+++ b/d5005/hardware/ofs_d5005/board_spec.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0"?>
-<<<<<<< HEAD
-<board version="22.1" name="ofs_d5005">
-=======
 <board version="22.3" name="ofs_d5005">
->>>>>>> master
 
   <compile name="flat" project="d5005" revision="afu_flat" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>

--- a/d5005/hardware/ofs_d5005_usm/board_spec.xml
+++ b/d5005/hardware/ofs_d5005_usm/board_spec.xml
@@ -22,7 +22,7 @@
   </device>
 
   <global_mem name="host" max_bandwidth="30000" interleaved_bytes="1024" config_addr="0x018" allocation_type="host, shared">
-    <interface name="board" port="kernel_mem" type="slave" width="512" maxburst="16" address="0x000000000" size="0x1000000000000" latency="800" waitrequest_allowance="7"/>
+    <interface name="board" port="kernel_mem" type="slave" width="512" maxburst="16" address="0x000000000" size="0x1000000000000" latency="1500" waitrequest_allowance="7"/>
   </global_mem>
   
   <!-- DDR4-2400 -->

--- a/d5005/hardware/ofs_d5005_usm/build/rtl/afu.sv
+++ b/d5005/hardware/ofs_d5005_usm/build/rtl/afu.sv
@@ -112,7 +112,8 @@ assign kernel_svm.reset_n = host_mem_if.reset_n;
 
 ofs_plat_avalon_mem_if_async_shim #(
     //change waitreq to be more like 'almost-full' rather than 'full'
-    .COMMAND_ALMFULL_THRESHOLD (8)
+    .COMMAND_ALMFULL_THRESHOLD (8),
+    .RESPONSE_FIFO_DEPTH (USM_CCB_RESPONSE_FIFO_DEPTH)
 ) kernel_svm_avmm_ccb_inst (
     .mem_sink   (kernel_svm),
     .mem_source (kernel_svm_kclk)

--- a/d5005/hardware/ofs_d5005_usm/build/rtl/dc_bsp_pkg.sv
+++ b/d5005/hardware/ofs_d5005_usm/build/rtl/dc_bsp_pkg.sv
@@ -102,4 +102,8 @@ package dc_bsp_pkg;
     // DFH end-of-list flag - '0' means this is the end of the DFH list
     parameter MPF_VTP_DFH_NEXT_ADDR = 0;
     
+    //USM clock-crossing bridge response FIFO depth (controls the number of
+    // outstanding read requests to the host) (default was 256, but that was too low)
+    parameter USM_CCB_RESPONSE_FIFO_DEPTH = 512;
+    
 endpackage : dc_bsp_pkg

--- a/d5005/linux64/libexec/setup_permissions.sh
+++ b/d5005/linux64/libexec/setup_permissions.sh
@@ -125,4 +125,15 @@ set_memlock_limits
 set_dev_permission
 set_hugepages
 
+################################################################################
+# Set aocl initialize permissions
+#
+# To run aocl initialize, read and write permissions are needed for Others class
+################################################################################
+set_devuio_permissions()
+{
+  echo "Setting access permisions of /dev/uio to 666"
+  sudo chmod 666 /dev/uio*
+}
+
 echo "Finished setup_permissions.sh script. All configuration settings are persistent."

--- a/d5005/scripts/build-opae.sh
+++ b/d5005/scripts/build-opae.sh
@@ -129,7 +129,7 @@ if [ -n "$OFS_OCL_ENV_ENABLE_ASE" ]; then
     OPAESIM_INSTALL_DIR="$OPAESIM_BUILD_PREFIX/install"
     # default opae-sim repo address
     if [ -z "${OPAESIM_REPO}" ]; then
-        OPAESIM_REPO="https://github.com/OPAE/opae-sim.git"
+        OPAESIM_REPO="https://github.com/OFS/opae-sim.git"
     fi
     # Default branch to 'master' if the branch variable is not set
     if [ -z "${OPAESIM_REPO_BRANCH}" ]; then

--- a/n6001/hardware/ofs_n6001_usm/board_spec.xml
+++ b/n6001/hardware/ofs_n6001_usm/board_spec.xml
@@ -29,7 +29,7 @@
   </device>
 
   <global_mem name="host" max_bandwidth="30000" interleaved_bytes="1024" config_addr="0x018" allocation_type="host, shared">
-    <interface name="board" port="kernel_mem" type="slave" width="512" maxburst="16" address="0x000000000" size="0x1000000000000" latency="800" waitrequest_allowance="7"/>
+    <interface name="board" port="kernel_mem" type="slave" width="512" maxburst="16" address="0x000000000" size="0x1000000000000" latency="1500" waitrequest_allowance="7"/>
   </global_mem>
   
   <!-- DDR4-2400 -->

--- a/n6001/hardware/ofs_n6001_usm/build/rtl/afu.sv
+++ b/n6001/hardware/ofs_n6001_usm/build/rtl/afu.sv
@@ -112,7 +112,8 @@ assign kernel_svm.reset_n = host_mem_if.reset_n;
 
 ofs_plat_avalon_mem_if_async_shim #(
     //change waitreq to be more like 'almost-full' rather than 'full'
-    .COMMAND_ALMFULL_THRESHOLD (8)
+    .COMMAND_ALMFULL_THRESHOLD (8),
+    .RESPONSE_FIFO_DEPTH (USM_CCB_RESPONSE_FIFO_DEPTH)
 ) kernel_svm_avmm_ccb_inst (
     .mem_sink   (kernel_svm),
     .mem_source (kernel_svm_kclk)

--- a/n6001/hardware/ofs_n6001_usm/build/rtl/dc_bsp_pkg.sv
+++ b/n6001/hardware/ofs_n6001_usm/build/rtl/dc_bsp_pkg.sv
@@ -102,4 +102,8 @@ package dc_bsp_pkg;
     // DFH end-of-list flag - '0' means this is the end of the DFH list
     parameter MPF_VTP_DFH_NEXT_ADDR = 0;
     
+    //USM clock-crossing bridge response FIFO depth (controls the number of
+    // outstanding read requests to the host) (default was 256, but that was too low)
+    parameter USM_CCB_RESPONSE_FIFO_DEPTH = 512;
+    
 endpackage : dc_bsp_pkg

--- a/n6001/linux64/libexec/setup_permissions.sh
+++ b/n6001/linux64/libexec/setup_permissions.sh
@@ -125,4 +125,15 @@ set_memlock_limits
 set_dev_permission
 set_hugepages
 
+################################################################################
+# Set aocl initialize permissions
+#
+# To run aocl initialize, read and write permissions are needed for Others class
+################################################################################
+set_devuio_permissions()
+{
+  echo "Setting access permisions of /dev/uio to 666"
+  sudo chmod 666 /dev/uio*
+}
+
 echo "Finished setup_permissions.sh script. All configuration settings are persistent."

--- a/n6001/scripts/build-opae.sh
+++ b/n6001/scripts/build-opae.sh
@@ -129,7 +129,7 @@ if [ -n "$OFS_OCL_ENV_ENABLE_ASE" ]; then
     OPAESIM_INSTALL_DIR="$OPAESIM_BUILD_PREFIX/install"
     # default opae-sim repo address
     if [ -z "${OPAESIM_REPO}" ]; then
-        OPAESIM_REPO="https://github.com/OPAE/opae-sim.git"
+        OPAESIM_REPO="https://github.com/OFS/opae-sim.git"
     fi
     # Default branch to 'master' if the branch variable is not set
     if [ -z "${OPAESIM_REPO_BRANCH}" ]; then


### PR DESCRIPTION
Coverity

DEADCODE kernel_interrupt.cpp - we are in else loop of if(num_events <= 0) so we don't need to check for num_events < 0 again , it will never be exercised.
CHECKED_RETURN - mmd.cpp - Now checking for return from uuid_parse() functions, around lines 500-520
CHECKED_RETURN - mmd.cpp - get_offline_num_acl_boards() returns unsigned int because it uses fpgaEnumerate() OPAE API which returns unsigned int, so in that scenario we dont need to check if num_acl_boards is < 0.
UNUSED_VALUE - mmd.cpp - return value rc was not used properly , fixed it.
DEAD_CODE - mmd_device.cpp - we already checked if 'res' was != FPGA_OK so when it comes to the end of function res is always FPGA_OK, so its deadcode , so removed it.
UNINT zlib_inflate.c - str.total_in , str.total_out were uninitialized
UNCAUGHT_EXCEPT - diagnostic/main.cpp - aocl_mmd_get_info() cant return std::runtime exception which were not caught
DEAD_CODE - diagnostic/main.cpp - maxbytes is int type so can't be greater than std::numeric_limits::max()
NEGATIVE_RETURNS - ftell() can return -ve if error which should be handled properly
d5005/scripts/internal/run-with-arc.sh , n6001/scripts/internal/run-with-arc.sh scripts updated to have arc resource coverity/2022.03
d5005/scripts/build-opae.sh , n6001/scripts/build-opae.sh scripts updated to point to new opae-sim github repo in OFS, earlier it was in OPAE github

Bug:
aocl diagnose all showing throughput of 0MBps.
Solution is to enable profiling using cl_queue_properties.

Bug:
Added code to capture return from opae calls fpgaGetProperties(), fpgaPropertiesGetObjectID()
If we don't find token for port or fme , printing both port fme tokens and then throwing std::runtime exception.
In that case user can see one or both tokens were determined as NULL and debug further.

tested on agilex board by running aocl diagnose all , some USM and non USM tests

Bug
aocl initialize <device_name> requires the Others class to have read and write permissions. By adding the permission change to setup_permissions.sh, the board can be configured without issue.

Updates to the BSP to improve the USM read bandwidth. The 'latency' value in board_spec.xml is increased and the BSP's clock-crossing bridge 'response depth' is increased - this allows for more outstanding read requests which increases read bandwidth.

Port the changes made to the N6001 BSP to improve USM read bandwidth performance.
Test on iofs_test_guest@10.233.115.155 using mem_bandwidth_svm design. Write bandwidth is not impacted, read bandwidth increases from 11.162 GB/s to 12.169 GB/s.

Creating memread kernel
Launching the kernel...
Processed 268435456 unsigned ints in 88221.1094 us
Read Bandwidth = 12171 MB/s
Kernel execution is complete.
Creating memwrite kernel
Launching the kernel...
Processed 268435456 unsigned ints in 85266.5625 us
Write Bandwidth = 12593 MB/s
Kernel execution is complete.
Verification finished.