### PR TITLE
Fix host/agent terminology in board_spec.xml

### DIFF
--- a/d5005/hardware/ofs_d5005/board_spec.xml
+++ b/d5005/hardware/ofs_d5005/board_spec.xml
@@ -23,10 +23,10 @@
   <!-- DDR4-2400 -->
   <!-- max-bandwidth: (interface freq) * 2 (bits per clock) * (num interfaces) * (data bytes per interface) -->
   <global_mem name="DDR" max_bandwidth="76800" interleaved_bytes="4096" config_addr="0x018">
-    <interface name="board" port="kernel_ddr4a" type="slave" width="512" maxburst="16" address="0x000000000" size="0x200000000" latency="1500" waitrequest_allowance="6"/>
-    <interface name="board" port="kernel_ddr4b" type="slave" width="512" maxburst="16" address="0x200000000" size="0x200000000" latency="1500" waitrequest_allowance="6"/>
-    <interface name="board" port="kernel_ddr4c" type="slave" width="512" maxburst="16" address="0x400000000" size="0x200000000" latency="1500" waitrequest_allowance="6"/>
-    <interface name="board" port="kernel_ddr4d" type="slave" width="512" maxburst="16" address="0x600000000" size="0x200000000" latency="1500" waitrequest_allowance="6"/>
+    <interface name="board" port="kernel_ddr4a" type="agent" width="512" maxburst="16" address="0x000000000" size="0x200000000" latency="1500" waitrequest_allowance="6"/>
+    <interface name="board" port="kernel_ddr4b" type="agent" width="512" maxburst="16" address="0x200000000" size="0x200000000" latency="1500" waitrequest_allowance="6"/>
+    <interface name="board" port="kernel_ddr4c" type="agent" width="512" maxburst="16" address="0x400000000" size="0x200000000" latency="1500" waitrequest_allowance="6"/>
+    <interface name="board" port="kernel_ddr4d" type="agent" width="512" maxburst="16" address="0x600000000" size="0x200000000" latency="1500" waitrequest_allowance="6"/>
   </global_mem>
     
   <host>
@@ -34,7 +34,7 @@
   </host>
 
   <interfaces>
-    <interface name="board" port="kernel_cra" type="master" width="64" misc="0" waitrequest_allowance="5"/>
+    <interface name="board" port="kernel_cra" type="host" width="64" misc="0" waitrequest_allowance="5"/>
     <interface name="board" port="kernel_irq" type="irq" width="1"/>
     <kernel_clk_reset clk="board.kernel_clk" clk2x="board.kernel_clk2x" reset="board.kernel_reset"/>
   </interfaces>

--- a/d5005/hardware/ofs_d5005_usm/board_spec.xml
+++ b/d5005/hardware/ofs_d5005_usm/board_spec.xml
@@ -22,16 +22,16 @@
   </device>
 
   <global_mem name="host" max_bandwidth="30000" interleaved_bytes="1024" config_addr="0x018" allocation_type="host, shared">
-    <interface name="board" port="kernel_mem" type="slave" width="512" maxburst="16" address="0x000000000" size="0x1000000000000" latency="1500" waitrequest_allowance="7"/>
+    <interface name="board" port="kernel_mem" type="agent" width="512" maxburst="16" address="0x000000000" size="0x1000000000000" latency="1500" waitrequest_allowance="7"/>
   </global_mem>
   
   <!-- DDR4-2400 -->
   <!-- max-bandwidth: (interface freq) * 2 (bits per clock) * (num interfaces) * (data bytes per interface) -->
   <global_mem name="device" max_bandwidth="76800" interleaved_bytes="4096" config_addr="0x018" allocation_type="device" default="1">
-    <interface name="board" port="kernel_ddr4a" type="slave" width="512" maxburst="16" address="0x1000000000000" size="0x200000000" latency="1500" waitrequest_allowance="6"/>
-    <interface name="board" port="kernel_ddr4b" type="slave" width="512" maxburst="16" address="0x1000200000000" size="0x200000000" latency="1500" waitrequest_allowance="6"/>
-    <interface name="board" port="kernel_ddr4c" type="slave" width="512" maxburst="16" address="0x1000400000000" size="0x200000000" latency="1500" waitrequest_allowance="6"/>
-    <interface name="board" port="kernel_ddr4d" type="slave" width="512" maxburst="16" address="0x1000600000000" size="0x200000000" latency="1500" waitrequest_allowance="6"/>
+    <interface name="board" port="kernel_ddr4a" type="agent" width="512" maxburst="16" address="0x1000000000000" size="0x200000000" latency="1500" waitrequest_allowance="6"/>
+    <interface name="board" port="kernel_ddr4b" type="agent" width="512" maxburst="16" address="0x1000200000000" size="0x200000000" latency="1500" waitrequest_allowance="6"/>
+    <interface name="board" port="kernel_ddr4c" type="agent" width="512" maxburst="16" address="0x1000400000000" size="0x200000000" latency="1500" waitrequest_allowance="6"/>
+    <interface name="board" port="kernel_ddr4d" type="agent" width="512" maxburst="16" address="0x1000600000000" size="0x200000000" latency="1500" waitrequest_allowance="6"/>
   </global_mem>
     
   <host>
