### PR TITLE
Change to make DMA single buffered because we see issues in double buffering tests

### DIFF
--- a/common/source/host/mmd_dma.cpp
+++ b/common/source/host/mmd_dma.cpp
@@ -265,7 +265,6 @@ void mmd_dma::read_register(uint64_t offset, const char* name)
  *  it won't affect performance or functionality
  */  
 int mmd_dma::send_descriptors(uint64_t dma_src_addr, uint64_t dma_dst_addr, uint64_t dma_len) {
-
   std::lock_guard<std::mutex> lock(m_dma_op_mutex);
 
 #if 0


### PR DESCRIPTION
Decision was made to prevent double buffering in ASP DMA to prevent users running into double buffering bug which we haven't resolved yet.
1) Updated mmd_dma.cpp to make DMA single buffered
2) Double buffering has bug which needs to be fixed
3) ASP SW Compile was successful and double buffering test also passed.