### PR TITLE
Software enhancement for IO Pipes Support

### DIFF
--- a/common/source/host/CMakeLists.txt
+++ b/common/source/host/CMakeLists.txt
@@ -20,6 +20,7 @@ set(MMD_SRC
    kernel_interrupt.cpp
    mmd_dma.cpp
    zlib_inflate.c
+   mmd_iopipes.cpp
 )
 
 add_library(intel_opae_mmd SHARED ${MMD_SRC})

--- a/common/source/host/mmd.cpp
+++ b/common/source/host/mmd.cpp
@@ -39,6 +39,8 @@
 #include "fpgaconf.h"
 #include "zlib_inflate.h"
 
+bool diagnose = 0;
+
 using namespace intel_opae_mmd;
 
 #define ACL_DCP_ERROR_IF(COND, NEXT, ...)                                      \

--- a/common/source/host/mmd_device.h
+++ b/common/source/host/mmd_device.h
@@ -21,6 +21,7 @@
 #include "kernel_interrupt.h"
 #include "mmd_dma.h"
 #include "pkg_editor.h"
+#include "mmd_iopipes.h"
 
 // Tune delay for simulation or HW. Eventually delay
 // should be removed for HW, may still be needed for ASE simulation
@@ -59,6 +60,7 @@
 
 // Below is GUID for DMA
 #define DMA_BBB_GUID   "BC24AD4F-8738-F840-575F-BAB5B61A8DAE"
+#define IOPIPES_GUID "9c8560c5-729f-f873-966d-1f07871d4396"
 
 #define NULL_DFH_BBB_GUID "da1182b1-b344-4e23-90fe-6aab12a0132f"
 
@@ -168,6 +170,7 @@ private:
   void initialize_local_cpus_sysfs();
 
   bool find_dma_dfh_offsets();
+  bool find_iopipes_dfh_offsets();
 
   uint8_t bus;
   uint8_t device;
@@ -194,8 +197,10 @@ private:
   uint64_t mpf_mmio_offset;
   uint64_t dma_ch0_dfh_offset;
   uint64_t dma_ch1_dfh_offset;
+  uint64_t iopipes_dfh_offset;
   intel_opae_mmd::mmd_dma *dma_host_to_fpga;
   intel_opae_mmd::mmd_dma *dma_fpga_to_host;
+  intel_opae_mmd::iopipes *io_pipes;
 
   char *mmd_copy_buffer;
 

--- a/common/source/host/mmd_dma.cpp
+++ b/common/source/host/mmd_dma.cpp
@@ -12,7 +12,7 @@
 #include "mmd_device.h"
 #include "mmd_dma.h"
 
-using namespace intel_opae_mmd;
+namespace intel_opae_mmd {
 const uint64_t KB = 2 << 9;
 const uint64_t MB = 2 << 20;
 
@@ -539,3 +539,4 @@ int mmd_dma::host_to_fpga(aocl_mmd_op_t op, const void *host_addr,
   }
   return enqueue_dma(item);
 }
+}// namespace intel_opae_mmd