@@ -39,7 +39,7 @@
   </host>
 
   <interfaces>
-    <interface name="board" port="kernel_cra" type="master" width="64" misc="0" waitrequest_allowance="5"/>
+    <interface name="board" port="kernel_cra" type="host" width="64" misc="0" waitrequest_allowance="5"/>
     <interface name="board" port="kernel_irq" type="irq" width="1"/>
     <kernel_clk_reset clk="board.kernel_clk" clk2x="board.kernel_clk2x" reset="board.kernel_reset"/>
   </interfaces>

--- a/n6001/hardware/ofs_n6001/board_spec.xml
+++ b/n6001/hardware/ofs_n6001/board_spec.xml
@@ -31,10 +31,10 @@
   <!-- DDR4-2400 -->
   <!-- max-bandwidth: (interface freq) * 2 (bits per clock) * (num interfaces) * (data bytes per interface) -->
   <global_mem name="DDR" max_bandwidth="76800" interleaved_bytes="4096" config_addr="0x018">
-    <interface name="board" port="kernel_ddr4a" type="slave" width="512" maxburst="16" address="0x000000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
-    <interface name="board" port="kernel_ddr4b" type="slave" width="512" maxburst="16" address="0x100000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
-    <interface name="board" port="kernel_ddr4c" type="slave" width="512" maxburst="16" address="0x200000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
-    <interface name="board" port="kernel_ddr4d" type="slave" width="512" maxburst="16" address="0x300000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
+    <interface name="board" port="kernel_ddr4a" type="agent" width="512" maxburst="16" address="0x000000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
+    <interface name="board" port="kernel_ddr4b" type="agent" width="512" maxburst="16" address="0x100000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
+    <interface name="board" port="kernel_ddr4c" type="agent" width="512" maxburst="16" address="0x200000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
+    <interface name="board" port="kernel_ddr4d" type="agent" width="512" maxburst="16" address="0x300000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
   </global_mem>
     
   <host>
@@ -42,7 +42,7 @@
   </host>
 
   <interfaces>
-    <interface name="board" port="kernel_cra" type="master" width="64" misc="0" waitrequest_allowance="5"/>
+    <interface name="board" port="kernel_cra" type="host" width="64" misc="0" waitrequest_allowance="5"/>
     <interface name="board" port="kernel_irq" type="irq" width="1"/>
     <kernel_clk_reset clk="board.kernel_clk" clk2x="board.kernel_clk2x" reset="board.kernel_reset"/>
   </interfaces>

--- a/n6001/hardware/ofs_n6001_iopipes/board_spec.xml
+++ b/n6001/hardware/ofs_n6001_iopipes/board_spec.xml
@@ -31,10 +31,10 @@
   <!-- DDR4-2400 -->
   <!-- max-bandwidth: (interface freq) * 2 (bits per clock) * (num interfaces) * (data bytes per interface) -->
   <global_mem name="DDR" max_bandwidth="76800" interleaved_bytes="4096" config_addr="0x018">
-    <interface name="board" port="kernel_ddr4a" type="slave" width="512" maxburst="16" address="0x000000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
-    <interface name="board" port="kernel_ddr4b" type="slave" width="512" maxburst="16" address="0x100000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
-    <interface name="board" port="kernel_ddr4c" type="slave" width="512" maxburst="16" address="0x200000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
-    <interface name="board" port="kernel_ddr4d" type="slave" width="512" maxburst="16" address="0x300000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
+    <interface name="board" port="kernel_ddr4a" type="agent" width="512" maxburst="16" address="0x000000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
+    <interface name="board" port="kernel_ddr4b" type="agent" width="512" maxburst="16" address="0x100000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
+    <interface name="board" port="kernel_ddr4c" type="agent" width="512" maxburst="16" address="0x200000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
+    <interface name="board" port="kernel_ddr4d" type="agent" width="512" maxburst="16" address="0x300000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
   </global_mem>
     
   <host>
@@ -42,7 +42,7 @@
   </host>
 
   <interfaces>
-    <interface name="board" port="kernel_cra" type="master" width="64" misc="0" waitrequest_allowance="5"/>
+    <interface name="board" port="kernel_cra" type="host" width="64" misc="0" waitrequest_allowance="5"/>
     <interface name="board" port="kernel_irq" type="irq" width="1"/>
     <kernel_clk_reset clk="board.kernel_clk" clk2x="board.kernel_clk2x" reset="board.kernel_reset"/>
   </interfaces>

--- a/n6001/hardware/ofs_n6001_usm/board_spec.xml
+++ b/n6001/hardware/ofs_n6001_usm/board_spec.xml
@@ -29,16 +29,16 @@
   </device>
 
   <global_mem name="host" max_bandwidth="30000" interleaved_bytes="1024" config_addr="0x018" allocation_type="host, shared">
