### PR TITLE
remove mutex to allow for double buffering

### DIFF
--- a/common/source/host/mmd_dma.cpp
+++ b/common/source/host/mmd_dma.cpp
@@ -393,6 +393,8 @@ int mmd_dma::send_descriptors(uint64_t dma_src_addr, uint64_t dma_dst_addr, uint
  *  it determines appropriate dma src, dst, len and calles send_descriptors() function  
  */
 int mmd_dma::do_dma(dma_work_item &item) {
+// adding the following mutex will disable double buffering  
+// const std::lock_guard<std::mutex> lock(pinning_mutex);
 #if 0 
   printf("do_dma\t");
   if (m_mode == dma_mode::f2h) {

--- a/common/source/host/mmd_dma.cpp
+++ b/common/source/host/mmd_dma.cpp
@@ -393,7 +393,6 @@ int mmd_dma::send_descriptors(uint64_t dma_src_addr, uint64_t dma_dst_addr, uint
  *  it determines appropriate dma src, dst, len and calles send_descriptors() function  
  */
 int mmd_dma::do_dma(dma_work_item &item) {
-  const std::lock_guard<std::mutex> lock(pinning_mutex);
 #if 0 
   printf("do_dma\t");
   if (m_mode == dma_mode::f2h) {


### PR DESCRIPTION
This change switches back to using double buffering which previously caused issues with the double_buffering and gzip designs.
The change was tested by running through
- 1000 iterations of double_buffering design
- 1000 iterations of gzip design with 500 MB input file
Requirement for this working is the updated FIM for N6001 with Quartus 23.2.