### PR TITLE
Improve selection of 'packager' utility

### DIFF
--- a/d5005/hardware/ofs_d5005/build/scripts/run.sh
+++ b/d5005/hardware/ofs_d5005/build/scripts/run.sh
@@ -33,21 +33,20 @@ if [ ${BSP_FLOW} = "afu_flat_kclk" ]; then
     BSP_FLOW="afu_flat"
 fi
 
-PYTHONPATH="$OFS_ASP_ROOT/build/opae/install/lib/python3.7/site-packages"
-
 cd "$SCRIPT_DIR_PATH/.." || exit
 
-if [[ -n "$OFS_OCL_ENV_USE_BSP_PACKAGER" || -n "$ARC_SITE" ]]; then
+if [ -n "$PACKAGER_BIN" ]; then
+  echo "Selected explicitly configured PACKAGER_BIN=\"$PACKAGER_BIN\""
+elif [ -z "$OFS_OCL_ENV_USE_BSP_PACKAGER" ] && PACKAGER_BIN="$(command -v packager)"; then
+  echo "Detected PACKAGER_BIN=\"$PACKAGER_BIN\" from \$PATH search"
+else
+  echo "Attempting fallback to BSP copy of packager"
   if [ -f ./tools/packager ]; then
     chmod +x ./tools/packager
     PACKAGER_BIN=$(readlink -f ./tools/packager)
+    PYTHONPATH="$OFS_ASP_ROOT"/build/opae/install/lib/python3*/site-packages
   else
     echo "Error cannot find BSP copy of packager"
-    exit 1
-  fi
-else
-  if ! PACKAGER_BIN=$(which packager); then
-    echo "Error: cannot find packager in path"
     exit 1
   fi
 fi

--- a/d5005/hardware/ofs_d5005/build/scripts/run.sh
+++ b/d5005/hardware/ofs_d5005/build/scripts/run.sh
@@ -37,7 +37,7 @@ cd "$SCRIPT_DIR_PATH/.." || exit
 
 if [ -n "$PACKAGER_BIN" ]; then
   echo "Selected explicitly configured PACKAGER_BIN=\"$PACKAGER_BIN\""
-elif [ -z "$OFS_OCL_ENV_USE_BSP_PACKAGER" ] && PACKAGER_BIN="$(command -v packager)"; then
+elif [ -z "$OFS_ASP_ENV_USE_BSP_PACKAGER" ] && PACKAGER_BIN="$(command -v packager)"; then
   echo "Detected PACKAGER_BIN=\"$PACKAGER_BIN\" from \$PATH search"
 else
   echo "Attempting fallback to BSP copy of packager"

--- a/d5005/hardware/ofs_d5005_usm/build/scripts/run.sh
+++ b/d5005/hardware/ofs_d5005_usm/build/scripts/run.sh
@@ -33,21 +33,20 @@ if [ ${BSP_FLOW} = "afu_flat_kclk" ]; then
     BSP_FLOW="afu_flat"
 fi
 
-PYTHONPATH="$OFS_ASP_ROOT/build/opae/install/lib/python3.7/site-packages"
-
 cd "$SCRIPT_DIR_PATH/.." || exit
 
-if [[ -n "$OFS_OCL_ENV_USE_BSP_PACKAGER" || -n "$ARC_SITE" ]]; then
+if [ -n "$PACKAGER_BIN" ]; then
+  echo "Selected explicitly configured PACKAGER_BIN=\"$PACKAGER_BIN\""
+elif [ -z "$OFS_OCL_ENV_USE_BSP_PACKAGER" ] && PACKAGER_BIN="$(command -v packager)"; then
+  echo "Detected PACKAGER_BIN=\"$PACKAGER_BIN\" from \$PATH search"
+else
+  echo "Attempting fallback to BSP copy of packager"
   if [ -f ./tools/packager ]; then
     chmod +x ./tools/packager
     PACKAGER_BIN=$(readlink -f ./tools/packager)
+    PYTHONPATH="$OFS_ASP_ROOT"/build/opae/install/lib/python3*/site-packages
   else
     echo "Error cannot find BSP copy of packager"
-    exit 1
-  fi
-else
-  if ! PACKAGER_BIN=$(which packager); then
-    echo "Error: cannot find packager in path"
     exit 1
   fi
 fi

--- a/d5005/hardware/ofs_d5005_usm/build/scripts/run.sh
+++ b/d5005/hardware/ofs_d5005_usm/build/scripts/run.sh
@@ -37,7 +37,7 @@ cd "$SCRIPT_DIR_PATH/.." || exit
 
 if [ -n "$PACKAGER_BIN" ]; then
   echo "Selected explicitly configured PACKAGER_BIN=\"$PACKAGER_BIN\""
-elif [ -z "$OFS_OCL_ENV_USE_BSP_PACKAGER" ] && PACKAGER_BIN="$(command -v packager)"; then
+elif [ -z "$OFS_ASP_ENV_USE_BSP_PACKAGER" ] && PACKAGER_BIN="$(command -v packager)"; then
   echo "Detected PACKAGER_BIN=\"$PACKAGER_BIN\" from \$PATH search"
 else
   echo "Attempting fallback to BSP copy of packager"

