### PR TITLE
D5005: remove blind copy of ipss and src folders in compile-script

### DIFF
--- a/d5005/hardware/ofs_d5005/build/scripts/compile_script.tcl
+++ b/d5005/hardware/ofs_d5005/build/scripts/compile_script.tcl
@@ -18,11 +18,7 @@ post_message "Running compile_script.tcl script"
 
 # get flow type (from quartus(args) variable)
 set flow [lindex $quartus(args) 0]
-# cp ipss to ../../../ to fix folder issue.
-puts [exec cp -r ipss ../../../ipss]
 
-#cp src to fix STP issue
-puts [exec cp -r src ../../../src]
 # simplified PR Quartus flow
 qexec "quartus_syn --read_settings_files=on --write_settings_files=off d5005 -c afu_$flow"
 qexec "quartus_fit --read_settings_files=on --write_settings_files=off d5005 -c afu_$flow"

--- a/d5005/hardware/ofs_d5005_usm/build/scripts/compile_script.tcl
+++ b/d5005/hardware/ofs_d5005_usm/build/scripts/compile_script.tcl
@@ -18,11 +18,7 @@ post_message "Running compile_script.tcl script"
 
 # get flow type (from quartus(args) variable)
 set flow [lindex $quartus(args) 0]
-# cp ipss to ../../../ to fix folder issue.
-puts [exec cp -r ipss ../../../ipss]
 
-#cp src to fix STP issue
-puts [exec cp -r src ../../../src]
 # simplified PR Quartus flow
 qexec "quartus_syn --read_settings_files=on --write_settings_files=off d5005 -c afu_$flow"
 qexec "quartus_fit --read_settings_files=on --write_settings_files=off d5005 -c afu_$flow"


### PR DESCRIPTION
OneAPI and OpenCL builds completed successfully. OneAPI boardtest.fpga tested in hw.