-    <interface name="board" port="kernel_mem" type="slave" width="512" maxburst="16" address="0x000000000" size="0x1000000000000" latency="800" waitrequest_allowance="7"/>
+    <interface name="board" port="kernel_mem" type="agent" width="512" maxburst="16" address="0x000000000" size="0x1000000000000" latency="800" waitrequest_allowance="7"/>
   </global_mem>
   
   <!-- DDR4-2400 -->
   <!-- max-bandwidth: (interface freq) * 2 (bits per clock) * (num interfaces) * (data bytes per interface) -->
   <global_mem name="device" max_bandwidth="76800" interleaved_bytes="4096" config_addr="0x018" allocation_type="device" default="1">
-    <interface name="board" port="kernel_ddr4a" type="slave" width="512" maxburst="16" address="0x1000000000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
-    <interface name="board" port="kernel_ddr4b" type="slave" width="512" maxburst="16" address="0x1000100000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
-    <interface name="board" port="kernel_ddr4c" type="slave" width="512" maxburst="16" address="0x1000200000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
-    <interface name="board" port="kernel_ddr4d" type="slave" width="512" maxburst="16" address="0x1000300000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
+    <interface name="board" port="kernel_ddr4a" type="agent" width="512" maxburst="16" address="0x1000000000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
+    <interface name="board" port="kernel_ddr4b" type="agent" width="512" maxburst="16" address="0x1000100000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
+    <interface name="board" port="kernel_ddr4c" type="agent" width="512" maxburst="16" address="0x1000200000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
+    <interface name="board" port="kernel_ddr4d" type="agent" width="512" maxburst="16" address="0x1000300000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
   </global_mem>
     
   <host>
@@ -46,7 +46,7 @@
   </host>
 
   <interfaces>
-    <interface name="board" port="kernel_cra" type="master" width="64" misc="0" waitrequest_allowance="5"/>
+    <interface name="board" port="kernel_cra" type="host" width="64" misc="0" waitrequest_allowance="5"/>
     <interface name="board" port="kernel_irq" type="irq" width="1"/>
     <kernel_clk_reset clk="board.kernel_clk" clk2x="board.kernel_clk2x" reset="board.kernel_reset"/>
   </interfaces>

--- a/n6001/hardware/ofs_n6001_usm_iopipes/board_spec.xml
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/board_spec.xml
@@ -29,16 +29,16 @@
   </device>
 
   <global_mem name="host" max_bandwidth="30000" interleaved_bytes="1024" config_addr="0x018" allocation_type="host, shared">
-    <interface name="board" port="kernel_mem" type="slave" width="512" maxburst="16" address="0x000000000" size="0x1000000000000" latency="800" waitrequest_allowance="7"/>
+    <interface name="board" port="kernel_mem" type="agent" width="512" maxburst="16" address="0x000000000" size="0x1000000000000" latency="800" waitrequest_allowance="7"/>
   </global_mem>
   
   <!-- DDR4-2400 -->
   <!-- max-bandwidth: (interface freq) * 2 (bits per clock) * (num interfaces) * (data bytes per interface) -->
   <global_mem name="device" max_bandwidth="76800" interleaved_bytes="4096" config_addr="0x018" allocation_type="device" default="1">
-    <interface name="board" port="kernel_ddr4a" type="slave" width="512" maxburst="16" address="0x1000000000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
-    <interface name="board" port="kernel_ddr4b" type="slave" width="512" maxburst="16" address="0x1000100000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
-    <interface name="board" port="kernel_ddr4c" type="slave" width="512" maxburst="16" address="0x1000200000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
-    <interface name="board" port="kernel_ddr4d" type="slave" width="512" maxburst="16" address="0x1000300000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
+    <interface name="board" port="kernel_ddr4a" type="agent" width="512" maxburst="16" address="0x1000000000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
+    <interface name="board" port="kernel_ddr4b" type="agent" width="512" maxburst="16" address="0x1000100000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
+    <interface name="board" port="kernel_ddr4c" type="agent" width="512" maxburst="16" address="0x1000200000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
+    <interface name="board" port="kernel_ddr4d" type="agent" width="512" maxburst="16" address="0x1000300000000" size="0x100000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
   </global_mem>
     
   <host>
@@ -46,7 +46,7 @@
   </host>
 
   <interfaces>
-    <interface name="board" port="kernel_cra" type="master" width="64" misc="0" waitrequest_allowance="5"/>
+    <interface name="board" port="kernel_cra" type="host" width="64" misc="0" waitrequest_allowance="5"/>
     <interface name="board" port="kernel_irq" type="irq" width="1"/>
     <kernel_clk_reset clk="board.kernel_clk" clk2x="board.kernel_clk2x" reset="board.kernel_reset"/>
   </interfaces>


### PR DESCRIPTION
Validation: ofs_n6001 board_test build generated a .fpga file.