--- a/d5005/scripts/build-bsp.sh
+++ b/d5005/scripts/build-bsp.sh
@@ -12,7 +12,6 @@
 #
 #   OFS_PLATFORM_AFU_BBB: root of OFS platform used for BSP
 #   LIBOPAE_C_ROOT: path to location where OPAE is installed
-#   ARC_SITE: only set for Intel PSG compute farm
 #   OPENCL_ASE_SIM: used as input for setup-bsp.py to determine if ASE is used
 #   OPAE_PLATFORM_ROOT: point to location where platform files are located
 #

--- a/n6001/hardware/ofs_n6001/build/scripts/run.sh
+++ b/n6001/hardware/ofs_n6001/build/scripts/run.sh
@@ -33,21 +33,20 @@ if [ ${BSP_FLOW} = "afu_flat_kclk" ]; then
     BSP_FLOW="afu_flat"
 fi
 
-PYTHONPATH="$OFS_ASP_ROOT/build/opae/install/lib/python3.7/site-packages"
-
 cd "$SCRIPT_DIR_PATH/.." || exit
 
-if [[ -n "$OFS_ASP_ENV_USE_BSP_PACKAGER" || -n "$ARC_SITE" ]]; then
+if [ -n "$PACKAGER_BIN" ]; then
+  echo "Selected explicitly configured PACKAGER_BIN=\"$PACKAGER_BIN\""
+elif [ -z "$OFS_ASP_ENV_USE_BSP_PACKAGER" ] && PACKAGER_BIN="$(command -v packager)"; then
+  echo "Detected PACKAGER_BIN=\"$PACKAGER_BIN\" from \$PATH search"
+else
+  echo "Attempting fallback to BSP copy of packager"
   if [ -f ./tools/packager ]; then
     chmod +x ./tools/packager
     PACKAGER_BIN=$(readlink -f ./tools/packager)
+    PYTHONPATH="$OFS_ASP_ROOT"/build/opae/install/lib/python3*/site-packages
   else
     echo "Error cannot find BSP copy of packager"
-    exit 1
-  fi
-else
-  if ! PACKAGER_BIN=$(which packager); then
-    echo "Error: cannot find packager in path"
     exit 1
   fi
 fi

--- a/n6001/hardware/ofs_n6001_usm/build/scripts/run.sh
+++ b/n6001/hardware/ofs_n6001_usm/build/scripts/run.sh
@@ -33,21 +33,20 @@ if [ ${BSP_FLOW} = "afu_flat_kclk" ]; then
     BSP_FLOW="afu_flat"
 fi
 
-PYTHONPATH="$OFS_ASP_ROOT/build/opae/install/lib/python3.7/site-packages"
-
 cd "$SCRIPT_DIR_PATH/.." || exit
 
-if [[ -n "$OFS_ASP_ENV_USE_BSP_PACKAGER" || -n "$ARC_SITE" ]]; then
+if [ -n "$PACKAGER_BIN" ]; then
+  echo "Selected explicitly configured PACKAGER_BIN=\"$PACKAGER_BIN\""
+elif [ -z "$OFS_ASP_ENV_USE_BSP_PACKAGER" ] && PACKAGER_BIN="$(command -v packager)"; then
+  echo "Detected PACKAGER_BIN=\"$PACKAGER_BIN\" from \$PATH search"
+else
+  echo "Attempting fallback to BSP copy of packager"
   if [ -f ./tools/packager ]; then
     chmod +x ./tools/packager
     PACKAGER_BIN=$(readlink -f ./tools/packager)
+    PYTHONPATH="$OFS_ASP_ROOT"/build/opae/install/lib/python3*/site-packages
   else
     echo "Error cannot find BSP copy of packager"
-    exit 1
-  fi
-else
-  if ! PACKAGER_BIN=$(which packager); then
-    echo "Error: cannot find packager in path"
     exit 1
   fi
 fi

--- a/n6001/scripts/build-bsp.sh
+++ b/n6001/scripts/build-bsp.sh
@@ -12,7 +12,6 @@
 #
 #   OFS_PLATFORM_AFU_BBB: root of OFS platform used for BSP
 #   LIBOPAE_C_ROOT: path to location where OPAE is installed
-#   ARC_SITE: only set for Intel PSG compute farm
 #   OPENCL_ASE_SIM: used as input for setup-bsp.py to determine if ASE is used
 #   OPAE_PLATFORM_ROOT: point to location where platform files are located
 #


### PR DESCRIPTION
To flexibly support all environments, the order of preference should be:

1) Explicit path if provided (a.k.a. stop trying to be "smart" and use
   exactly what I'm asking, dagnabbit!)

2) $PATH search -- a set of installed OPAE .rpms should Just Work
   and be usable *anywhere* the script runs.

3) If neither of these yield a working 'packager', fall back to a
   bundled copy. This will only ever work in limited contexts such as an
   HPC farm's local build of the product, and thus it should never take
   priority over the either of the previous two selection paths.