### PR TITLE
N6001: revert USM read bw changes

### DIFF
--- a/n6001/hardware/ofs_n6001_usm/board_spec.xml
+++ b/n6001/hardware/ofs_n6001_usm/board_spec.xml
@@ -29,7 +29,7 @@
   </device>
 
   <global_mem name="host" max_bandwidth="30000" interleaved_bytes="1024" config_addr="0x018" allocation_type="host, shared">
-    <interface name="board" port="kernel_mem" type="slave" width="512" maxburst="16" address="0x000000000" size="0x1000000000000" latency="1500" waitrequest_allowance="7"/>
+    <interface name="board" port="kernel_mem" type="slave" width="512" maxburst="16" address="0x000000000" size="0x1000000000000" latency="800" waitrequest_allowance="7"/>
   </global_mem>
   
   <!-- DDR4-2400 -->

--- a/n6001/hardware/ofs_n6001_usm/build/rtl/dc_bsp_pkg.sv
+++ b/n6001/hardware/ofs_n6001_usm/build/rtl/dc_bsp_pkg.sv
@@ -103,7 +103,8 @@ package dc_bsp_pkg;
     parameter MPF_VTP_DFH_NEXT_ADDR = 0;
     
     //USM clock-crossing bridge response FIFO depth (controls the number of
-    // outstanding read requests to the host) (default was 256, but that was too low)
-    parameter USM_CCB_RESPONSE_FIFO_DEPTH = 512;
+    // outstanding read requests to the host) (default is 256, but it caps 
+    // read bandwidth; anything larger can result in host crashes)
+    parameter USM_CCB_RESPONSE_FIFO_DEPTH = 256;
     
 endpackage : dc_bsp_pkg


### PR DESCRIPTION
Leaving the CCB's response-fifo-depth set to 256 allows simple-host-streaming's default configuration to pass, albeit with reduced bandwidth in the read direction during simple-host-streaming; increasing to anything greater than 256 results in a host-crash (although mem_bandwidth_svm test shows full bandwidth).