### PR TITLE
Fix the adjust-plls script to accept devices with more than 1M ALUTs

### DIFF
--- a/d5005/hardware/ofs_d5005/build/scripts/adjust_plls.tcl
+++ b/d5005/hardware/ofs_d5005/build/scripts/adjust_plls.tcl
@@ -325,8 +325,8 @@ while { $timing_clean == 0 && $timing_loop_cnt <= $max_num_loops} {
     
     post_message "Generating acl_quartus_report.txt"
     set outfile   [open "acl_quartus_report.txt" w]
-    set aluts_l   [regsub "," [get_fitter_resource_usage -alut] "" ]
-    if {[catch {set aluts_m [regsub "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
+    set aluts_l   [regsub -all "," [get_fitter_resource_usage -alut] "" ]
+    if {[catch {set aluts_m [regsub -all "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
         set aluts_m 0
     }
     if { [string length $aluts_m] < 1 || ! [string is integer $aluts_m] } {

--- a/d5005/hardware/ofs_d5005_usm/build/scripts/adjust_plls.tcl
+++ b/d5005/hardware/ofs_d5005_usm/build/scripts/adjust_plls.tcl
@@ -325,8 +325,8 @@ while { $timing_clean == 0 && $timing_loop_cnt <= $max_num_loops} {
     
     post_message "Generating acl_quartus_report.txt"
     set outfile   [open "acl_quartus_report.txt" w]
-    set aluts_l   [regsub "," [get_fitter_resource_usage -alut] "" ]
-    if {[catch {set aluts_m [regsub "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
+    set aluts_l   [regsub -all "," [get_fitter_resource_usage -alut] "" ]
+    if {[catch {set aluts_m [regsub -all "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
         set aluts_m 0
     }
     if { [string length $aluts_m] < 1 || ! [string is integer $aluts_m] } {

--- a/n6001/hardware/ofs_n6001/build/scripts/adjust_plls.tcl
+++ b/n6001/hardware/ofs_n6001/build/scripts/adjust_plls.tcl
@@ -326,8 +326,8 @@ while { $timing_clean == 0 && $timing_loop_cnt <= $max_num_loops} {
     
     post_message "Generating acl_quartus_report.txt"
     set outfile   [open "acl_quartus_report.txt" w]
-    set aluts_l   [regsub "," [get_fitter_resource_usage -alut] "" ]
-    if {[catch {set aluts_m [regsub "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
+    set aluts_l   [regsub -all "," [get_fitter_resource_usage -alut] "" ]
+    if {[catch {set aluts_m [regsub -all "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
         set aluts_m 0
     }
     if { [string length $aluts_m] < 1 || ! [string is integer $aluts_m] } {

--- a/n6001/hardware/ofs_n6001_iopipes/build/scripts/adjust_plls.tcl
+++ b/n6001/hardware/ofs_n6001_iopipes/build/scripts/adjust_plls.tcl
@@ -326,8 +326,8 @@ while { $timing_clean == 0 && $timing_loop_cnt <= $max_num_loops} {
     
     post_message "Generating acl_quartus_report.txt"
     set outfile   [open "acl_quartus_report.txt" w]
-    set aluts_l   [regsub "," [get_fitter_resource_usage -alut] "" ]
-    if {[catch {set aluts_m [regsub "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
+    set aluts_l   [regsub -all "," [get_fitter_resource_usage -alut] "" ]
+    if {[catch {set aluts_m [regsub -all "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
         set aluts_m 0
     }
     if { [string length $aluts_m] < 1 || ! [string is integer $aluts_m] } {

--- a/n6001/hardware/ofs_n6001_usm/build/scripts/adjust_plls.tcl
+++ b/n6001/hardware/ofs_n6001_usm/build/scripts/adjust_plls.tcl
@@ -326,8 +326,8 @@ while { $timing_clean == 0 && $timing_loop_cnt <= $max_num_loops} {
     
     post_message "Generating acl_quartus_report.txt"
     set outfile   [open "acl_quartus_report.txt" w]
-    set aluts_l   [regsub "," [get_fitter_resource_usage -alut] "" ]
-    if {[catch {set aluts_m [regsub "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
+    set aluts_l   [regsub -all "," [get_fitter_resource_usage -alut] "" ]
+    if {[catch {set aluts_m [regsub -all "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
         set aluts_m 0
     }
     if { [string length $aluts_m] < 1 || ! [string is integer $aluts_m] } {

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/scripts/adjust_plls.tcl
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/scripts/adjust_plls.tcl
@@ -326,8 +326,8 @@ while { $timing_clean == 0 && $timing_loop_cnt <= $max_num_loops} {
     
     post_message "Generating acl_quartus_report.txt"
     set outfile   [open "acl_quartus_report.txt" w]
-    set aluts_l   [regsub "," [get_fitter_resource_usage -alut] "" ]
-    if {[catch {set aluts_m [regsub "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
+    set aluts_l   [regsub -all "," [get_fitter_resource_usage -alut] "" ]
+    if {[catch {set aluts_m [regsub -all "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
         set aluts_m 0
     }
     if { [string length $aluts_m] < 1 || ! [string is integer $aluts_m] } {


### PR DESCRIPTION
This was a fix suggested by SSE for devices with more than 1M ALUTs. The tcl script does a bit of manipulation of the ALUT numbers which requires them to not have commas, so this change removes all commas from the string returned from get_fitter_resource_usage. N6001 compilation completed without issue (granted, it doesn't have 1M+ ALUTs but at least it didn't break the current build).