### PR TITLE
N6001: Update build-flow to match recent FIM changes

### DIFF
--- a/n6001/hardware/ofs_n6001/board_spec.xml
+++ b/n6001/hardware/ofs_n6001/board_spec.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <board version="22.4" name="ofs_n6001">
 
-  <compile name="afu_flat" project="ofs_top" revision="afu_flat" qsys_file="none" generic_kernel="1">
+  <compile name="afu_flat" project="ofs_top" revision="ofs_pr_afu" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>
     <synthesize cmd="quartus_sh -t build/scripts/entry.tcl afu_flat"/>
     <auto_migrate platform_type="none" >
@@ -10,7 +10,7 @@
     </auto_migrate>
   </compile>
   
-  <compile name="afu_flat_kclk" project="ofs_top" revision="afu_flat" qsys_file="none" generic_kernel="1">
+  <compile name="afu_flat_kclk" project="ofs_top" revision="ofs_pr_afu" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>
     <synthesize cmd="quartus_sh -t build/scripts/entry.tcl afu_flat_kclk"/>
     <auto_migrate platform_type="none" >

--- a/n6001/hardware/ofs_n6001/build/afu_ip.qsf
+++ b/n6001/hardware/ofs_n6001/build/afu_ip.qsf
@@ -3,11 +3,9 @@
 
 set_global_assignment -name SOURCE_TCL_SCRIPT_FILE bsp_design_files.tcl
 
-#increase placement and routing effort (at the expense of extra time)
-set_global_assignment -name PLACEMENT_EFFORT_MULTIPLIER 4.0
-set_global_assignment -name FINAL_PLACEMENT_OPTIMIZATION ALWAYS
-set_global_assignment -name ROUTER_EFFORT_MULTIPLIER 4.0
-
+#add the MPF/VTP components
+set_global_assignment -name VERILOG_MACRO "MPF_PLATFORM_DCP_PCIE=1"
+source "./ip/BBB_cci_mpf/hw/par/qsf_cci_mpf_PAR_files.qsf"
 
 #The following lines should be included when compiling with SignalTap.
 #  Rename the .stp file as appropriate.
@@ -15,9 +13,5 @@ set_global_assignment -name ROUTER_EFFORT_MULTIPLIER 4.0
 #set_global_assignment -name ENABLE_SIGNALTAP ON
 #set_global_assignment -name USE_SIGNALTAP_FILE stp1.stp
 #set_global_assignment -name SIGNALTAP_FILE stp1.stp
-
-#force duplication of local reset signals
-set_instance_assignment -name MAX_FANOUT 50 -to green_bs|pim_green_bs|*bsp_logic_inst|dma_controller_inst|*rst_local
-set_instance_assignment -name MAX_FANOUT 50 -to green_bs|pim_green_bs|*bsp_logic_inst|bsp_host_mem_if_mux_inst|*rst_local
 
 set_global_assignment -name VERILOG_INPUT_VERSION SYSTEMVERILOG_2012

--- a/n6001/hardware/ofs_n6001/build/scripts/compile_script.tcl
+++ b/n6001/hardware/ofs_n6001/build/scripts/compile_script.tcl
@@ -7,9 +7,9 @@ post_message "Running compile_script.tcl script"
 # get flow type (from quartus(args) variable)
 set flow [lindex $quartus(args) 0]
 
-puts [exec cp -rf ipss ../..]
-puts [exec cp -rf src ../..]
-puts [exec cp -rf ofs-common ../..]
+#puts [exec cp -rf ipss ../..]
+#puts [exec cp -rf src ../..]
+#puts [exec cp -rf ofs-common ../..]
 
 # simplified PR Quartus flow
 qexec "quartus_syn --read_settings_files=on --write_settings_files=off ofs_top -c $flow"

--- a/n6001/hardware/ofs_n6001/build/scripts/compile_script.tcl
+++ b/n6001/hardware/ofs_n6001/build/scripts/compile_script.tcl
@@ -7,10 +7,6 @@ post_message "Running compile_script.tcl script"
 # get flow type (from quartus(args) variable)
 set flow [lindex $quartus(args) 0]
 
-#puts [exec cp -rf ipss ../..]
-#puts [exec cp -rf src ../..]
-#puts [exec cp -rf ofs-common ../..]
-
 # simplified PR Quartus flow
 qexec "quartus_syn --read_settings_files=on --write_settings_files=off ofs_top -c $flow"
 qexec "quartus_fit --read_settings_files=on --write_settings_files=off ofs_top -c $flow"

--- a/n6001/hardware/ofs_n6001/build/scripts/entry.tcl
+++ b/n6001/hardware/ofs_n6001/build/scripts/entry.tcl
@@ -15,6 +15,7 @@ switch $tcl_platform(platform) {
       set revision_name import
     }
     post_message "Compiling revision $revision_name"
-    qexec "bash build/scripts/run.sh $revision_name"
+    #qexec "bash build/scripts/run.sh $revision_name"
+    qexec "bash fim_platform/build/syn/board/n6001/syn_top/scripts/run.sh $revision_name"
   }
 }

--- a/n6001/hardware/ofs_n6001/build/scripts/entry.tcl
+++ b/n6001/hardware/ofs_n6001/build/scripts/entry.tcl
@@ -16,6 +16,10 @@ switch $tcl_platform(platform) {
     }
     post_message "Compiling revision $revision_name"
     #qexec "bash build/scripts/run.sh $revision_name"
-    qexec "bash fim_platform/build/syn/board/n6001/syn_top/scripts/run.sh $revision_name"
+    set FIM_BOARD_PATH [glob  -directory fim_platform/build/syn/board/ -type d *]
+    post_message "FIM_BOARD_PATH is $FIM_BOARD_PATH"
+    if {[catch {qexec "bash $FIM_BOARD_PATH/syn_top/scripts/run.sh $revision_name"} result]} {
+	post_message -type error "OneAPI ASP build failed. Please see quartus_sh_compile.log for more information."
+    }
   }
 }

--- a/n6001/hardware/ofs_n6001/build/scripts/run.sh
+++ b/n6001/hardware/ofs_n6001/build/scripts/run.sh
@@ -144,8 +144,6 @@ qsys-archive --quartus-project=ofs_top --rev=afu_flat --add-to-project board.qsy
 quartus_sh -t scripts/compile_script.tcl "$BSP_FLOW"
 FLOW_SUCCESS=$?
 
-echo "we've made it pretty far, look around"
-exit 1
 
 # Report Timing
 # =============
@@ -230,8 +228,8 @@ if [ ! -f fpga.bin ]; then
 fi
 
 #copy fpga.bin to parent directory so aoc flow can find it
-cp fpga.bin ../
-cp acl_quartus_report.txt ../
+cp fpga.bin $RELATIVE_KERNEL_BUILD_PATH_TO_HERE/
+cp acl_quartus_report.txt $RELATIVE_KERNEL_BUILD_PATH_TO_HERE/
 
 echo ""
 echo "==========================================================================="

--- a/n6001/hardware/ofs_n6001/build/scripts/run.sh
+++ b/n6001/hardware/ofs_n6001/build/scripts/run.sh
@@ -84,13 +84,10 @@ echo "source afu_ip.qsf" >> ./afu_flat.qsf
 
 #symlink the compiled kernel files to here from their origin (except the )
 MYLIST=`ls --ignore=fim_platform --ignore=build $RELATIVE_KERNEL_BUILD_PATH_TO_HERE`
-echo "MYLIST is $MYLIST"
 for f in ${MYLIST}
 do
-    echo "f is $f"
     #merge the ASP's 'ip' folder with the kernel-system's 'ip' folder
     if [ "$f" == "ip" ]; then