--- a/common/source/host/mmd_iopipes.cpp
+++ b/common/source/host/mmd_iopipes.cpp
@@ -1,0 +1,451 @@
+// Copyright 2020 Intel Corporation.
+//
+// THIS SOFTWARE MAY CONTAIN PREPRODUCTION CODE AND IS PROVIDED BY THE
+// COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+// OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+// EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: MIT
+
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <sys/mman.h>
+#include <algorithm>
+#include <sstream>
+
+#include <chrono>
+#include <iostream>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netinet/ether.h>
+
+#include "mmd_device.h"
+#include "mmd_iopipes.h"
+
+namespace intel_opae_mmd {
+#define INVALID_MAC 0xffffffffffffffffULL
+#define CSR_ADDRESS_MAP_JUMP_1 2
+#define CSR_ADDRESS_MAP_JUMP_2 13
+
+//base address is 0x20800
+//dfh base offset is 0x0
+//udp offload engine csrs offset is 0x10
+// do we need below defines anymore?
+#define CHECKSUM_IP     43369
+/*#define UDP_MAX_BUFSIZE 16*1024
+#define UDP_PORT_NUM    12345
+#define CSR_MAC_VAL     0x001122334455
+
+#define N               50 // data size*/
+
+// Utility to parse a MAC address string
+// It converts MAC address to unsigned long number
+/*unsigned long ParseMACAddress(std::string mac_str){
+  std::replace(mac_str.begin(), mac_str.end(), ':', ' ');
+  std::array<int, 6> mac_nums;
+  std::stringstream ss(mac_str);
+  int i = 0;
+  int tmp;
+
+  while (ss >> std::hex >> tmp) {
+    mac_nums[i++] = tmp;
+  }
+
+  if (i != 6) {
+    std::cerr << "ERROR: invalid MAC address string\n";
+    return 0;
+  }
+
+  unsigned long ret = 0;
+  for (size_t j = 0; j < 6; j++) {
+    ret += mac_nums[j] & 0xFF;
+    if (j != 5) {
+      ret <<= 8;
+    }
+  }
+
+  return ret;
+}*/
+
+uint64_t ParseMACAddress(std::string addr)
+{
+    uint64_t res = INVALID_MAC;
+    struct ether_addr *eth = ether_aton(addr.c_str());
+  
+    if (eth) {
+      res = 0ULL;
+      memcpy(&res, eth->ether_addr_octet, sizeof(eth->ether_addr_octet));
+    }
+
+    return res;
+}
+
+//iopipes constructor with initializer list
+iopipes::iopipes(int mmd_handle, std::string local_ip_address, std::string local_mac_address, std::string local_netmask, int local_udp_port,
+                 std::string remote_ip_address, std::string remote_mac_address, int remote_udp_port, uint64_t iopipes_dfh_offset)
+                : mmd_handle_(mmd_handle), local_ip_address_(local_ip_address), local_mac_address_(local_mac_address), local_netmask_(local_netmask),
+                  local_udp_port_(local_udp_port), remote_ip_address_(remote_ip_address), remote_mac_address_(remote_mac_address),
+                  remote_udp_port_(remote_udp_port), mmio_num_(0), iopipes_dfh_offset_(iopipes_dfh_offset){ }
+
+//iopipes noop destructor
+iopipes::~iopipes(){}
+// setting IP/gateway/netmask to PAC
+// void setup_pac(unsigned long mac, const char *fpga_ip,const char *gw_ip,const char *netmask)
+// void setup_pac(fpga_handle afc_handle, unsigned long mac, const std::string& fpga_ip, const std::string&  gw_ip, const std::string& netmask)
+// void setup_pac()
+
+// function to setup io pipes CSR space
+bool iopipes::setup_iopipes_asp(fpga_handle afc_handle)
+{
+  if(std::getenv("MMD_ENABLE_DEBUG")){
+      DEBUG_LOG("DEBUG LOG : IO-PIPES : Inside setup-iopipes_asp function");
+  }
+  printf("** Inside setup-iopipes_asp function **\n");
+  const uint64_t REG_UDPOE_BASE_ADDR       = iopipes::iopipes_dfh_offset_;
+  //uint64_t REG_UDPOE_DFH_BASE_ADDR   = REG_UDPOE_BASE_ADDR + (0x0*0x8);
+  const uint64_t REG_UDPOE_CSR_BASE_ADDR   = REG_UDPOE_BASE_ADDR + (0x10*0x8);
+  //uint64_t CSR_SCRATCHPAD_ADDR      = REG_UDPOE_CSR_BASE_ADDR+(0x00*0x8);
+  const uint64_t CSR_SCRATCHPAD_ADDR           = REG_UDPOE_CSR_BASE_ADDR+(0x00*0x8);
+  const uint64_t CSR_UDPOE_NUM_IOPIPES_ADDR     = REG_UDPOE_CSR_BASE_ADDR+(0x01*0x8);
+
+  const uint64_t CSR_FPGA_MAC_ADR_ADDR     = REG_UDPOE_CSR_BASE_ADDR+(0x02*0x8);
+  const uint64_t CSR_FPGA_IP_ADR_ADDR      = REG_UDPOE_CSR_BASE_ADDR+(0x03*0x8);
+  const uint64_t CSR_FPGA_UDP_PORT_ADDR    = REG_UDPOE_CSR_BASE_ADDR+(0x04*0x8);
+  const uint64_t CSR_FPGA_NETMASK_ADDR     = REG_UDPOE_CSR_BASE_ADDR+(0x05*0x8);
+  const uint64_t CSR_HOST_MAC_ADR_ADDR     = REG_UDPOE_CSR_BASE_ADDR+(0x06*0x8);
+  const uint64_t CSR_HOST_IP_ADR_ADDR      = REG_UDPOE_CSR_BASE_ADDR+(0x07*0x8);
+  const uint64_t CSR_HOST_UDP_PORT_ADDR    = REG_UDPOE_CSR_BASE_ADDR+(0x08*0x8);
+
+  const uint64_t CSR_PAYLOAD_PER_PACKET_ADDR   = REG_UDPOE_CSR_BASE_ADDR+(0x09*0x8);
+  const uint64_t CSR_CHECKSUM_IP_ADDR          = REG_UDPOE_CSR_BASE_ADDR+(0x0a*0x8);
+  //uint64_t CSR_RESET_REG_ADDR            = REG_UDPOE_CSR_BASE_ADDR+(0x09*0x8);
+
+  const uint64_t IOPIPES_CSR_START_ADDR          = REG_UDPOE_CSR_BASE_ADDR+(0x10*0x8);
+
+  std::string local_ip_addr = local_ip_address_;
+  printf("local ip address= %s\n", local_ip_addr.c_str());
+  
+  uint64_t local_mac_addr = ParseMACAddress(local_mac_address_);
+  if(local_mac_addr == 0xffffffffffffffffULL){
+    printf("Invalid Local MAC address. Please provide MAC address in 'aa:bb:cc:dd:ee:ff' format\n");
+    return false;
+  } else{
+    printf("local mac address= %ld\n", local_mac_addr);
+  }
+
+  std::string local_netmask = local_netmask_;
+  printf("local netmask = %s\n", local_netmask.c_str());
+
+  uint64_t local_udp_port = (unsigned long)local_udp_port_;
+  printf("local udp port= %ld\n", local_udp_port);
+
+  std::string remote_ip_addr = remote_ip_address_;
+  printf("remote ip address= %s\n", remote_ip_addr.c_str());
+ 
+  uint64_t remote_mac_addr = ParseMACAddress(remote_mac_address_); 
+  if(remote_mac_addr == 0xffffffffffffffffULL){
+    printf("Invalid Remote MAC address. Please provide MAC address in 'aa:bb:cc:dd:ee:ff' format\n");
+    return false;
+  } else{
+    printf("remote mac address= %ld\n", remote_mac_addr);
+  }
+
+  uint64_t remote_udp_port = (unsigned long)remote_udp_port_;
+  printf("remote udp port= %ld\n", remote_udp_port);
+
+  if(std::getenv("MMD_ENABLE_DEBUG")){
+    DEBUG_LOG("DEBUG LOG : IO-PIPES : \n local ip address= %s\n local mac address= %ld\n" 
+               "local netmask = %s\n local udp port= %ld\n remote ip address= %s\n" 
+               "remote mac address= %ld\n remote udp port= %ld\n", local_ip_addr.c_str(), local_mac_addr,
+               local_netmask.c_str(), local_udp_port, remote_ip_addr.c_str(), remote_mac_addr, remote_udp_port);
+  }
+ 
+  fpga_result res = FPGA_OK;
+  
+  // MAC reset
+  if(std::getenv("MMD_ENABLE_DEBUG")){
+    DEBUG_LOG("DEBUG LOG : IO-PIPES : MAC reset\n");
+  }
+  res = fpgaWriteMMIO64(afc_handle, mmio_num_, REG_UDPOE_BASE_ADDR, 0x7);
+  if (res != FPGA_OK) {
+    printf("error is %d, OK is %d, Exception is %d, Invalid param is %d \n",res, FPGA_OK, FPGA_EXCEPTION, FPGA_INVALID_PARAM);
+    printf("Error:writing RST\n");
+    printf("%s \n",fpgaErrStr(res));
+    return false;;
+  }
+  
+  if((res = fpgaWriteMMIO64(afc_handle, mmio_num_, CSR_SCRATCHPAD_ADDR, 0xf)) != FPGA_OK) {
+    printf("Error:Reading number of channels CSR\n");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+
+// Read MMIO CSR NUM_CHANNELS to determine how many io channels to initialize
+  uint64_t number_of_channels;
+  if((res = fpgaReadMMIO64(afc_handle, mmio_num_, CSR_UDPOE_NUM_IOPIPES_ADDR, &number_of_channels)) != FPGA_OK) {
+    printf("Error:Reading number of channels CSR\n");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  } 
+  if(std::getenv("MMD_ENABLE_DEBUG")){
+    DEBUG_LOG("DEBUG LOG : IO-PIPES : Reading number of channels CSR : Number of Channels : %ld\n", number_of_channels);
+  }
+
+// Setting CSRs needed for UDP offload Engine
+// Setting CSRs which will be common on all pipes, if we have instantiated multiple pipes
+  if(std::getenv("MMD_ENABLE_DEBUG")){
+    DEBUG_LOG("DEBUG LOG : IO-PIPES : Setting common CSRs for all IO Pipes\n");
+  }
+
+  if ((res = fpgaWriteMMIO64(afc_handle, mmio_num_, CSR_FPGA_MAC_ADR_ADDR, local_mac_addr)) != FPGA_OK) {
+    printf("Error:writing CSR_FPGA_MAC_ADR CSR");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+  if ((res = fpgaWriteMMIO64(afc_handle, mmio_num_, CSR_HOST_MAC_ADR_ADDR, remote_mac_addr)) != FPGA_OK) {
+    printf("Error:writing CSR_HOST_MAC_ADR CSR");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+
+  if ((res = fpgaWriteMMIO64(afc_handle, mmio_num_, CSR_FPGA_UDP_PORT_ADDR, local_udp_port)) != FPGA_OK) {
+    printf("Error:writing CSR_FPGA_UDP_PORT CSR");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+  if ((res = fpgaWriteMMIO64(afc_handle, mmio_num_, CSR_HOST_UDP_PORT_ADDR, remote_udp_port)) != FPGA_OK) {
+    printf("Error:writing CSR_HOST_UDP_PORT CSR");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+  
+  //CSR_PAYLOAD_PER_PACKET_ADDR
+  if ((res = fpgaWriteMMIO64(afc_handle, mmio_num_, CSR_PAYLOAD_PER_PACKET_ADDR, (unsigned long) 32)) != FPGA_OK) {
+    printf("Error:writing CSR_PAYLOAD_PER_PACKET CSR");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+
+  //CSR CHECKSUM IP
+  if ((res = fpgaWriteMMIO64(afc_handle, mmio_num_, CSR_CHECKSUM_IP_ADDR, (unsigned long)CHECKSUM_IP)) != FPGA_OK) {
+    printf("Error:writing CSR_CHECKSUM_IP CSR");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+  
+  
+// TO do - need to clean code to write to CSRs, we dont need below calculations
+// just write to CSRs what we got from environment variables or initialize to known values
+  unsigned long ul_local_ip_addr = htonl(inet_addr(local_ip_addr.c_str()));
+  unsigned long ul_local_netmask = htonl(inet_addr(local_netmask.c_str()));
+  unsigned long ul_remote_ip_addr = htonl(inet_addr(remote_ip_addr.c_str()));
+  //if ((res = fpgaWriteMMIO64(afc_handle, mmio_num, CSR_FPGA_IP_ADR_ADDR, tmp1 * 0x100000000 + (tmp2 & 0xffffffff))) != FPGA_OK) {
+  if ((res = fpgaWriteMMIO64(afc_handle, mmio_num_, CSR_FPGA_IP_ADR_ADDR, ul_local_ip_addr)) != FPGA_OK) { 
+    printf("Error:writing CSR_FPGA_IP_ADR CSR");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+  //if ((res = fpgaWriteMMIO64(afc_handle, mmio_num, CSR_HOST_IP_ADR_ADDR, tmp1 * 0x100000000 + (tmp2 & 0xffffffff))) != FPGA_OK) {
+  if ((res = fpgaWriteMMIO64(afc_handle, mmio_num_, CSR_HOST_IP_ADR_ADDR, ul_remote_ip_addr)) != FPGA_OK) { 
+    printf("Error:writing CSR_HOST_IP_ADR CSR");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+  //unsigned long tmp4 = htonl(inet_addr(local_netmask.c_str()));
+  if ((res = fpgaWriteMMIO64(afc_handle, mmio_num_, CSR_FPGA_NETMASK_ADDR, ul_local_netmask)) != FPGA_OK) {
+    printf("Error:writing CSR_FPGA_NETMASK CSR");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+
+// Setting CSRs for each IO Pipe instantiated 
+  if(std::getenv("MMD_ENABLE_DEBUG")){
+    DEBUG_LOG("DEBUG LOG : IO-PIPES : Setting CSRs specific for each IO Pipe\n");
+  }
+  int i = 0x00;
+  for(uint64_t loop=0; loop<number_of_channels; loop++) { 
+    printf("Looping on channel %ld, Writing CSRs for channel %ld\n", loop, loop); 
+    printf("Writing CSR_RESET_REG_ADDR for IO Pipe %ld\n", loop);
+    if ((res = fpgaWriteMMIO64(afc_handle, mmio_num_, (IOPIPES_CSR_START_ADDR + (++i*0x8)), 0x1)) != FPGA_OK) {
+      printf("Error:writing CSR_RESET_REG CSR");
+      printf("%s \n",fpgaErrStr(res));
+      return false;
+    }
+    i = i+CSR_ADDRESS_MAP_JUMP_1;
+    printf("Writing CSR_MISC_CTRL_REG for IO Pipe %ld\n", loop);
+    if ((res = fpgaWriteMMIO64(afc_handle, mmio_num_, (IOPIPES_CSR_START_ADDR + (i*0x8)), 0xFFFFFFFF)) != FPGA_OK) {
+      printf("Error:writing CSR_MISC_CTRL_REG CSR");
+      printf("%s \n",fpgaErrStr(res));
+      return false;
+    }
+    i = i + CSR_ADDRESS_MAP_JUMP_2;
+  }
+
+  // Read CSRs to help in debug
+  // Reading CSRs common to all pipes
+  uint64_t debug_scratchpad_csr, debug_num_iopipes_csr, debug_fpga_mac_addr_csr, debug_fpga_ip_addr_csr,
+           debug_fpga_udp_port_csr, debug_fpga_netmask_csr, debug_host_mac_addr_csr, debug_host_ip_addr_csr, 
+           debug_host_udp_port_csr, debug_payload_per_packet_csr, debug_checksum_ip_csr;
+
+  if ((res = fpgaReadMMIO64(afc_handle, mmio_num_, CSR_SCRATCHPAD_ADDR, &debug_scratchpad_csr)) != FPGA_OK) {
+    printf("Error reading CSR_SCRATCHPAD_ADDR\n");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+  printf("Read CSR: Scratchpad:%ld\n", debug_scratchpad_csr);
+
+  if ((res = fpgaReadMMIO64(afc_handle, mmio_num_, CSR_UDPOE_NUM_IOPIPES_ADDR, &debug_num_iopipes_csr)) != FPGA_OK) {
+    printf("Error reading CSR_UDPOE_NUM_IOPIPES_ADDR\n");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+  printf("Read CSR: Number of IO Channels/Pipes:%ld\n", debug_num_iopipes_csr);
+
+  if ((res = fpgaReadMMIO64(afc_handle, mmio_num_, CSR_FPGA_MAC_ADR_ADDR, &debug_fpga_mac_addr_csr)) != FPGA_OK) {
+    printf("Error reading CSR_FPGA_MAC_ADR_ADDR\n");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+  printf("Read CSR: FPGA_MAC_ADDR:%ld\n", debug_fpga_mac_addr_csr);
+
+  if ((res = fpgaReadMMIO64(afc_handle, mmio_num_, CSR_FPGA_IP_ADR_ADDR, &debug_fpga_ip_addr_csr)) != FPGA_OK) {
+    printf("Error reading CSR_FPGA_IP_ADR_ADDR\n");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+  printf("Read CSR: FPGA_IP_ADDR:%ld\n", debug_fpga_ip_addr_csr);
+
+  if ((res = fpgaReadMMIO64(afc_handle, mmio_num_, CSR_FPGA_UDP_PORT_ADDR, &debug_fpga_udp_port_csr)) != FPGA_OK) {
+    printf("Error reading CSR_FPGA_UDP_PORT_ADDR\n");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }   
+  printf("Read CSR: FPGA_UDP_PORT:%ld\n", debug_fpga_udp_port_csr);
+
+  if ((res = fpgaReadMMIO64(afc_handle, mmio_num_, CSR_FPGA_NETMASK_ADDR, &debug_fpga_netmask_csr)) != FPGA_OK) {
+    printf("Error reading CSR_FPGA_NETMASK_ADDR\n");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+  printf("Read CSR: FPGA_NETMASK:%ld\n", debug_fpga_netmask_csr);
+
+  if ((res = fpgaReadMMIO64(afc_handle, mmio_num_, CSR_HOST_MAC_ADR_ADDR, &debug_host_mac_addr_csr)) != FPGA_OK) {
+    printf("Error reading CSR_HOST_MAC_ADR_ADDR\n");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+  printf("Read CSR: HOST_MAC_ADDR:%ld\n", debug_host_mac_addr_csr);
+
+  if ((res = fpgaReadMMIO64(afc_handle, mmio_num_, CSR_HOST_IP_ADR_ADDR, &debug_host_ip_addr_csr)) != FPGA_OK) {
+    printf("Error reading CSR_HOST_IP_ADR_ADDR\n");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+  printf("Read CSR: HOST_IP_ADDR:%ld\n", debug_host_ip_addr_csr);
+
+  if ((res = fpgaReadMMIO64(afc_handle, mmio_num_, CSR_HOST_UDP_PORT_ADDR, &debug_host_udp_port_csr)) != FPGA_OK) {
+    printf("Error reading CSR_HOST_UDP_PORT_ADDR\n");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+  printf("Read CSR: HOST_UDP_PORT:%ld\n", debug_host_udp_port_csr);
+
+  if ((res = fpgaReadMMIO64(afc_handle, mmio_num_, CSR_PAYLOAD_PER_PACKET_ADDR, &debug_payload_per_packet_csr)) != FPGA_OK) {
+    printf("Error reading CSR_PAYLOAD_PER_PACKET_ADDR\n");
+    printf("%s \n",fpgaErrStr(res));
+    return false;
+  }
+  printf("Read CSR: PAYLOAD_PER_PACKET:%ld\n", debug_payload_per_packet_csr);
+
+  if ((res = fpgaReadMMIO64(afc_handle, mmio_num_, CSR_CHECKSUM_IP_ADDR , &debug_checksum_ip_csr)) != FPGA_OK) {
+    printf("Error reading CSR_CHECKSUM_IP_ADDR\n");
+    printf("%s \n",fpgaErrStr(res));
+    return false; 
+  }
+  printf("Read CSR: CHECKSUM_IP:%ld\n", debug_checksum_ip_csr);
+
+  if(std::getenv("MMD_ENABLE_DEBUG")){
+    DEBUG_LOG("DEBUG LOG : IO-PIPES : \n CSR: Scratchpad:%ld\n CSR: Number of IO Channels/Pipes:%ld\n"
+              "CSR: FPGA_MAC_ADDR:%ld\n CSR: FPGA_IP_ADDR:%ld\n CSR: FPGA_UDP_PORT:%ld\n"
+              "CSR: FPGA_NETMASK:%ld\n CSR: HOST_MAC_ADDR:%ld\n CSR: HOST_IP_ADDR:%ld\n"
+              "CSR: HOST_UDP_PORT:%ld\n CSR: PAYLOAD_PER_PACKET:%ld\n CSR: CHECKSUM_IP:%ld\n", debug_scratchpad_csr, 
+              debug_num_iopipes_csr, debug_fpga_mac_addr_csr, debug_fpga_ip_addr_csr, debug_fpga_udp_port_csr,
+              debug_fpga_netmask_csr, debug_host_mac_addr_csr, debug_host_ip_addr_csr, debug_host_udp_port_csr,
+              debug_payload_per_packet_csr, debug_checksum_ip_csr);
+  }
+
+//Reading CSRs for each pipe instantiated
+  uint64_t debug_iopipe_info_csr, debug_reset_csr, 
+           debug_status_csr, debug_misc_ctrl_csr,
+           debug_tx_status_csr, debug_rx_status_csr;
+  i = 0x00;
+  for(uint64_t loop=0; loop<number_of_channels; loop++) { 
+    printf("Looping on channel %ld, Reading CSRs for channel %ld\n", loop, loop); 
+    printf("Reading CSR_IOPIPE_INFO_REG_ADDR for IO pipe %ld\n", loop);
+    if ((res = fpgaReadMMIO64(afc_handle, mmio_num_, (IOPIPES_CSR_START_ADDR + (i++*0x8)), &debug_iopipe_info_csr)) != FPGA_OK) {
+      printf("Error:reading CSR_IOPIPE_INFO_REG_ADDR");
+      printf("%s \n",fpgaErrStr(res));
+      return false;
+    }
+    printf("Read CSR_IOPIPE_INFO_REG_ADDR:%ld\n", debug_iopipe_info_csr);
+
+    printf("Reading CSR_RESET_REG_ADDR for IO pipe %ld\n", loop);
+    if ((res = fpgaReadMMIO64(afc_handle, mmio_num_, (IOPIPES_CSR_START_ADDR + (i++*0x8)), &debug_reset_csr)) != FPGA_OK) {
+      printf("Error:reading CSR_RESET_REG_ADDR");
+      printf("%s \n",fpgaErrStr(res));
+      return false;
+    }
+    printf("Read CSR_RESET_REG_ADDR:%ld\n", debug_reset_csr);
+
+    printf("Reading CSR_STATUS_REG_ADDR for IO Pipe %ld\n", loop);
+    if ((res = fpgaReadMMIO64(afc_handle, mmio_num_, (IOPIPES_CSR_START_ADDR + (i++*0x8)), &debug_status_csr)) != FPGA_OK) {
+      printf("Error:reading CSR_STATUS_REG_ADDR");
+      printf("%s \n",fpgaErrStr(res));
+      return false;
+    }
+    printf("Read CSR_STATUS_REG_ADDR:%ld\n", debug_status_csr);
+
+    printf("Reading CSR_MISC_CTRL_REG_ADDR for IO Pipe %ld\n", loop);
+    if ((res = fpgaReadMMIO64(afc_handle, mmio_num_, (IOPIPES_CSR_START_ADDR + (i++*0x8)), &debug_misc_ctrl_csr)) != FPGA_OK) {
+      printf("Error:reading CSR_MISC_CTRL_REG_ADDR");
+      printf("%s \n",fpgaErrStr(res));
+      return false;
+    }
+    printf("Read CSR_MISC_CTRL_REG_ADDR:%ld\n", debug_misc_ctrl_csr);
+
+    printf("Reading CSR_TX_STATUS_REG_ADDR for IO Pipe %ld\n", loop);
+    if ((res = fpgaReadMMIO64(afc_handle, mmio_num_, (IOPIPES_CSR_START_ADDR + (i++*0x8)), &debug_tx_status_csr)) != FPGA_OK) {
+      printf("Error:reading CSR_TX_STATUS_REG_ADDR");
+      printf("%s \n",fpgaErrStr(res));
+      return false;
+    }
+    printf("Read CSR_TX_STATUS_REG_ADDR:%ld\n", debug_tx_status_csr);
+
+    printf("Reading CSR_RX_STATUS_REG_ADDR for IO Pipe %ld\n", loop);
+    if ((res = fpgaReadMMIO64(afc_handle, mmio_num_, (IOPIPES_CSR_START_ADDR + (i++*0x8)), &debug_rx_status_csr)) != FPGA_OK) {
+      printf("Error:reading CSR_RX_STATUS_REG_ADDR");
+      printf("%s \n",fpgaErrStr(res));
+      return false;
+    }
+    printf("Read CSR_RX_STATUS_REG_ADDR:%ld\n", debug_rx_status_csr);
+
+    if(std::getenv("MMD_ENABLE_DEBUG")){
+    DEBUG_LOG("DEBUG LOG : IO-PIPES : \n CSR_IOPIPE_INFO_REG_ADDR:%ld\n CSR_RESET_REG_ADDR:%ld\n"
+              "CSR_STATUS_REG_ADDR:%ld\n CSR_MISC_CTRL_REG_ADDR:%ld\n CSR_TX_STATUS_REG_ADDR:%ld\n"
+              "CSR_RX_STATUS_REG_ADDR:%ld\n", debug_iopipe_info_csr, debug_reset_csr, debug_status_csr,
+              debug_misc_ctrl_csr, debug_tx_status_csr, debug_rx_status_csr);
+    }
+  }
+  return true;
+}
+}// namespace intel_opae_mmd

--- a/common/source/host/mmd_iopipes.h
+++ b/common/source/host/mmd_iopipes.h
@@ -1,0 +1,68 @@
+// Copyright 2020 Intel Corporation.
+//
+// THIS SOFTWARE MAY CONTAIN PREPRODUCTION CODE AND IS PROVIDED BY THE
+// COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+// OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+// EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: MIT
+
+#include <string.h> 
+#include <cstring> 
+
+#ifndef MMD_IOPIPES_H_
+#define MMD_IOPIPES_H_
+
+//#define MAC 1234
+//#define FPGA_IP "abc"
+//#define GW_IP   "abc"
+//#define NETMASK "abc"
+
+namespace intel_opae_mmd {
+//void setup_pac(fpga_handle, unsigned long , const std::string& , const std::string& , const std::string& );
+//void setup_pac(unsigned long , char * , char * , char * );
+//void setup_pac();
+
+// TO DO - do we need any code to monitor IO Pipes errors or performance in MMD?
+
+class iopipes final {
+public:
+  /** IO Pipes constructor */
+  iopipes(int, std::string, std::string, std::string, int,
+          std::string, std::string, int, uint64_t);
+
+  /** deleting copy constructor, copy assignment operator, move constructor, move assignment operator */
+  iopipes(const iopipes&) = delete;
+  iopipes& operator=(const iopipes&) = delete;
+  iopipes(const iopipes&&) = delete;
+  iopipes& operator=(const iopipes&&) = delete;
+
+  ~iopipes();
+
+  bool setup_iopipes_asp(fpga_handle);
+
+  private:
+    int mmd_handle_;
+    std::string local_ip_address_;
+    std::string local_mac_address_;
+    std::string local_netmask_;
+    int local_udp_port_;
+    std::string remote_ip_address_;
+    std::string remote_mac_address_;
+    int remote_udp_port_;
+    int mmio_num_;
+    uint64_t iopipes_dfh_offset_;
+
+
+}; 
+
+}; // namespace intel_opae_mmd
+#endif

--- a/common/source/include/mmd.h
+++ b/common/source/include/mmd.h
@@ -14,6 +14,6 @@
 */
 int mmd_device_reprogram(const char *device_name, void *data,
                               size_t data_size);
-
+extern bool diagnose;
 #define DEBUG_LOG(...) fprintf(stderr, __VA_ARGS__)
 #endif // MMD_H

--- a/common/source/util/diagnostic/main.cpp
+++ b/common/source/util/diagnostic/main.cpp
@@ -41,6 +41,7 @@
 #undef _GNU_SOURCE
 
 #include "aocl_mmd.h"
+#include "mmd.h"
 
 #define ACL_BOARD_PKG_NAME "ofs"
 #define ACL_VENDOR_NAME "Intel(R) Corporation"
@@ -55,6 +56,8 @@
 #define DEFAULT_MINNUMBYTES (512ULL * INT_KB)
 
 #define DIAGNOSE_FAILED -1
+
+bool diagnose = 1;
 
 bool mmd_dma_setup_check();
 bool mmd_check_fme_driver_for_pr();

--- a/common/source/util/reprogram/reprogram.cpp
+++ b/common/source/util/reprogram/reprogram.cpp
@@ -9,6 +9,8 @@
 #include "aocl_mmd.h"
 #include "mmd.h"
 
+bool diagnose = 0;
+
 /* given filename, load its content into memory.
  * Returns file size in file_size_out ptr and ptr to buffer (allocated
  * with malloc() by this function that contains the content of the file.*/


### PR DESCRIPTION
Added support for IO pipes in MMD software code, to satisfy LZ for 2023.2
Tested on agilex type of machines. 
Code should ideally work on stratix machines as well but not tested.
Testing
  1) ASE testing using 1 and 4 pipes
  2) Lab testing for 1 pipes currently with loopback within ASP , further testing in progress.
Tests
  aocl diagnose
  aocl program
  openCL io pipe test
  oneapi io streaming sample test - 
     1 pipe  - https://github.com/pajgaonk/oneAPI-samples/tree/io_streaming_one_iopipe_test_update_2023.2
      4 pipe (test in progress) - https://github.com/pajgaonk/oneAPI-samples/tree/io_streaming_multi_iopipes_test_update_2023.2

Currently loop back through HSSI using loopback cable in lab is not working and it might be timing related issue.
