### PR TITLE
Updating ASP to use opae-sdk master branch and removing dependency on a particular python version

### DIFF
--- a/d5005/hardware/ofs_d5005/build/scripts/run.sh
+++ b/d5005/hardware/ofs_d5005/build/scripts/run.sh
@@ -33,7 +33,7 @@ if [ ${BSP_FLOW} = "afu_flat_kclk" ]; then
     BSP_FLOW="afu_flat"
 fi
 
-PYTHONPATH="$OFS_OCL_SHIM_ROOT/build/opae/install/lib/python3.7/site-packages"
+PYTHONPATH="$OFS_OCL_SHIM_ROOT/build/opae/install/lib/python*/site-packages"
 
 cd "$SCRIPT_DIR_PATH/.." || exit
 

--- a/d5005/hardware/ofs_d5005_usm/build/scripts/run.sh
+++ b/d5005/hardware/ofs_d5005_usm/build/scripts/run.sh
@@ -33,7 +33,7 @@ if [ ${BSP_FLOW} = "afu_flat_kclk" ]; then
     BSP_FLOW="afu_flat"
 fi
 
-PYTHONPATH="$OFS_OCL_SHIM_ROOT/build/opae/install/lib/python3.7/site-packages"
+PYTHONPATH="$OFS_OCL_SHIM_ROOT/build/opae/install/lib/python*/site-packages"
 
 cd "$SCRIPT_DIR_PATH/.." || exit
 

--- a/d5005/scripts/build-opae.sh
+++ b/d5005/scripts/build-opae.sh
@@ -76,7 +76,7 @@ fi
 
 # Default branch to 'master' if the branch variable is not set
 if [ -z "${OPAE_SDK_REPO_BRANCH}" ]; then
-    OPAE_SDK_REPO_BRANCH="release/2.5.0"
+    OPAE_SDK_REPO_BRANCH="master"
 fi
 
 # Default location to clone is $OPAESDK_BUILD_PREFIX/opae-sdk

--- a/n6001/hardware/ofs_n6001/build/scripts/run.sh
+++ b/n6001/hardware/ofs_n6001/build/scripts/run.sh
@@ -33,7 +33,7 @@ if [ ${BSP_FLOW} = "afu_flat_kclk" ]; then
     BSP_FLOW="afu_flat"
 fi
 
-PYTHONPATH="$OFS_OCL_SHIM_ROOT/build/opae/install/lib/python3.7/site-packages"
+PYTHONPATH="$OFS_OCL_SHIM_ROOT/build/opae/install/lib/python*/site-packages"
 
 cd "$SCRIPT_DIR_PATH/.." || exit
 

--- a/n6001/hardware/ofs_n6001_usm/build/scripts/run.sh
+++ b/n6001/hardware/ofs_n6001_usm/build/scripts/run.sh
@@ -33,7 +33,7 @@ if [ ${BSP_FLOW} = "afu_flat_kclk" ]; then
     BSP_FLOW="afu_flat"
 fi
 
-PYTHONPATH="$OFS_OCL_SHIM_ROOT/build/opae/install/lib/python3.7/site-packages"
+PYTHONPATH="$OFS_OCL_SHIM_ROOT/build/opae/install/lib/python*/site-packages"
 
 cd "$SCRIPT_DIR_PATH/.." || exit
 

--- a/n6001/scripts/build-opae.sh
+++ b/n6001/scripts/build-opae.sh
@@ -76,7 +76,7 @@ fi
 
 # Default branch to 'master' if the branch variable is not set
 if [ -z "${OPAE_SDK_REPO_BRANCH}" ]; then
-    OPAE_SDK_REPO_BRANCH="release/2.5.0"
+    OPAE_SDK_REPO_BRANCH="master"
 fi
 
 # Default location to clone is $OPAESDK_BUILD_PREFIX/opae-sdk


### PR DESCRIPTION
1) Updated run.sh script to use python* instead of hardcoding python version number for both n6001 and d5005
2) Updated scripts/build-opae.sh to use master branch of opae-sdk for both n6001 and d5005
3) Tested change with both n6001 and d5005 in arc environment