### PR TITLE
Change to make DMA single buffered because we see issues in double buffering tests

### DIFF
--- a/common/source/host/mmd_dma.cpp
+++ b/common/source/host/mmd_dma.cpp
@@ -393,6 +393,7 @@ int mmd_dma::send_descriptors(uint64_t dma_src_addr, uint64_t dma_dst_addr, uint
  *  it determines appropriate dma src, dst, len and calles send_descriptors() function  
  */
 int mmd_dma::do_dma(dma_work_item &item) {
+  const std::lock_guard<std::mutex> lock(pinning_mutex);
 #if 0 
   printf("do_dma\t");
   if (m_mode == dma_mode::f2h) {


### PR DESCRIPTION
Change to make DMA single buffered because we see issues in double buffering tests