### PR TITLE
Change setup_permissions.sh to call uncalled function

### DIFF
--- a/d5005/linux64/libexec/setup_permissions.sh
+++ b/d5005/linux64/libexec/setup_permissions.sh
@@ -108,11 +108,6 @@ EOF
   sudo sh -c "echo $NUM_HUGE_PAGES > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages"
 }
 
-
-set_memlock_limits
-set_dev_permission
-set_hugepages
-
 ################################################################################
 # Set aocl initialize permissions
 #
@@ -123,5 +118,12 @@ set_devuio_permissions()
   echo "Setting access permisions of /dev/uio to 666"
   sudo chmod 666 /dev/uio*
 }
+
+
+set_memlock_limits
+set_dev_permission
+set_hugepages
+set_devuio_permissions
+
 
 echo "Finished setup_permissions.sh script. All configuration settings are persistent."

--- a/n6001/linux64/libexec/setup_permissions.sh
+++ b/n6001/linux64/libexec/setup_permissions.sh
@@ -108,11 +108,6 @@ EOF
   sudo sh -c "echo $NUM_HUGE_PAGES > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages"
 }
 
-
-set_memlock_limits
-set_dev_permission
-set_hugepages
-
 ################################################################################
 # Set aocl initialize permissions
 #
@@ -123,5 +118,11 @@ set_devuio_permissions()
   echo "Setting access permisions of /dev/uio to 666"
   sudo chmod 666 /dev/uio*
 }
+
+set_memlock_limits
+set_dev_permission
+set_hugepages
+set_devuio_permissions
+
 
 echo "Finished setup_permissions.sh script. All configuration settings are persistent."


### PR DESCRIPTION
Resolves https://hsdes.intel.com/appstore/article/#/14018513582

The function in setup_permissions.sh to set the correct read and write permissions for /dev/uio* was never actually called, causing an error when trying to read from /dev/uio*.