### PR TITLE
changing the USM CCB for the kernel to host mem path

### DIFF
--- a/n6001/hardware/ofs_n6001_usm/build/rtl/afu.sv
+++ b/n6001/hardware/ofs_n6001_usm/build/rtl/afu.sv
@@ -99,9 +99,9 @@ assign kernel_svm.clk = host_mem_if.clk;
 assign kernel_svm.reset_n = host_mem_if.reset_n;
 
 ofs_plat_avalon_mem_if_async_shim #(
-    //change waitreq to be more like 'almost-full' rather than 'full'
-    .COMMAND_ALMFULL_THRESHOLD (8),
-    .RESPONSE_FIFO_DEPTH (USM_CCB_RESPONSE_FIFO_DEPTH)
+    .RESPONSE_FIFO_DEPTH       (USM_CCB_RESPONSE_FIFO_DEPTH),
+    .COMMAND_FIFO_DEPTH        (USM_CCB_COMMAND_FIFO_DEPTH),
+    .COMMAND_ALMFULL_THRESHOLD (USM_CCB_COMMAND_ALMFULL_THRESHOLD)
 ) kernel_svm_avmm_ccb_inst (
     .mem_sink   (kernel_svm),
     .mem_source (kernel_svm_kclk)

--- a/n6001/hardware/ofs_n6001_usm/build/rtl/dc_bsp_pkg.sv
+++ b/n6001/hardware/ofs_n6001_usm/build/rtl/dc_bsp_pkg.sv
@@ -92,9 +92,9 @@ package dc_bsp_pkg;
     // DFH end-of-list flag - '0' means this is the end of the DFH list
     parameter MPF_VTP_DFH_NEXT_ADDR = 0;
     
-    //USM clock-crossing bridge response FIFO depth (controls the number of
-    // outstanding read requests to the host) (default is 256, but it caps 
-    // read bandwidth; anything larger can result in host crashes)
-    parameter USM_CCB_RESPONSE_FIFO_DEPTH = 256;
+    // USM kernel clock crossing bridge
+    parameter USM_CCB_RESPONSE_FIFO_DEPTH       = 512;
+    parameter USM_CCB_COMMAND_FIFO_DEPTH        = 256;
+    parameter USM_CCB_COMMAND_ALMFULL_THRESHOLD = 16;
     
 endpackage : dc_bsp_pkg


### PR DESCRIPTION
This change submits Doug's change he made in March for the USM CCB for the kernel to host mem path in order to fix the USM read bandwidth.
The change doubles not only the read response FIFO depth to 512, but also the command FIFO depth to 256 and command FIFO almost full threshold to 16.
The bandwidth changed as follows:

```
state | USM read+write | USM read | USM write
before | 29.63 GB/s | 17.99 GB/s | 24.65 GB/s
after | 44.56 GB/s | 27.21 GB/s | 24.62 GB/s
```

Test run so far:
- usm-bandwidth in a loop for 100 iterations
- simple_host_streaming in a loop for 100 iterations
- buffered_host_streaming in a loop for 100 iterations
- zero_copy_data_transfer in a loop for 100 iterations
- explicit_data_movement in a loop for 100 iterations