-        echo "simlinking all of the ip files"
         cd ip
         ln -s ../${RELATIVE_KERNEL_BUILD_PATH_TO_HERE}/ip/* .
         cd  ..

--- a/n6001/hardware/ofs_n6001/build/scripts/run.sh
+++ b/n6001/hardware/ofs_n6001/build/scripts/run.sh
@@ -9,6 +9,12 @@ fi
 
 echo "This is the OFS HLD shim BSP run.sh script."
 
+KERNEL_BUILD_PWD=`pwd`
+echo "run.sh KERNEL_BUILD_PWD is $KERNEL_BUILD_PWD"
+
+BSP_BUILD_PWD="$KERNEL_BUILD_PWD/../"
+echo "run.sh BSP_BUILD_PWD is $BSP_BUILD_PWD"
+
 # set BSP flow
 if [ $# -eq 0 ]
 then
@@ -20,9 +26,7 @@ echo "Compiling '$BSP_FLOW' bsp-flow"
 
 SCRIPT_PATH=$(readlink -f "${BASH_SOURCE[0]}")
 echo "OFS BSP run.sh script path: $SCRIPT_PATH"
-
 SCRIPT_DIR_PATH="$(dirname "$SCRIPT_PATH")"
-echo "OFS BSP build dir: $SCRIPT_DIR_PATH"
 
 #if flow-type is 'flat_kclk' uncomment USE_KERNEL_CLK_EVERYWHERE_IN_PR_REGION in opencl_bsp.vh
 if [ ${BSP_FLOW} = "afu_flat_kclk" ]; then
@@ -34,6 +38,8 @@ if [ ${BSP_FLOW} = "afu_flat_kclk" ]; then
 fi
 
 cd "$SCRIPT_DIR_PATH/.." || exit
+AFU_BUILD_PWD=`pwd`
+echo "run.sh AFU_BUILD_PWD is $AFU_BUILD_PWD"
 
 if [ -n "$PACKAGER_BIN" ]; then
   echo "Selected explicitly configured PACKAGER_BIN=\"$PACKAGER_BIN\""
@@ -62,10 +68,10 @@ then
     echo "ERROR: BSP is not setup"
 fi
 
-cp ../quartus.ini .
+#cp ../quartus.ini .
 
 #import opencl kernel files
-quartus_sh -t scripts/import_opencl_kernel.tcl
+#quartus_sh -t scripts/import_opencl_kernel.tcl
 
 #check for bypass/alternative flows
 if [ -n "$OFS_ASP_ENV_ENABLE_ASE" ]; then
@@ -75,39 +81,71 @@ if [ -n "$OFS_ASP_ENV_ENABLE_ASE" ]; then
 fi
 
 #add BBBs to quartus pr project
-quartus_sh -t scripts/add_bbb_to_pr_project.tcl "$BSP_FLOW"
+#quartus_sh -t scripts/add_bbb_to_pr_project.tcl "$BSP_FLOW"
 
-cp ../afu_opencl_kernel.qsf .
+#cp ../afu_opencl_kernel.qsf .
+
+RELATIVE_BSP_BUILD_PATH_TO_HERE=`realpath --relative-to=$AFU_BUILD_PWD $BSP_BUILD_PWD`
+RELATIVE_KERNEL_BUILD_PATH_TO_HERE=`realpath --relative-to=$AFU_BUILD_PWD $KERNEL_BUILD_PWD`
+#create new 'afu_flat' revision based on the one used to compile the kernel
+cp -f ${RELATIVE_KERNEL_BUILD_PATH_TO_HERE}/ofs_pr_afu.qsf ./afu_flat.qsf
+#add ASP/afu_flat-specific stuff to the qsf file
+echo "source afu_ip.qsf" >> ./afu_flat.qsf
+
+#add SEARCH_PATH up to where the kernel was compiled
+#echo "set_global_assignment -name SEARCH_PATH \"${RELATIVE_BSP_BUILD_PATH_TO_HERE}\"" >> ./afu_flat.qsf
+#echo "set_global_assignment -name SEARCH_PATH \"${RELATIVE_KERNEL_BUILD_PATH_TO_HERE}\"" >> ./afu_flat.qsf
+
+#symlink the compiled kernel files to here from their origin (except the )
+MYLIST=`ls --ignore=fim_platform --ignore=build $RELATIVE_KERNEL_BUILD_PATH_TO_HERE`
+echo "MYLIST is $MYLIST"
+for f in ${MYLIST}
+do
+    echo "f is $f"
+    #merge the ASP's 'ip' folder with the kernel-system's 'ip' folder
+    if [ "$f" == "ip" ]; then
+        echo "simlinking all of the ip files"
+        cd ip
+        ln -s ../${RELATIVE_KERNEL_BUILD_PATH_TO_HERE}/ip/* .
+        cd  ..
+    else
+        ln -s ${RELATIVE_KERNEL_BUILD_PATH_TO_HERE}/${f} .
+    fi
+done
+#ln -s ${RELATIVE_KERNEL_BUILD_PATH_TO_HERE}/* .
 
 #get a list of gsys files that are mentioned in qsf files; then generate each of them
-eval "$(grep "QSYS_FILE" afu_flat.qsf | grep -v "^#" > qsys_filelist.txt)"
+#eval "$(grep "QSYS_FILE" afu_flat.qsf | grep -v "^#" > qsys_filelist.txt)"
+#
+#while read -r line; do
+#    f=$(echo "$line" | awk '{print $4}')
+#    qsys-generate -syn --quartus-project=ofs_top --rev=afu_opencl_kernel "$f"
+#    # adding board.qsys and corresponding .ip parameterization files to opencl_bsp_ip.qsf
+#    qsys-archive --quartus-project=ofs_top --rev=afu_opencl_kernel --add-to-project "$f"
+#done < qsys_filelist.txt
+#
+#rm -rf qsys_filelist.txt
 
-while read -r line; do
-    f=$(echo "$line" | awk '{print $4}')
-    qsys-generate -syn --quartus-project=ofs_top --rev=afu_opencl_kernel "$f"
-    # adding board.qsys and corresponding .ip parameterization files to opencl_bsp_ip.qsf
-    qsys-archive --quartus-project=ofs_top --rev=afu_opencl_kernel --add-to-project "$f"
-done < qsys_filelist.txt
-
-rm -rf qsys_filelist.txt
-
-qsys-generate -syn --quartus-project=ofs_top --rev=afu_opencl_kernel board.qsys
-# adding board.qsys and corresponding .ip parameterization files to opencl_bsp_ip.qsf
-qsys-archive --quartus-project=ofs_top --rev=afu_opencl_kernel --add-to-project board.qsys
+qsys-generate -syn --quartus-project=ofs_top --rev=afu_flat board.qsys
+## adding board.qsys and corresponding .ip parameterization files to opencl_bsp_ip.qsf
+qsys-archive --quartus-project=ofs_top --rev=afu_flat --add-to-project board.qsys
 
 #append kernel_system qsys/ip assignments to all revisions
-rm -f kernel_system_qsf_append.txt
-{ echo
-  grep -A10000 OPENCL_KERNEL_ASSIGNMENTS_START_HERE afu_opencl_kernel.qsf
-  echo
-} >> kernel_system_qsf_append.txt
-
-cat kernel_system_qsf_append.txt >> afu_flat.qsf
+#rm -f kernel_system_qsf_append.txt
+#{ echo
+#  grep -A10000 OPENCL_KERNEL_ASSIGNMENTS_START_HERE afu_opencl_kernel.qsf
+#  echo
+#} >> kernel_system_qsf_append.txt
+#
+#cat kernel_system_qsf_append.txt >> afu_flat.qsf
 
 # compile project
 # =====================
 quartus_sh -t scripts/compile_script.tcl "$BSP_FLOW"
 FLOW_SUCCESS=$?
+
+echo "we've made it pretty far, look around"
+exit 1
 
 # Report Timing
 # =============
@@ -197,6 +235,6 @@ cp acl_quartus_report.txt ../
 
 echo ""
 echo "==========================================================================="
-echo "OpenCL AFU compilation complete"
+echo "OneAPI ASP AFU compilation complete"
 echo "==========================================================================="
 echo ""

--- a/n6001/hardware/ofs_n6001_iopipes/board_spec.xml
+++ b/n6001/hardware/ofs_n6001_iopipes/board_spec.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <board version="22.4" name="ofs_n6001_iopipes">
 
-  <compile name="afu_flat" project="ofs_top" revision="afu_flat" qsys_file="none" generic_kernel="1">
+  <compile name="afu_flat" project="ofs_top" revision="ofs_pr_afu" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>
     <synthesize cmd="quartus_sh -t build/scripts/entry.tcl afu_flat"/>
     <auto_migrate platform_type="none" >
@@ -10,7 +10,7 @@
     </auto_migrate>
   </compile>
   
-  <compile name="afu_flat_kclk" project="ofs_top" revision="afu_flat" qsys_file="none" generic_kernel="1">
+  <compile name="afu_flat_kclk" project="ofs_top" revision="ofs_pr_afu" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>
     <synthesize cmd="quartus_sh -t build/scripts/entry.tcl afu_flat_kclk"/>
     <auto_migrate platform_type="none" >

--- a/n6001/hardware/ofs_n6001_iopipes/build/afu_ip.qsf
+++ b/n6001/hardware/ofs_n6001_iopipes/build/afu_ip.qsf
@@ -3,11 +3,9 @@
 
 set_global_assignment -name SOURCE_TCL_SCRIPT_FILE bsp_design_files.tcl
 
-#increase placement and routing effort (at the expense of extra time)
-set_global_assignment -name PLACEMENT_EFFORT_MULTIPLIER 4.0
-set_global_assignment -name FINAL_PLACEMENT_OPTIMIZATION ALWAYS
-set_global_assignment -name ROUTER_EFFORT_MULTIPLIER 4.0
-
+#add the MPF/VTP components
+set_global_assignment -name VERILOG_MACRO "MPF_PLATFORM_DCP_PCIE=1"
+source "./ip/BBB_cci_mpf/hw/par/qsf_cci_mpf_PAR_files.qsf"
 
 #The following lines should be included when compiling with SignalTap.
 #  Rename the .stp file as appropriate.
@@ -15,9 +13,5 @@ set_global_assignment -name ROUTER_EFFORT_MULTIPLIER 4.0
 #set_global_assignment -name ENABLE_SIGNALTAP ON
 #set_global_assignment -name USE_SIGNALTAP_FILE stp1.stp
 #set_global_assignment -name SIGNALTAP_FILE stp1.stp
-
-#force duplication of local reset signals
-set_instance_assignment -name MAX_FANOUT 50 -to green_bs|pim_green_bs|*bsp_logic_inst|dma_controller_inst|*rst_local
-set_instance_assignment -name MAX_FANOUT 50 -to green_bs|pim_green_bs|*bsp_logic_inst|bsp_host_mem_if_mux_inst|*rst_local
 
 set_global_assignment -name VERILOG_INPUT_VERSION SYSTEMVERILOG_2012

--- a/n6001/hardware/ofs_n6001_iopipes/build/scripts/compile_script.tcl
+++ b/n6001/hardware/ofs_n6001_iopipes/build/scripts/compile_script.tcl
@@ -7,10 +7,6 @@ post_message "Running compile_script.tcl script"
 # get flow type (from quartus(args) variable)
 set flow [lindex $quartus(args) 0]
 
-puts [exec cp -rf ipss ../..]
-puts [exec cp -rf src ../..]
-puts [exec cp -rf ofs-common ../..]
-
 # simplified PR Quartus flow
 qexec "quartus_syn --read_settings_files=on --write_settings_files=off ofs_top -c $flow"
 qexec "quartus_fit --read_settings_files=on --write_settings_files=off ofs_top -c $flow"

--- a/n6001/hardware/ofs_n6001_iopipes/build/scripts/entry.tcl
+++ b/n6001/hardware/ofs_n6001_iopipes/build/scripts/entry.tcl
@@ -15,6 +15,7 @@ switch $tcl_platform(platform) {
       set revision_name import
     }
     post_message "Compiling revision $revision_name"
-    qexec "bash build/scripts/run.sh $revision_name"
+    #qexec "bash build/scripts/run.sh $revision_name"
+    qexec "bash fim_platform/build/syn/board/n6001/syn_top/scripts/run.sh $revision_name"
   }
 }

--- a/n6001/hardware/ofs_n6001_iopipes/build/scripts/entry.tcl
+++ b/n6001/hardware/ofs_n6001_iopipes/build/scripts/entry.tcl
@@ -16,6 +16,10 @@ switch $tcl_platform(platform) {
     }
     post_message "Compiling revision $revision_name"
     #qexec "bash build/scripts/run.sh $revision_name"
-    qexec "bash fim_platform/build/syn/board/n6001/syn_top/scripts/run.sh $revision_name"
+    set FIM_BOARD_PATH [glob  -directory fim_platform/build/syn/board/ -type d *]
+    post_message "FIM_BOARD_PATH is $FIM_BOARD_PATH"
+    if {[catch {qexec "bash $FIM_BOARD_PATH/syn_top/scripts/run.sh $revision_name"} result]} {
+	post_message -type error "OneAPI ASP build failed. Please see quartus_sh_compile.log for more information."
+    }
   }
 }

--- a/n6001/hardware/ofs_n6001_iopipes/build/scripts/run.sh
+++ b/n6001/hardware/ofs_n6001_iopipes/build/scripts/run.sh
@@ -7,7 +7,13 @@ if [ -n "$OFS_ASP_ENV_DEBUG_SCRIPTS" ]; then
   set -x
 fi
 
-echo "This is the OFS HLD shim BSP run.sh script."
+echo "This is the OFS OneAPI ASP run.sh script."
+
+KERNEL_BUILD_PWD=`pwd`
+echo "run.sh KERNEL_BUILD_PWD is $KERNEL_BUILD_PWD"
+
+BSP_BUILD_PWD="$KERNEL_BUILD_PWD/../"
+echo "run.sh BSP_BUILD_PWD is $BSP_BUILD_PWD"
 
 # set BSP flow
 if [ $# -eq 0 ]
@@ -20,9 +26,7 @@ echo "Compiling '$BSP_FLOW' bsp-flow"
 
 SCRIPT_PATH=$(readlink -f "${BASH_SOURCE[0]}")
 echo "OFS BSP run.sh script path: $SCRIPT_PATH"
-
 SCRIPT_DIR_PATH="$(dirname "$SCRIPT_PATH")"
-echo "OFS BSP build dir: $SCRIPT_DIR_PATH"
 
 #if flow-type is 'flat_kclk' uncomment USE_KERNEL_CLK_EVERYWHERE_IN_PR_REGION in opencl_bsp.vh
 if [ ${BSP_FLOW} = "afu_flat_kclk" ]; then
@@ -34,6 +38,8 @@ if [ ${BSP_FLOW} = "afu_flat_kclk" ]; then
 fi
 
 cd "$SCRIPT_DIR_PATH/.." || exit
+AFU_BUILD_PWD=`pwd`
+echo "run.sh AFU_BUILD_PWD is $AFU_BUILD_PWD"
 
 if [ -n "$PACKAGER_BIN" ]; then
   echo "Selected explicitly configured PACKAGER_BIN=\"$PACKAGER_BIN\""
@@ -62,11 +68,6 @@ then
     echo "ERROR: BSP is not setup"
 fi
 
-cp ../quartus.ini .
-
-#import opencl kernel files
-quartus_sh -t scripts/import_opencl_kernel.tcl
-
 #check for bypass/alternative flows
 if [ -n "$OFS_ASP_ENV_ENABLE_ASE" ]; then
     echo "Calling ASE simulation flow compile"
@@ -74,37 +75,33 @@ if [ -n "$OFS_ASP_ENV_ENABLE_ASE" ]; then
     exit $?
 fi
 
-#add BBBs to quartus pr project
-quartus_sh -t scripts/add_bbb_to_pr_project.tcl "$BSP_FLOW"
+RELATIVE_BSP_BUILD_PATH_TO_HERE=`realpath --relative-to=$AFU_BUILD_PWD $BSP_BUILD_PWD`
+RELATIVE_KERNEL_BUILD_PATH_TO_HERE=`realpath --relative-to=$AFU_BUILD_PWD $KERNEL_BUILD_PWD`
+#create new 'afu_flat' revision based on the one used to compile the kernel
+cp -f ${RELATIVE_KERNEL_BUILD_PATH_TO_HERE}/ofs_pr_afu.qsf ./afu_flat.qsf
+#add ASP/afu_flat-specific stuff to the qsf file
+echo "source afu_ip.qsf" >> ./afu_flat.qsf
 
-cp ../afu_opencl_kernel.qsf .
+#symlink the compiled kernel files to here from their origin (except the )
+MYLIST=`ls --ignore=fim_platform --ignore=build $RELATIVE_KERNEL_BUILD_PATH_TO_HERE`
+echo "MYLIST is $MYLIST"
+for f in ${MYLIST}
+do
+    echo "f is $f"
+    #merge the ASP's 'ip' folder with the kernel-system's 'ip' folder
+    if [ "$f" == "ip" ]; then
+        echo "simlinking all of the ip files"
+        cd ip
+        ln -s ../${RELATIVE_KERNEL_BUILD_PATH_TO_HERE}/ip/* .
+        cd  ..
+    else
+        ln -s ${RELATIVE_KERNEL_BUILD_PATH_TO_HERE}/${f} .
+    fi
+done
 
-#get a list of gsys files that are mentioned in qsf files; then generate each of them
-eval "$(grep "QSYS_FILE" afu_flat.qsf | grep -v "^#" > qsys_filelist.txt)"
-eval "$(grep "IP_FILE" afu_flat.qsf | grep -v "^#" >> qsys_filelist.txt)"
-
-while read -r line; do
-    f=$(echo "$line" | awk '{print $4}')
-    echo "running qsys-generate on $f"
-    qsys-generate -syn --quartus-project=ofs_top --rev=afu_opencl_kernel "$f"
-    # adding board.qsys and corresponding .ip parameterization files to opencl_bsp_ip.qsf
-    qsys-archive --quartus-project=ofs_top --rev=afu_opencl_kernel --add-to-project "$f"
-done < qsys_filelist.txt
-
-rm -rf qsys_filelist.txt
-
-qsys-generate -syn --quartus-project=ofs_top --rev=afu_opencl_kernel board.qsys
-# adding board.qsys and corresponding .ip parameterization files to opencl_bsp_ip.qsf
-qsys-archive --quartus-project=ofs_top --rev=afu_opencl_kernel --add-to-project board.qsys
-
-#append kernel_system qsys/ip assignments to all revisions
-rm -f kernel_system_qsf_append.txt
-{ echo
-  grep -A10000 OPENCL_KERNEL_ASSIGNMENTS_START_HERE afu_opencl_kernel.qsf
-  echo
-} >> kernel_system_qsf_append.txt
-
-cat kernel_system_qsf_append.txt >> afu_flat.qsf
+qsys-generate -syn --quartus-project=ofs_top --rev=afu_flat board.qsys
+## adding board.qsys and corresponding .ip parameterization files to opencl_bsp_ip.qsf
+qsys-archive --quartus-project=ofs_top --rev=afu_flat --add-to-project board.qsys
 
 # compile project
 # =====================
@@ -194,11 +191,11 @@ if [ ! -f fpga.bin ]; then
 fi
 
 #copy fpga.bin to parent directory so aoc flow can find it
-cp fpga.bin ../
-cp acl_quartus_report.txt ../
+cp fpga.bin $RELATIVE_KERNEL_BUILD_PATH_TO_HERE/
+cp acl_quartus_report.txt $RELATIVE_KERNEL_BUILD_PATH_TO_HERE/
 
 echo ""
 echo "==========================================================================="
-echo "OpenCL AFU compilation complete"
+echo "OneAPI ASP AFU compilation complete"
 echo "==========================================================================="
 echo ""

--- a/n6001/hardware/ofs_n6001_iopipes/build/scripts/run.sh
+++ b/n6001/hardware/ofs_n6001_iopipes/build/scripts/run.sh
@@ -84,13 +84,10 @@ echo "source afu_ip.qsf" >> ./afu_flat.qsf
 
 #symlink the compiled kernel files to here from their origin (except the )
 MYLIST=`ls --ignore=fim_platform --ignore=build $RELATIVE_KERNEL_BUILD_PATH_TO_HERE`
-echo "MYLIST is $MYLIST"
 for f in ${MYLIST}
 do
-    echo "f is $f"
     #merge the ASP's 'ip' folder with the kernel-system's 'ip' folder
     if [ "$f" == "ip" ]; then
-        echo "simlinking all of the ip files"
         cd ip
         ln -s ../${RELATIVE_KERNEL_BUILD_PATH_TO_HERE}/ip/* .
         cd  ..

--- a/n6001/hardware/ofs_n6001_usm/board_spec.xml
+++ b/n6001/hardware/ofs_n6001_usm/board_spec.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <board version="22.4" name="ofs_n6001_usm">
 
-  <compile name="afu_flat" project="ofs_top" revision="afu_flat" qsys_file="none" generic_kernel="1">
+  <compile name="afu_flat" project="ofs_top" revision="ofs_pr_afu" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>
     <synthesize cmd="quartus_sh -t build/scripts/entry.tcl afu_flat"/>
     <auto_migrate platform_type="none" >
@@ -10,7 +10,7 @@
     </auto_migrate>
   </compile>
   
-  <compile name="afu_flat_kclk" project="ofs_top" revision="afu_flat" qsys_file="none" generic_kernel="1">
+  <compile name="afu_flat_kclk" project="ofs_top" revision="ofs_pr_afu" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>
     <synthesize cmd="quartus_sh -t build/scripts/entry.tcl afu_flat_kclk"/>
     <auto_migrate platform_type="none" >

--- a/n6001/hardware/ofs_n6001_usm/build/afu_ip.qsf
+++ b/n6001/hardware/ofs_n6001_usm/build/afu_ip.qsf
@@ -3,11 +3,9 @@
 
 set_global_assignment -name SOURCE_TCL_SCRIPT_FILE bsp_design_files.tcl
 
-#increase placement and routing effort (at the expense of extra time)
-set_global_assignment -name PLACEMENT_EFFORT_MULTIPLIER 4.0
-set_global_assignment -name FINAL_PLACEMENT_OPTIMIZATION ALWAYS
-set_global_assignment -name ROUTER_EFFORT_MULTIPLIER 4.0
-
+#add the MPF/VTP components
+set_global_assignment -name VERILOG_MACRO "MPF_PLATFORM_DCP_PCIE=1"
+source "./ip/BBB_cci_mpf/hw/par/qsf_cci_mpf_PAR_files.qsf"
 
 #The following lines should be included when compiling with SignalTap.
 #  Rename the .stp file as appropriate.
@@ -15,9 +13,5 @@ set_global_assignment -name ROUTER_EFFORT_MULTIPLIER 4.0
 #set_global_assignment -name ENABLE_SIGNALTAP ON
 #set_global_assignment -name USE_SIGNALTAP_FILE stp1.stp
 #set_global_assignment -name SIGNALTAP_FILE stp1.stp
-
-#force duplication of local reset signals
-set_instance_assignment -name MAX_FANOUT 50 -to green_bs|pim_green_bs|*bsp_logic_inst|dma_controller_inst|*rst_local
-set_instance_assignment -name MAX_FANOUT 50 -to green_bs|pim_green_bs|*bsp_logic_inst|bsp_host_mem_if_mux_inst|*rst_local
 
 set_global_assignment -name VERILOG_INPUT_VERSION SYSTEMVERILOG_2012

--- a/n6001/hardware/ofs_n6001_usm/build/scripts/compile_script.tcl
+++ b/n6001/hardware/ofs_n6001_usm/build/scripts/compile_script.tcl
@@ -7,10 +7,6 @@ post_message "Running compile_script.tcl script"
 # get flow type (from quartus(args) variable)
 set flow [lindex $quartus(args) 0]
 
-puts [exec cp -rf ipss ../..]
-puts [exec cp -rf src ../..]
-puts [exec cp -rf ofs-common ../..]
-
 # simplified PR Quartus flow
 qexec "quartus_syn --read_settings_files=on --write_settings_files=off ofs_top -c $flow"
 qexec "quartus_fit --read_settings_files=on --write_settings_files=off ofs_top -c $flow"

--- a/n6001/hardware/ofs_n6001_usm/build/scripts/entry.tcl
+++ b/n6001/hardware/ofs_n6001_usm/build/scripts/entry.tcl
@@ -15,6 +15,7 @@ switch $tcl_platform(platform) {
       set revision_name import
     }
     post_message "Compiling revision $revision_name"
-    qexec "bash build/scripts/run.sh $revision_name"
+    #qexec "bash build/scripts/run.sh $revision_name"
+    qexec "bash fim_platform/build/syn/board/n6001/syn_top/scripts/run.sh $revision_name"
   }
 }

--- a/n6001/hardware/ofs_n6001_usm/build/scripts/entry.tcl
+++ b/n6001/hardware/ofs_n6001_usm/build/scripts/entry.tcl
@@ -16,6 +16,10 @@ switch $tcl_platform(platform) {
     }
     post_message "Compiling revision $revision_name"
     #qexec "bash build/scripts/run.sh $revision_name"
-    qexec "bash fim_platform/build/syn/board/n6001/syn_top/scripts/run.sh $revision_name"
+    set FIM_BOARD_PATH [glob  -directory fim_platform/build/syn/board/ -type d *]
+    post_message "FIM_BOARD_PATH is $FIM_BOARD_PATH"
+    if {[catch {qexec "bash $FIM_BOARD_PATH/syn_top/scripts/run.sh $revision_name"} result]} {
+	post_message -type error "OneAPI ASP build failed. Please see quartus_sh_compile.log for more information."
+    }
   }
 }

--- a/n6001/hardware/ofs_n6001_usm/build/scripts/run.sh
+++ b/n6001/hardware/ofs_n6001_usm/build/scripts/run.sh
@@ -84,13 +84,10 @@ echo "source afu_ip.qsf" >> ./afu_flat.qsf
 
 #symlink the compiled kernel files to here from their origin (except the )
 MYLIST=`ls --ignore=fim_platform --ignore=build $RELATIVE_KERNEL_BUILD_PATH_TO_HERE`
-echo "MYLIST is $MYLIST"
 for f in ${MYLIST}
 do
-    echo "f is $f"
     #merge the ASP's 'ip' folder with the kernel-system's 'ip' folder
     if [ "$f" == "ip" ]; then
-        echo "simlinking all of the ip files"
         cd ip
         ln -s ../${RELATIVE_KERNEL_BUILD_PATH_TO_HERE}/ip/* .
         cd  ..

--- a/n6001/hardware/ofs_n6001_usm/build/scripts/run.sh
+++ b/n6001/hardware/ofs_n6001_usm/build/scripts/run.sh
@@ -7,7 +7,13 @@ if [ -n "$OFS_ASP_ENV_DEBUG_SCRIPTS" ]; then
   set -x
 fi
 
-echo "This is the OFS HLD shim BSP run.sh script."
+echo "This is the OFS OneAPI ASP run.sh script."
+
+KERNEL_BUILD_PWD=`pwd`
+echo "run.sh KERNEL_BUILD_PWD is $KERNEL_BUILD_PWD"
+
+BSP_BUILD_PWD="$KERNEL_BUILD_PWD/../"
+echo "run.sh BSP_BUILD_PWD is $BSP_BUILD_PWD"
 
 # set BSP flow
 if [ $# -eq 0 ]
@@ -20,9 +26,7 @@ echo "Compiling '$BSP_FLOW' bsp-flow"
 
 SCRIPT_PATH=$(readlink -f "${BASH_SOURCE[0]}")
 echo "OFS BSP run.sh script path: $SCRIPT_PATH"
-
 SCRIPT_DIR_PATH="$(dirname "$SCRIPT_PATH")"
-echo "OFS BSP build dir: $SCRIPT_DIR_PATH"
 
 #if flow-type is 'flat_kclk' uncomment USE_KERNEL_CLK_EVERYWHERE_IN_PR_REGION in opencl_bsp.vh
 if [ ${BSP_FLOW} = "afu_flat_kclk" ]; then
@@ -34,6 +38,8 @@ if [ ${BSP_FLOW} = "afu_flat_kclk" ]; then
 fi
 
 cd "$SCRIPT_DIR_PATH/.." || exit
+AFU_BUILD_PWD=`pwd`
+echo "run.sh AFU_BUILD_PWD is $AFU_BUILD_PWD"
 
 if [ -n "$PACKAGER_BIN" ]; then
   echo "Selected explicitly configured PACKAGER_BIN=\"$PACKAGER_BIN\""
@@ -62,11 +68,6 @@ then
     echo "ERROR: BSP is not setup"
 fi
 
-cp ../quartus.ini .
-
-#import opencl kernel files
-quartus_sh -t scripts/import_opencl_kernel.tcl
-
 #check for bypass/alternative flows
 if [ -n "$OFS_ASP_ENV_ENABLE_ASE" ]; then
     echo "Calling ASE simulation flow compile"
@@ -74,35 +75,33 @@ if [ -n "$OFS_ASP_ENV_ENABLE_ASE" ]; then
     exit $?
 fi
 
-#add BBBs to quartus pr project
-quartus_sh -t scripts/add_bbb_to_pr_project.tcl "$BSP_FLOW"
+RELATIVE_BSP_BUILD_PATH_TO_HERE=`realpath --relative-to=$AFU_BUILD_PWD $BSP_BUILD_PWD`
+RELATIVE_KERNEL_BUILD_PATH_TO_HERE=`realpath --relative-to=$AFU_BUILD_PWD $KERNEL_BUILD_PWD`
+#create new 'afu_flat' revision based on the one used to compile the kernel
+cp -f ${RELATIVE_KERNEL_BUILD_PATH_TO_HERE}/ofs_pr_afu.qsf ./afu_flat.qsf
+#add ASP/afu_flat-specific stuff to the qsf file
+echo "source afu_ip.qsf" >> ./afu_flat.qsf
 
-cp ../afu_opencl_kernel.qsf .
+#symlink the compiled kernel files to here from their origin (except the )
+MYLIST=`ls --ignore=fim_platform --ignore=build $RELATIVE_KERNEL_BUILD_PATH_TO_HERE`
+echo "MYLIST is $MYLIST"
+for f in ${MYLIST}
+do
+    echo "f is $f"
+    #merge the ASP's 'ip' folder with the kernel-system's 'ip' folder
+    if [ "$f" == "ip" ]; then
+        echo "simlinking all of the ip files"
+        cd ip
+        ln -s ../${RELATIVE_KERNEL_BUILD_PATH_TO_HERE}/ip/* .
+        cd  ..
+    else
+        ln -s ${RELATIVE_KERNEL_BUILD_PATH_TO_HERE}/${f} .
+    fi
+done
 
-#get a list of gsys files that are mentioned in qsf files; then generate each of them
-eval "$(grep "QSYS_FILE" afu_flat.qsf | grep -v "^#" > qsys_filelist.txt)"
-
-while read -r line; do
-    f=$(echo "$line" | awk '{print $4}')
-    qsys-generate -syn --quartus-project=ofs_top --rev=afu_opencl_kernel "$f"
-    # adding board.qsys and corresponding .ip parameterization files to opencl_bsp_ip.qsf
-    qsys-archive --quartus-project=ofs_top --rev=afu_opencl_kernel --add-to-project "$f"
-done < qsys_filelist.txt
-
-rm -rf qsys_filelist.txt
-
-qsys-generate -syn --quartus-project=ofs_top --rev=afu_opencl_kernel board.qsys
-# adding board.qsys and corresponding .ip parameterization files to opencl_bsp_ip.qsf
-qsys-archive --quartus-project=ofs_top --rev=afu_opencl_kernel --add-to-project board.qsys
-
-#append kernel_system qsys/ip assignments to all revisions
-rm -f kernel_system_qsf_append.txt
-{ echo
-  grep -A10000 OPENCL_KERNEL_ASSIGNMENTS_START_HERE afu_opencl_kernel.qsf
-  echo
-} >> kernel_system_qsf_append.txt
-
-cat kernel_system_qsf_append.txt >> afu_flat.qsf
+qsys-generate -syn --quartus-project=ofs_top --rev=afu_flat board.qsys
+## adding board.qsys and corresponding .ip parameterization files to opencl_bsp_ip.qsf
+qsys-archive --quartus-project=ofs_top --rev=afu_flat --add-to-project board.qsys
 
 # compile project
 # =====================
@@ -192,11 +191,11 @@ if [ ! -f fpga.bin ]; then
 fi
 
 #copy fpga.bin to parent directory so aoc flow can find it
-cp fpga.bin ../
-cp acl_quartus_report.txt ../
+cp fpga.bin $RELATIVE_KERNEL_BUILD_PATH_TO_HERE/
+cp acl_quartus_report.txt $RELATIVE_KERNEL_BUILD_PATH_TO_HERE/
 
 echo ""
 echo "==========================================================================="
-echo "OpenCL AFU compilation complete"
+echo "OneAPI ASP AFU compilation complete"
 echo "==========================================================================="
 echo ""

--- a/n6001/hardware/ofs_n6001_usm_iopipes/board_spec.xml
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/board_spec.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <board version="22.4" name="ofs_n6001_usm_iopipes">
 
-  <compile name="afu_flat" project="ofs_top" revision="afu_flat" qsys_file="none" generic_kernel="1">
+  <compile name="afu_flat" project="ofs_top" revision="ofs_pr_afu" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>
     <synthesize cmd="quartus_sh -t build/scripts/entry.tcl afu_flat"/>
     <auto_migrate platform_type="none" >
@@ -10,7 +10,7 @@
     </auto_migrate>
   </compile>
   
-  <compile name="afu_flat_kclk" project="ofs_top" revision="afu_flat" qsys_file="none" generic_kernel="1">
+  <compile name="afu_flat_kclk" project="ofs_top" revision="ofs_pr_afu" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>
     <synthesize cmd="quartus_sh -t build/scripts/entry.tcl afu_flat_kclk"/>
     <auto_migrate platform_type="none" >

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/afu_ip.qsf
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/afu_ip.qsf
@@ -3,11 +3,9 @@
 
 set_global_assignment -name SOURCE_TCL_SCRIPT_FILE bsp_design_files.tcl
 
-#increase placement and routing effort (at the expense of extra time)
-set_global_assignment -name PLACEMENT_EFFORT_MULTIPLIER 4.0
-set_global_assignment -name FINAL_PLACEMENT_OPTIMIZATION ALWAYS
-set_global_assignment -name ROUTER_EFFORT_MULTIPLIER 4.0
-
+#add the MPF/VTP components
+set_global_assignment -name VERILOG_MACRO "MPF_PLATFORM_DCP_PCIE=1"
+source "./ip/BBB_cci_mpf/hw/par/qsf_cci_mpf_PAR_files.qsf"
 
 #The following lines should be included when compiling with SignalTap.
 #  Rename the .stp file as appropriate.
@@ -15,9 +13,5 @@ set_global_assignment -name ROUTER_EFFORT_MULTIPLIER 4.0
 #set_global_assignment -name ENABLE_SIGNALTAP ON
 #set_global_assignment -name USE_SIGNALTAP_FILE stp1.stp
 #set_global_assignment -name SIGNALTAP_FILE stp1.stp
-
-#force duplication of local reset signals
-set_instance_assignment -name MAX_FANOUT 50 -to green_bs|pim_green_bs|*bsp_logic_inst|dma_controller_inst|*rst_local
-set_instance_assignment -name MAX_FANOUT 50 -to green_bs|pim_green_bs|*bsp_logic_inst|bsp_host_mem_if_mux_inst|*rst_local
 
 set_global_assignment -name VERILOG_INPUT_VERSION SYSTEMVERILOG_2012

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/scripts/compile_script.tcl
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/scripts/compile_script.tcl
@@ -7,10 +7,6 @@ post_message "Running compile_script.tcl script"
 # get flow type (from quartus(args) variable)
 set flow [lindex $quartus(args) 0]
 
-puts [exec cp -rf ipss ../..]
-puts [exec cp -rf src ../..]
-puts [exec cp -rf ofs-common ../..]
-
 # simplified PR Quartus flow
 qexec "quartus_syn --read_settings_files=on --write_settings_files=off ofs_top -c $flow"
 qexec "quartus_fit --read_settings_files=on --write_settings_files=off ofs_top -c $flow"

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/scripts/entry.tcl
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/scripts/entry.tcl
@@ -15,6 +15,7 @@ switch $tcl_platform(platform) {
       set revision_name import
     }
     post_message "Compiling revision $revision_name"
-    qexec "bash build/scripts/run.sh $revision_name"
+    #qexec "bash build/scripts/run.sh $revision_name"
+    qexec "bash fim_platform/build/syn/board/n6001/syn_top/scripts/run.sh $revision_name"
   }
 }

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/scripts/entry.tcl
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/scripts/entry.tcl
@@ -16,6 +16,10 @@ switch $tcl_platform(platform) {
     }
     post_message "Compiling revision $revision_name"
     #qexec "bash build/scripts/run.sh $revision_name"
-    qexec "bash fim_platform/build/syn/board/n6001/syn_top/scripts/run.sh $revision_name"
+    set FIM_BOARD_PATH [glob  -directory fim_platform/build/syn/board/ -type d *]
+    post_message "FIM_BOARD_PATH is $FIM_BOARD_PATH"
+    if {[catch {qexec "bash $FIM_BOARD_PATH/syn_top/scripts/run.sh $revision_name"} result]} {
+	post_message -type error "OneAPI ASP build failed. Please see quartus_sh_compile.log for more information."
+    }
   }
 }

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/scripts/run.sh
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/scripts/run.sh
@@ -7,7 +7,13 @@ if [ -n "$OFS_ASP_ENV_DEBUG_SCRIPTS" ]; then
   set -x
 fi
 
-echo "This is the OFS HLD shim BSP run.sh script."
+echo "This is the OFS OneAPI ASP run.sh script."
+
+KERNEL_BUILD_PWD=`pwd`
+echo "run.sh KERNEL_BUILD_PWD is $KERNEL_BUILD_PWD"
+
+BSP_BUILD_PWD="$KERNEL_BUILD_PWD/../"
+echo "run.sh BSP_BUILD_PWD is $BSP_BUILD_PWD"
 
 # set BSP flow
 if [ $# -eq 0 ]
@@ -20,9 +26,7 @@ echo "Compiling '$BSP_FLOW' bsp-flow"
 
 SCRIPT_PATH=$(readlink -f "${BASH_SOURCE[0]}")
 echo "OFS BSP run.sh script path: $SCRIPT_PATH"
-
 SCRIPT_DIR_PATH="$(dirname "$SCRIPT_PATH")"
-echo "OFS BSP build dir: $SCRIPT_DIR_PATH"
 
 #if flow-type is 'flat_kclk' uncomment USE_KERNEL_CLK_EVERYWHERE_IN_PR_REGION in opencl_bsp.vh
 if [ ${BSP_FLOW} = "afu_flat_kclk" ]; then
@@ -34,6 +38,8 @@ if [ ${BSP_FLOW} = "afu_flat_kclk" ]; then
 fi
 
 cd "$SCRIPT_DIR_PATH/.." || exit
+AFU_BUILD_PWD=`pwd`
+echo "run.sh AFU_BUILD_PWD is $AFU_BUILD_PWD"
 
 if [ -n "$PACKAGER_BIN" ]; then
   echo "Selected explicitly configured PACKAGER_BIN=\"$PACKAGER_BIN\""
@@ -62,11 +68,6 @@ then
     echo "ERROR: BSP is not setup"
 fi
 
-cp ../quartus.ini .
-
-#import opencl kernel files
-quartus_sh -t scripts/import_opencl_kernel.tcl
-
 #check for bypass/alternative flows
 if [ -n "$OFS_ASP_ENV_ENABLE_ASE" ]; then
     echo "Calling ASE simulation flow compile"
@@ -74,37 +75,33 @@ if [ -n "$OFS_ASP_ENV_ENABLE_ASE" ]; then
     exit $?
 fi
 
-#add BBBs to quartus pr project
-quartus_sh -t scripts/add_bbb_to_pr_project.tcl "$BSP_FLOW"
+RELATIVE_BSP_BUILD_PATH_TO_HERE=`realpath --relative-to=$AFU_BUILD_PWD $BSP_BUILD_PWD`
+RELATIVE_KERNEL_BUILD_PATH_TO_HERE=`realpath --relative-to=$AFU_BUILD_PWD $KERNEL_BUILD_PWD`
+#create new 'afu_flat' revision based on the one used to compile the kernel
+cp -f ${RELATIVE_KERNEL_BUILD_PATH_TO_HERE}/ofs_pr_afu.qsf ./afu_flat.qsf
+#add ASP/afu_flat-specific stuff to the qsf file
+echo "source afu_ip.qsf" >> ./afu_flat.qsf
 
-cp ../afu_opencl_kernel.qsf .
+#symlink the compiled kernel files to here from their origin (except the )
+MYLIST=`ls --ignore=fim_platform --ignore=build $RELATIVE_KERNEL_BUILD_PATH_TO_HERE`
+echo "MYLIST is $MYLIST"
+for f in ${MYLIST}
+do
+    echo "f is $f"
+    #merge the ASP's 'ip' folder with the kernel-system's 'ip' folder
+    if [ "$f" == "ip" ]; then
+        echo "simlinking all of the ip files"
+        cd ip
+        ln -s ../${RELATIVE_KERNEL_BUILD_PATH_TO_HERE}/ip/* .
+        cd  ..
+    else
+        ln -s ${RELATIVE_KERNEL_BUILD_PATH_TO_HERE}/${f} .
+    fi
+done
 
-#get a list of gsys files that are mentioned in qsf files; then generate each of them
-eval "$(grep "QSYS_FILE" afu_flat.qsf | grep -v "^#" > qsys_filelist.txt)"
-eval "$(grep "IP_FILE" afu_flat.qsf | grep -v "^#" >> qsys_filelist.txt)"
-
-while read -r line; do
-    f=$(echo "$line" | awk '{print $4}')
-    echo "running qsys-generate on $f"
-    qsys-generate -syn --quartus-project=ofs_top --rev=afu_opencl_kernel "$f"
-    # adding board.qsys and corresponding .ip parameterization files to opencl_bsp_ip.qsf
-    qsys-archive --quartus-project=ofs_top --rev=afu_opencl_kernel --add-to-project "$f"
-done < qsys_filelist.txt
-
-rm -rf qsys_filelist.txt
-
-qsys-generate -syn --quartus-project=ofs_top --rev=afu_opencl_kernel board.qsys
-# adding board.qsys and corresponding .ip parameterization files to opencl_bsp_ip.qsf
-qsys-archive --quartus-project=ofs_top --rev=afu_opencl_kernel --add-to-project board.qsys
-
-#append kernel_system qsys/ip assignments to all revisions
-rm -f kernel_system_qsf_append.txt
-{ echo
-  grep -A10000 OPENCL_KERNEL_ASSIGNMENTS_START_HERE afu_opencl_kernel.qsf
-  echo
-} >> kernel_system_qsf_append.txt
-
-cat kernel_system_qsf_append.txt >> afu_flat.qsf
+qsys-generate -syn --quartus-project=ofs_top --rev=afu_flat board.qsys
+## adding board.qsys and corresponding .ip parameterization files to opencl_bsp_ip.qsf
+qsys-archive --quartus-project=ofs_top --rev=afu_flat --add-to-project board.qsys
 
 # compile project
 # =====================
@@ -194,11 +191,11 @@ if [ ! -f fpga.bin ]; then
 fi
 
 #copy fpga.bin to parent directory so aoc flow can find it
-cp fpga.bin ../
-cp acl_quartus_report.txt ../
+cp fpga.bin $RELATIVE_KERNEL_BUILD_PATH_TO_HERE/
+cp acl_quartus_report.txt $RELATIVE_KERNEL_BUILD_PATH_TO_HERE/
 
 echo ""
 echo "==========================================================================="
-echo "OpenCL AFU compilation complete"
+echo "OneAPI ASP AFU compilation complete"
 echo "==========================================================================="
 echo ""

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/scripts/run.sh
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/scripts/run.sh
@@ -84,13 +84,10 @@ echo "source afu_ip.qsf" >> ./afu_flat.qsf
 
 #symlink the compiled kernel files to here from their origin (except the )
 MYLIST=`ls --ignore=fim_platform --ignore=build $RELATIVE_KERNEL_BUILD_PATH_TO_HERE`
-echo "MYLIST is $MYLIST"
 for f in ${MYLIST}
 do
-    echo "f is $f"
     #merge the ASP's 'ip' folder with the kernel-system's 'ip' folder
     if [ "$f" == "ip" ]; then
-        echo "simlinking all of the ip files"
         cd ip
         ln -s ../${RELATIVE_KERNEL_BUILD_PATH_TO_HERE}/ip/* .
         cd  ..

--- a/n6001/scripts/setup-bsp.py
+++ b/n6001/scripts/setup-bsp.py
@@ -149,7 +149,7 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     bsp_dir = os.path.join(bsp_root,"hardware",bsp)
     bsp_qsf_dir = os.path.join(bsp_dir, 'build')
 
-    print("asp_dir is %s\n" % asp_dir)
+    print("bsp_dir is %s\n" % bsp_dir)
     
     # copy the FIM FME information text files
     copy_glob(os.path.join(deliverable_hwlib_dir, 'fme*.txt'), bsp_qsf_dir, verbose)

--- a/n6001/scripts/setup-bsp.py
+++ b/n6001/scripts/setup-bsp.py
@@ -152,8 +152,8 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     print("bsp_qsf_dir is %s\n" % bsp_qsf_dir)
     
     #preserve the pr-build-template folder
-    delete_and_mkdir(os.path.join(bsp_dir, '../../pr_build_template'))
-    copy_glob(deliverable_dir, os.path.join(bsp_dir, '../../'),verbose)
+    delete_and_mkdir(os.path.join(bsp_dir, 'pr_build_template'))
+    copy_glob(deliverable_dir, os.path.join(bsp_dir, 'pr_build_template'),verbose)
 
     # copy the FIM FME information text files
     copy_glob(os.path.join(deliverable_hwlib_dir, 'fme*.txt'), bsp_qsf_dir, verbose)
@@ -179,7 +179,7 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     cmd_afu_synth_setup_filelist = ("--sources " + filelist_path)
     cmd_afu_synth_setup_lib_arb = ("--lib " + deliverable_hwlib_dir)
     cmd_afu_synth_setup_force_arg = "--force"
-    cmd_afu_synth_setup_platform_dst = os.path.join(bsp_dir,'pim')
+    cmd_afu_synth_setup_platform_dst = os.path.join(bsp_dir,'fim_platform')
     full_afu_synth_setup_cmd = (cmd_afu_synth_setup_opae_PATH_update + " " +
                                 cmd_afu_synth_setup_opae_platform_db_path + " " +
                                 cmd_afu_synth_setup_script + " " +
@@ -190,17 +190,22 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     print ("full afu_synth_setup cmd is %s" % full_afu_synth_setup_cmd)
     run_cmd(full_afu_synth_setup_cmd)
 
-    #copy/move the pim folder into build/ to keep it common
-    src_platform_dir = os.path.join(bsp_dir, 'pim')
-    src = os.path.join(src_platform_dir,'*')
-    dst = os.path.join(bsp_dir)
-    #print("Ran the afu-synth-setup cmd; now use copy_glob to move/copy it to the proper place")
-    #print ("src is %s" % src)
-    #print ("dst is %s" % dst)
-
-    copy_glob(src, dst, verbose)
-    shutil.rmtree(src_platform_dir, ignore_errors=True)
-
+    #find the Quartus-build folder expected by the FIM
+    #use syn_top for now, but it might change depending on FIM board/variant/etc
+    QUARTUS_SYN_DIR=get_dir_path("syn_top",bsp_dir)
+    #symlink the contents of bsp_dir/build into syn_top
+    os.symlink(bsp_qsf_dir,QUARTUS_SYN_DIR)
+    #symlink the ofs_top.qpf and ofs_pr_afu.qsf file to bsp_dir
+    os.symlink(QUARTUS_SYN_DIR/ofs_pr_afu.qsf,bsp_dir/ofs_pr_afu.qsf)
+    os.symlink(QUARTUS_SYN_DIR/ofs_pr_afu.qsf,bsp_dir/ofs_top.qpf)
+    
+    
+    
+    print("in setup-bsp.py, just finished afu-synth-setup")
+    sys.exit(-1)
+    
+    
+    
     #move the release directory's syn_top files to hardware/<target>/build/
     dst_build_path=bsp_qsf_dir
     syn_top_dir_name="syn_top"

--- a/n6001/scripts/setup-bsp.py
+++ b/n6001/scripts/setup-bsp.py
@@ -149,12 +149,8 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     bsp_dir = os.path.join(bsp_root,"hardware",bsp)
     bsp_qsf_dir = os.path.join(bsp_dir, 'build')
 
-    print("bsp_qsf_dir is %s\n" % bsp_qsf_dir)
+    print("asp_dir is %s\n" % asp_dir)
     
-    #preserve the pr-build-template folder
-    delete_and_mkdir(os.path.join(bsp_dir, 'pr_build_template'))
-    copy_glob(deliverable_dir, os.path.join(bsp_dir, 'pr_build_template'),verbose)
-
     # copy the FIM FME information text files
     copy_glob(os.path.join(deliverable_hwlib_dir, 'fme*.txt'), bsp_qsf_dir, verbose)
     
@@ -193,94 +189,36 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     #find the Quartus-build folder expected by the FIM
     #use syn_top for now, but it might change depending on FIM board/variant/etc
     QUARTUS_SYN_DIR=get_dir_path("syn_top",bsp_dir)
+    ASP_BASE_DIR_ABS=bsp_dir
+    
+    QUARTUS_BUILD_DIR_RELATIVE_TO_ASP_BUILD_DIR=os.path.relpath(QUARTUS_SYN_DIR,bsp_qsf_dir)
+    #print("QUARTUS_BUILD_DIR_RELATIVE_TO_ASP_BUILD_DIR %s" % (QUARTUS_BUILD_DIR_RELATIVE_TO_ASP_BUILD_DIR) )
+    
+    QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR=os.path.relpath(QUARTUS_SYN_DIR,bsp_dir)
+    #print("QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR %s" % (QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR) )
+    
+    ASP_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR=os.path.relpath(bsp_qsf_dir,QUARTUS_SYN_DIR)
+    #print("ASP_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR %s" % (ASP_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR) )
+    
+    KERNEL_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR=os.path.relpath(bsp_dir,QUARTUS_SYN_DIR)
+    #print("KERNEL_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR %s" % (KERNEL_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR) )
+    
     #symlink the contents of bsp_dir/build into syn_top
-    os.symlink(bsp_qsf_dir,QUARTUS_SYN_DIR)
+    BSP_BUILD_DIR_FILES=os.path.join(bsp_qsf_dir, '*')
+    #symlink_glob(BSP_BUILD_DIR_FILES,QUARTUS_SYN_DIR)
+    ASP_BUILD_DIR_SYMLINK_CMD="cd " + QUARTUS_SYN_DIR + " && ln -s " + ASP_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR + "/* ."
+    #ASP_BUILD_DIR_SYMLINK_CMD="ln -s " + ASP_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR + "/* " + QUARTUS_SYN_DIR + "/"
+    run_cmd(ASP_BUILD_DIR_SYMLINK_CMD)
+    
     #symlink the ofs_top.qpf and ofs_pr_afu.qsf file to bsp_dir
-    os.symlink(QUARTUS_SYN_DIR/ofs_pr_afu.qsf,bsp_dir/ofs_pr_afu.qsf)
-    os.symlink(QUARTUS_SYN_DIR/ofs_pr_afu.qsf,bsp_dir/ofs_top.qpf)
-    
-    
-    
-    print("in setup-bsp.py, just finished afu-synth-setup")
-    sys.exit(-1)
-    
-    
-    
-    #move the release directory's syn_top files to hardware/<target>/build/
-    dst_build_path=bsp_qsf_dir
-    syn_top_dir_name="syn_top"
-    src_syn_top_path=get_dir_path(syn_top_dir_name,bsp_qsf_dir)
-    src_syn_top_files=os.path.join(src_syn_top_path, '*')
-    #print("Moving the contents of syn_top from %s to %s " % (src_syn_top_files, dst_build_path) )
-    copy_glob(src_syn_top_files,dst_build_path)
-    #print("done copying the contents of syn_top into build/")
-    shutil.rmtree(src_syn_top_path, ignore_errors=True)
-    
-    # create quartus project revision for opencl kernel qsf
-    kernel_qsf_path = os.path.join(bsp_dir, 'afu_opencl_kernel.qsf')
-    #print ("kernel_qsf_path is %s\n" % kernel_qsf_path)
+    rm_glob(os.path.join(bsp_dir, 'ofs_pr_afu.qsf'))
+    OFS_PR_AFU_QSF_SYMLINK_CMD="cd " + bsp_dir + " && ln -s " + QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR + "/ofs_pr_afu.qsf ."
+    run_cmd(OFS_PR_AFU_QSF_SYMLINK_CMD)
 
-    ofs_pr_afu_qsf_file=os.path.join(bsp_qsf_dir, 'ofs_pr_afu.qsf')
-    #print ("copy %s ofs_pr_afu_qsf_file to %s\n" % (bsp_qsf_dir, kernel_qsf_path))
-    shutil.copy2(ofs_pr_afu_qsf_file, kernel_qsf_path)
-
-    update_qsf_settings_for_opencl_kernel_qsf(kernel_qsf_path)
-    #print ("update qsf setting for opencl-kernel-qsf")
-
-    orig_qpf_file=os.path.join(bsp_qsf_dir, 'ofs_top.qpf')
-    ocl_qpf_file=os.path.join(bsp_dir, 'ofs_top.qpf')
-    #print ("copy %s  to %s" % (orig_qpf_file, ocl_qpf_file))
-    shutil.copy2(orig_qpf_file, ocl_qpf_file)
-    #print ("update qpf project for opencl flow of %s \n" % ocl_qpf_file)
-    update_qpf_project_for_opencl_flow(ocl_qpf_file)
-
-    # update quartus project files for opencl
-    quartus_qpf_file=orig_qpf_file
-    #print ("update qpf project for afu %s\n" % quartus_qpf_file)
-    update_qpf_project_for_afu(quartus_qpf_file)
+    rm_glob(os.path.join(bsp_dir, 'ofs_top.qpf'))
+    OFS_TOP_QPF_SYMLINK_CMD="cd " + bsp_dir + " && ln -s " + QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR + "/ofs_top.qpf ."
+    run_cmd(OFS_TOP_QPF_SYMLINK_CMD)
     
-    #print ("update qsf settings for opencl afu %s \n" % ofs_pr_afu_qsf_file)
-    update_qsf_settings_for_opencl_afu(ofs_pr_afu_qsf_file)
-
-    #rename the ofs_pr_afu_qsf_file file to afu_flat.qsf. Up to this point we were using the ofs_pr_afu_qsf_file file from the platform build, now we need to move forward with appropriate OpenCL/HPR-naming
-    afu_flat_qsf_path=os.path.join(bsp_qsf_dir, 'afu_flat.qsf')
-    shutil.move(ofs_pr_afu_qsf_file,afu_flat_qsf_path)
-    
-    #write some stuff into afu_flat.qsf - this is to replace some lines in ofs_pr_afu_sources.tcl where the paths aren't correct
-    #with open(afu_flat_qsf_path, 'a') as f:
-    #    f.write('set_global_assignment -name SEARCH_PATH "./platform"\n')
-    #    f.write('set_global_assignment -name SOURCE_TCL_SCRIPT_FILE "./platform/ofs_plat_if/par/ofs_plat_if_addenda.qsf"\n')
-    #    # Map FIM interfaces to the PIM
-    #    f.write('set_global_assignment -name SYSTEMVERILOG_FILE "./src/port_gasket/agilex/afu_main_pim/afu_main.sv"\n')
-        
-    #remove the hw folder; it isn't needed
-    rel_template_hw_folder_path=os.path.join(bsp_qsf_dir, '../hw')
-    shutil.rmtree(rel_template_hw_folder_path, ignore_errors=True)
-    
-    #remove the paths and files listed in the ofs_pr_afu_sources.tcl file
-    ofs_pr_afu_source_tcl_file=os.path.join(bsp_qsf_dir, 'ofs_pr_afu_sources.tcl')
-    #this still needs to be done in order to eliminate Quartus warnings
-    replace_text_in_file(ofs_pr_afu_source_tcl_file, '../../', '$::env(BUILD_ROOT_REL)/')
-    replace_lines_in_file(afu_flat_qsf_path, 'set_global_assignment -name SOURCE_TCL_SCRIPT_FILE ../setup/suppress_warning.tcl', '#set_global_assignment -name SOURCE_TCL_SCRIPT_FILE ../setup/suppress_warning.tcl')
-    
-    #update the build_env_db.txt file with the appropriate BUILD_ROOT_REL path
-    build_env_db_path=os.path.join(bsp_qsf_dir, 'build_env_db.txt')
-    remove_lines_in_file(build_env_db_path, 'BUILD_ROOT_REL=')
-    with open(build_env_db_path, 'a') as f:
-        f.write('BUILD_ROOT_REL=../build')
-    #move the syn/*/setup/ folder
-    config_env_file_path=get_file_path("config_env.tcl", bsp_qsf_dir)
-    copy_glob(config_env_file_path,bsp_qsf_dir)
-    
-    replace_lines_in_file(afu_flat_qsf_path, 'set_global_assignment -name SOURCE_TCL_SCRIPT_FILE ../setup/config_env.tcl', 'set_global_assignment -name SOURCE_TCL_SCRIPT_FILE ./config_env.tcl')
-    
-    #remove user/kernel-clock constraints from ofs_top.out.sdc - use the constraints from user_clk.sdc
-    FIM_sdc_file=os.path.join(bsp_qsf_dir, 'ofs_top.out.sdc')
-    remove_lines_in_file(FIM_sdc_file,"create_generated_clock -name {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0")
-    
-    # create manifest
-    create_manifest(bsp_dir)
-
 
 # create a file manifest for use in later copy-steps
 def create_manifest(dst_dir):

