### PR TITLE
N6001: Update create-tarball script to handle symlinks

### DIFF
--- a/n6001/scripts/create-tarball.sh
+++ b/n6001/scripts/create-tarball.sh
@@ -32,5 +32,15 @@ for i in "${!bsp_files[@]}"; do
   fi
 done
 
-tar --transform='s,^,oneapi-asp-n6001/,' --create --gzip \
-    --file="$BSP_ROOT/oneapi-asp-n6001.tar.gz" --owner=0 --group=0  "${bsp_files[@]}"
+if [ -d "$BSP_ROOT/oneapi-asp-n6001" ]; then
+    echo "$BSP_ROOT/oneapi-asp-n6001 exists; Removing it first"
+    rm -rf $BSP_ROOT/oneapi-asp-n6001
+fi
+
+mkdir $BSP_ROOT/oneapi-asp-n6001
+
+cp -rf "${bsp_files[@]}" $BSP_ROOT/oneapi-asp-n6001/
+
+tar czf oneapi-asp-n6001.tar.gz --owner=0 --group=0 --no-same-owner --no-same-permissions oneapi-asp-n6001
+
+rm -rf "$BSP_ROOT/oneapi-asp-n6001"


### PR DESCRIPTION
The original script would prepend oneapi-asp-b6001/ to the symlink paths, which would make them unusable later. This change simplifies the tar process and looks to work better (symlinks at kernel-build location and Quartus-build location look good).