### PR TITLE
Clean up PYTHONPATH and packager handling

### DIFF
--- a/d5005/hardware/ofs_d5005/build/scripts/run.sh
+++ b/d5005/hardware/ofs_d5005/build/scripts/run.sh
@@ -44,7 +44,8 @@ else
   if [ -f ./tools/packager ]; then
     chmod +x ./tools/packager
     PACKAGER_BIN=$(readlink -f ./tools/packager)
-    PYTHONPATH="$OFS_ASP_ROOT/build/opae/install/lib/python3.8/site-packages"
+    PYTHONPATH=`find $OFS_ASP_ROOT -path *install*site-packages`
+    echo "PYTHONPATH is $PYTHONPATH"
   else
     echo "Error cannot find BSP copy of packager"
     exit 1

--- a/d5005/hardware/ofs_d5005_usm/build/scripts/run.sh
+++ b/d5005/hardware/ofs_d5005_usm/build/scripts/run.sh
@@ -44,7 +44,8 @@ else
   if [ -f ./tools/packager ]; then
     chmod +x ./tools/packager
     PACKAGER_BIN=$(readlink -f ./tools/packager)
-    PYTHONPATH="$OFS_ASP_ROOT/build/opae/install/lib/python3.8/site-packages"
+    PYTHONPATH=`find $OFS_ASP_ROOT -path *install*site-packages`
+    echo "PYTHONPATH is $PYTHONPATH"
   else
     echo "Error cannot find BSP copy of packager"
     exit 1

--- a/n6001/hardware/ofs_n6001/build/scripts/run.sh
+++ b/n6001/hardware/ofs_n6001/build/scripts/run.sh
@@ -50,7 +50,8 @@ else
   if [ -f ./tools/packager ]; then
     chmod +x ./tools/packager
     PACKAGER_BIN=$(readlink -f ./tools/packager)
-    PYTHONPATH="$OFS_ASP_ROOT/build/opae/install/lib/python3.8/site-packages"
+    PYTHONPATH=`find $OFS_ASP_ROOT -path *install*site-packages`
+    echo "PYTHONPATH is $PYTHONPATH"
   else
     echo "Error cannot find BSP copy of packager"
     exit 1

--- a/n6001/hardware/ofs_n6001_iopipes/build/scripts/run.sh
+++ b/n6001/hardware/ofs_n6001_iopipes/build/scripts/run.sh
@@ -50,7 +50,8 @@ else
   if [ -f ./tools/packager ]; then
     chmod +x ./tools/packager
     PACKAGER_BIN=$(readlink -f ./tools/packager)
-    PYTHONPATH="$OFS_ASP_ROOT/build/opae/install/lib/python3.8/site-packages"
+    PYTHONPATH=`find $OFS_ASP_ROOT -path *install*site-packages`
+    echo "PYTHONPATH is $PYTHONPATH"
   else
     echo "Error cannot find BSP copy of packager"
     exit 1

--- a/n6001/hardware/ofs_n6001_usm/build/scripts/run.sh
+++ b/n6001/hardware/ofs_n6001_usm/build/scripts/run.sh
@@ -50,7 +50,8 @@ else
   if [ -f ./tools/packager ]; then
     chmod +x ./tools/packager
     PACKAGER_BIN=$(readlink -f ./tools/packager)
-    PYTHONPATH="$OFS_ASP_ROOT/build/opae/install/lib/python3.8/site-packages"
+    PYTHONPATH=`find $OFS_ASP_ROOT -path *install*site-packages`
+    echo "PYTHONPATH is $PYTHONPATH"
   else
     echo "Error cannot find BSP copy of packager"
     exit 1

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/scripts/run.sh
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/scripts/run.sh
@@ -50,7 +50,8 @@ else
   if [ -f ./tools/packager ]; then
     chmod +x ./tools/packager
     PACKAGER_BIN=$(readlink -f ./tools/packager)
-    PYTHONPATH="$OFS_ASP_ROOT/build/opae/install/lib/python3.8/site-packages"
+    PYTHONPATH=`find $OFS_ASP_ROOT -path *install*site-packages`
+    echo "PYTHONPATH is $PYTHONPATH"
   else
     echo "Error cannot find BSP copy of packager"
     exit 1


### PR DESCRIPTION
We previously hard-coded the path to the packager, which included a Python version. This change will try to find the installation and set PYTHONPATH appropriately.