--- a/n6001/scripts/setup-bsp.py
+++ b/n6001/scripts/setup-bsp.py
@@ -151,6 +151,10 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
 
     print("bsp_dir is %s\n" % bsp_dir)
     
+    #preserve the pr-build-template folder
+    delete_and_mkdir(os.path.join(bsp_dir, '../../pr_build_template'))
+    copy_glob(deliverable_dir, os.path.join(bsp_dir, '../../'),verbose)
+    
     # copy the FIM FME information text files
     copy_glob(os.path.join(deliverable_hwlib_dir, 'fme*.txt'), bsp_qsf_dir, verbose)
     

--- a/n6001/scripts/setup-bsp.py
+++ b/n6001/scripts/setup-bsp.py
@@ -213,9 +213,7 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     
     #symlink the contents of bsp_dir/build into syn_top
     BSP_BUILD_DIR_FILES=os.path.join(bsp_qsf_dir, '*')
-    #symlink_glob(BSP_BUILD_DIR_FILES,QUARTUS_SYN_DIR)
     ASP_BUILD_DIR_SYMLINK_CMD="cd " + QUARTUS_SYN_DIR + " && ln -s " + ASP_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR + "/* ."
-    #ASP_BUILD_DIR_SYMLINK_CMD="ln -s " + ASP_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR + "/* " + QUARTUS_SYN_DIR + "/"
     run_cmd(ASP_BUILD_DIR_SYMLINK_CMD)
     
     #symlink the ofs_top.qpf and ofs_pr_afu.qsf file to bsp_dir

