### PR TITLE
N6001: remove abs path from setup_bsp

### DIFF
--- a/fseries_dk/scripts/setup-bsp.py
+++ b/fseries_dk/scripts/setup-bsp.py
@@ -175,12 +175,13 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     else:
         cmd_afu_synth_setup_opae_platform_db_path = ""
     cmd_afu_synth_setup_script = "${LIBOPAE_C_ROOT}/bin/afu_synth_setup"
-    filelist_path = os.path.join(bsp_qsf_dir, "filelist.txt")
+    filelist_path = "filelist.txt"
     cmd_afu_synth_setup_filelist = ("--sources " + filelist_path)
     cmd_afu_synth_setup_lib_arb = ("--lib " + deliverable_hwlib_dir)
     cmd_afu_synth_setup_force_arg = "--force"
     cmd_afu_synth_setup_platform_dst = os.path.join(bsp_dir,'fim_platform')
-    full_afu_synth_setup_cmd = (cmd_afu_synth_setup_opae_PATH_update + " " +
+    full_afu_synth_setup_cmd = ("cd " + bsp_qsf_dir + " && " +  
+                                cmd_afu_synth_setup_opae_PATH_update + " " +
                                 cmd_afu_synth_setup_opae_platform_db_path + " " +
                                 cmd_afu_synth_setup_script + " " +
                                 cmd_afu_synth_setup_filelist + " " +

--- a/n6001/scripts/setup-bsp.py
+++ b/n6001/scripts/setup-bsp.py
@@ -175,12 +175,13 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     else:
         cmd_afu_synth_setup_opae_platform_db_path = ""
     cmd_afu_synth_setup_script = "${LIBOPAE_C_ROOT}/bin/afu_synth_setup"
-    filelist_path = os.path.join(bsp_qsf_dir, "filelist.txt")
+    filelist_path = "filelist.txt"
     cmd_afu_synth_setup_filelist = ("--sources " + filelist_path)
     cmd_afu_synth_setup_lib_arb = ("--lib " + deliverable_hwlib_dir)
     cmd_afu_synth_setup_force_arg = "--force"
     cmd_afu_synth_setup_platform_dst = os.path.join(bsp_dir,'fim_platform')
-    full_afu_synth_setup_cmd = (cmd_afu_synth_setup_opae_PATH_update + " " +
+    full_afu_synth_setup_cmd = ("cd " + bsp_qsf_dir + " && " +  
+                                cmd_afu_synth_setup_opae_PATH_update + " " +
                                 cmd_afu_synth_setup_opae_platform_db_path + " " +
                                 cmd_afu_synth_setup_script + " " +
                                 cmd_afu_synth_setup_filelist + " " +


### PR DESCRIPTION
The afu-synth-setup command in setup_bsp was passed an absolute path for filelist.txt. This absolute path was embedded in the output of afu-synth-setup, which makes the files not portable. This change removes that absolute path.