### PR TITLE
Remove fatal error when temperature not found on board if no BMC present

### DIFF
--- a/common/source/host/mmd_device.cpp
+++ b/common/source/host/mmd_device.cpp
@@ -909,9 +909,13 @@ float Device::get_temperature() {
   fpga_result res;
   res = fpgaTokenGetObject(fme_token, name, &obj, FPGA_OBJECT_GLOB);
   if (res != FPGA_OK) {
-    throw std::runtime_error(
-        std::string("Error reading temperature monitor from BMC : ") +
-        std::string(fpgaErrStr(res)));
+    if(std::getenv("MMD_ENABLE_DEBUG")){
+      DEBUG_LOG("DEBUG LOG : Error reading temperature monitor from BMC :");
+      DEBUG_LOG(" %s \n",fpgaErrStr(res));
+    }
+    fpgaDestroyObject(&obj);
+    temp = -999;
+    return temp;
   }
 
   uint64_t value = 0;

--- a/common/source/util/diagnostic/main.cpp
+++ b/common/source/util/diagnostic/main.cpp
@@ -169,7 +169,7 @@ int scan_devices(const char *device_name) {
 
     // Temperature reported in celsius
     // anything below -273 is below absolute zero
-    // we return -999 is no BMC found or some other error and so no temperature returned by OPAE API calls
+    // we return -999 if no BMC found or some other error and so no temperature returned by OPAE API calls
     if (temperature > -273.15) {
       o_list_stream << std::left << std::setw(38) << " "
                     << "FPGA temperature = " << temperature << " degrees C.\n";

--- a/common/source/util/diagnostic/main.cpp
+++ b/common/source/util/diagnostic/main.cpp
@@ -173,7 +173,7 @@ int scan_devices(const char *device_name) {
     if (temperature > -273.15) {
       o_list_stream << std::left << std::setw(38) << " "
                     << "FPGA temperature = " << temperature << " degrees C.\n";
-    } else if (temperature == -999.000000){
+    } else {
       o_list_stream << std::left << std::setw(38) << " "
                     << "FPGA temperature = " << " NA \n";
     }

--- a/common/source/util/diagnostic/main.cpp
+++ b/common/source/util/diagnostic/main.cpp
@@ -167,11 +167,15 @@ int scan_devices(const char *device_name) {
       return -1;
     }
 
-    // There is a bug with Darby Creek where temperature is reported as 0.
-    // If this happens skip printing temperature
-    if (temperature > 0) {
+    // Temperature reported in celsius
+    // anything below -273 is below absolute zero
+    // we return -999 is no BMC found or some other error and so no temperature returned by OPAE API calls
+    if (temperature > -273.15) {
       o_list_stream << std::left << std::setw(38) << " "
                     << "FPGA temperature = " << temperature << " degrees C.\n";
+    } else if (temperature == -999.000000){
+      o_list_stream << std::left << std::setw(38) << " "
+                    << "FPGA temperature = " << " NA \n";
     }
   }
 


### PR DESCRIPTION
Fix for hsd 22018519029 - Remove fatal error when temperature not found on board if no BMC present. We don't want diagnose to fatally error out if it doesnt find temperature, just sau NA for temperature to let users know asp was not able to find temperature information, it might be because BMC is absent or some other reason