### PR TITLE
bmc missing , aocl diagnose temperature reporting fix 

### DIFF
--- a/common/source/host/mmd_device.cpp
+++ b/common/source/host/mmd_device.cpp
@@ -971,7 +971,6 @@ float Device::get_temperature() {
       DEBUG_LOG("DEBUG LOG : Error reading temperature monitor from BMC :");
       DEBUG_LOG(" %s \n",fpgaErrStr(res));
     }
-    fpgaDestroyObject(&obj);
     temp = -999;
     return temp;
   }


### PR DESCRIPTION
If BMC is missing we saw bug where code crashes because we try to destroy object which is never created because of missing BMC in system.
Fixed the bug , tested on f dev kit in SJ minicloud