--- a/n6001/scripts/setup-bsp.py
+++ b/n6001/scripts/setup-bsp.py
@@ -196,16 +196,20 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     ASP_BASE_DIR_ABS=bsp_dir
     
     QUARTUS_BUILD_DIR_RELATIVE_TO_ASP_BUILD_DIR=os.path.relpath(QUARTUS_SYN_DIR,bsp_qsf_dir)
-    #print("QUARTUS_BUILD_DIR_RELATIVE_TO_ASP_BUILD_DIR %s" % (QUARTUS_BUILD_DIR_RELATIVE_TO_ASP_BUILD_DIR) )
+    if verbose:
+        print("QUARTUS_BUILD_DIR_RELATIVE_TO_ASP_BUILD_DIR %s" % (QUARTUS_BUILD_DIR_RELATIVE_TO_ASP_BUILD_DIR) )
     
     QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR=os.path.relpath(QUARTUS_SYN_DIR,bsp_dir)
-    #print("QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR %s" % (QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR) )
+    if verbose:
+        print("QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR %s" % (QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR) )
     
     ASP_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR=os.path.relpath(bsp_qsf_dir,QUARTUS_SYN_DIR)
-    #print("ASP_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR %s" % (ASP_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR) )
+    if verbose:
+        print("ASP_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR %s" % (ASP_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR) )
     
     KERNEL_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR=os.path.relpath(bsp_dir,QUARTUS_SYN_DIR)
-    #print("KERNEL_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR %s" % (KERNEL_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR) )
+    if verbose:
+        print("KERNEL_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR %s" % (KERNEL_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR) )
     
     #symlink the contents of bsp_dir/build into syn_top
     BSP_BUILD_DIR_FILES=os.path.join(bsp_qsf_dir, '*')
@@ -222,7 +226,7 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     rm_glob(os.path.join(bsp_dir, 'ofs_top.qpf'))
     OFS_TOP_QPF_SYMLINK_CMD="cd " + bsp_dir + " && ln -s " + QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR + "/ofs_top.qpf ."
     run_cmd(OFS_TOP_QPF_SYMLINK_CMD)
-    
+
 
 # create a file manifest for use in later copy-steps
 def create_manifest(dst_dir):


### PR DESCRIPTION
Due to some recent changes in the FIM repo (additional hierarchy of board/{target}/ to the syn/syn_top path broke the ASP setup and build flows. This commit should clean it up and be more adaptable in the future.
OneAPI kernel compilation still occurs at the hardware/{variant}/ location, while the Quartus build now occurs in {tmp|hardware}/{variant}/fim_platform/build/syn/board/{FIM variant}/syn_top.