### PR TITLE
fseries-dk: adapt to FIM's kernel-clock hierarchy name change

### DIFF
--- a/fseries_dk/hardware/fseries_dk/build/opencl_bsp.sdc
+++ b/fseries_dk/hardware/fseries_dk/build/opencl_bsp.sdc
@@ -1,11 +1,11 @@
 #separate the PCIe/host, user/kernel, and DDR4-user clocks
 set_clock_groups -asynchronous  -group [get_clocks {sys_pll|iopll_0_clk_sys}] \
-                                -group [get_clocks {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
-                                                    afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
+                                -group [get_clocks {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
+                                                    afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
                                 -group [get_clocks {mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_0_core_usr_clk \
                                                     mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_1_core_usr_clk \
                                                     mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_2_core_usr_clk \
                                                     mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_3_core_usr_clk}]
 
 #false paths in the user_clock prescalar logic since it is locked-down during FIM-build
-set_false_path -from {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]} -to {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]}
+set_false_path -from {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]} -to {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]}

--- a/fseries_dk/hardware/fseries_dk/build/scripts/adjust_plls.tcl
+++ b/fseries_dk/hardware/fseries_dk/build/scripts/adjust_plls.tcl
@@ -9,9 +9,9 @@ package require ::quartus::flow
 
 # Definitions
 #normal/slow clock
-set k_clk_name "afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1"
+set k_clk_name "afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1"
 #double/fast clock
-set k_clk2x_name "afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0"
+set k_clk2x_name "afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0"
 set k_fmax -1
 set jitter_compensation 0.01
 set unused_clock_freq 10000
@@ -326,8 +326,8 @@ while { $timing_clean == 0 && $timing_loop_cnt <= $max_num_loops} {
     
     post_message "Generating acl_quartus_report.txt"
     set outfile   [open "acl_quartus_report.txt" w]
-    set aluts_l   [regsub "," [get_fitter_resource_usage -alut] "" ]
-    if {[catch {set aluts_m [regsub "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
+    set aluts_l   [regsub -all "," [get_fitter_resource_usage -alut] "" ]
+    if {[catch {set aluts_m [regsub -all "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
         set aluts_m 0
     }
     if { [string length $aluts_m] < 1 || ! [string is integer $aluts_m] } {
@@ -433,8 +433,8 @@ while { $timing_clean == 0 && $timing_loop_cnt <= $max_num_loops} {
     set sdcfile   [open "user_clock.sdc" w]
     puts $sdcfile "#updated user-clock.sdc assignments based on fmax from previous fit attempt."
     puts $sdcfile "puts \"Updated user-clock constraints based on fmax from previous fit attempt.\" "
-    puts $sdcfile "create_clock -name {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0} -period $period2 \[get_pins {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]}]"
-    puts $sdcfile "create_clock -name {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1} -period $period \[get_pins {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]}] "
+    puts $sdcfile "create_clock -name {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0} -period $period2 \[get_pins {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]}]"
+    puts $sdcfile "create_clock -name {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1} -period $period \[get_pins {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]}] "
     puts $sdcfile "$disable_mpw_sdccmd"
     close $sdcfile
     

--- a/fseries_dk/hardware/fseries_dk/build/user_clock.sdc
+++ b/fseries_dk/hardware/fseries_dk/build/user_clock.sdc
@@ -10,13 +10,13 @@
 #1.25ns 800mhz
 
 #remove existing constraints on the user clocks
-remove_clock afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0
-remove_clock afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]
-remove_clock afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1
-remove_clock afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]
+remove_clock afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0
+remove_clock afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]
+remove_clock afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1
+remove_clock afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]
 
 #kernel clk 1x / uClk_usrDiv2
-create_clock -name {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0} -period 1.5 [get_pins {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]}] 
+create_clock -name {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0} -period 1.5 [get_pins {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]}] 
 
 #kernel clk 2x / uClk_usr
-create_clock -name {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1} -period 1.5 [get_pins {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]}] 
+create_clock -name {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1} -period 1.5 [get_pins {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]}] 

--- a/fseries_dk/hardware/fseries_dk_iopipes/build/opencl_bsp.sdc
+++ b/fseries_dk/hardware/fseries_dk_iopipes/build/opencl_bsp.sdc
@@ -1,11 +1,11 @@
 #separate the PCIe/host, user/kernel, and DDR4-user clocks
 set_clock_groups -asynchronous  -group [get_clocks {sys_pll|iopll_0_clk_sys}] \
-                                -group [get_clocks {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
-                                                    afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
+                                -group [get_clocks {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
+                                                    afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
                                 -group [get_clocks {mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_0_core_usr_clk \
                                                     mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_1_core_usr_clk \
                                                     mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_2_core_usr_clk \
                                                     mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_3_core_usr_clk}]
 
 #false paths in the user_clock prescalar logic since it is locked-down during FIM-build
-set_false_path -from {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]} -to {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]}
+set_false_path -from {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]} -to {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]}

--- a/fseries_dk/hardware/fseries_dk_iopipes/build/scripts/adjust_plls.tcl
+++ b/fseries_dk/hardware/fseries_dk_iopipes/build/scripts/adjust_plls.tcl
@@ -9,9 +9,9 @@ package require ::quartus::flow
 
 # Definitions
 #normal/slow clock
-set k_clk_name "afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1"
+set k_clk_name "afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1"
 #double/fast clock
-set k_clk2x_name "afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0"
+set k_clk2x_name "afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0"
 set k_fmax -1
 set jitter_compensation 0.01
 set unused_clock_freq 10000
@@ -326,8 +326,8 @@ while { $timing_clean == 0 && $timing_loop_cnt <= $max_num_loops} {
     
     post_message "Generating acl_quartus_report.txt"
     set outfile   [open "acl_quartus_report.txt" w]
-    set aluts_l   [regsub "," [get_fitter_resource_usage -alut] "" ]
-    if {[catch {set aluts_m [regsub "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
+    set aluts_l   [regsub -all "," [get_fitter_resource_usage -alut] "" ]
+    if {[catch {set aluts_m [regsub -all "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
         set aluts_m 0
     }
     if { [string length $aluts_m] < 1 || ! [string is integer $aluts_m] } {
@@ -433,8 +433,8 @@ while { $timing_clean == 0 && $timing_loop_cnt <= $max_num_loops} {
     set sdcfile   [open "user_clock.sdc" w]
     puts $sdcfile "#updated user-clock.sdc assignments based on fmax from previous fit attempt."
     puts $sdcfile "puts \"Updated user-clock constraints based on fmax from previous fit attempt.\" "
-    puts $sdcfile "create_clock -name {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0} -period $period2 \[get_pins {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]}]"
-    puts $sdcfile "create_clock -name {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1} -period $period \[get_pins {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]}] "
+    puts $sdcfile "create_clock -name {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0} -period $period2 \[get_pins {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]}]"
+    puts $sdcfile "create_clock -name {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1} -period $period \[get_pins {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]}] "
     puts $sdcfile "$disable_mpw_sdccmd"
     close $sdcfile
     

--- a/fseries_dk/hardware/fseries_dk_iopipes/build/user_clock.sdc
+++ b/fseries_dk/hardware/fseries_dk_iopipes/build/user_clock.sdc
@@ -10,13 +10,13 @@
 #1.25ns 800mhz
 
 #remove existing constraints on the user clocks
-remove_clock afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0
-remove_clock afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]
-remove_clock afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1
-remove_clock afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]
+remove_clock afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0
+remove_clock afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]
+remove_clock afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1
+remove_clock afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]
 
 #kernel clk 1x / uClk_usrDiv2
-create_clock -name {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0} -period 1.5 [get_pins {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]}] 
+create_clock -name {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0} -period 1.5 [get_pins {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]}] 
 
 #kernel clk 2x / uClk_usr
-create_clock -name {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1} -period 1.5 [get_pins {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]}] 
+create_clock -name {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1} -period 1.5 [get_pins {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]}] 

--- a/fseries_dk/hardware/fseries_dk_usm/build/opencl_bsp.sdc
+++ b/fseries_dk/hardware/fseries_dk_usm/build/opencl_bsp.sdc
@@ -1,11 +1,11 @@
 #separate the PCIe/host, user/kernel, and DDR4-user clocks
 set_clock_groups -asynchronous  -group [get_clocks {sys_pll|iopll_0_clk_sys}] \
-                                -group [get_clocks {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
-                                                    afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
+                                -group [get_clocks {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
+                                                    afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
                                 -group [get_clocks {mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_0_core_usr_clk \
                                                     mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_1_core_usr_clk \
                                                     mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_2_core_usr_clk \
                                                     mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_3_core_usr_clk}]
 
 #false paths in the user_clock prescalar logic since it is locked-down during FIM-build
-set_false_path -from {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]} -to {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]}
+set_false_path -from {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]} -to {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]}

--- a/fseries_dk/hardware/fseries_dk_usm/build/scripts/adjust_plls.tcl
+++ b/fseries_dk/hardware/fseries_dk_usm/build/scripts/adjust_plls.tcl
@@ -9,9 +9,9 @@ package require ::quartus::flow
 
 # Definitions
 #normal/slow clock
-set k_clk_name "afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1"
+set k_clk_name "afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1"
 #double/fast clock
-set k_clk2x_name "afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0"
+set k_clk2x_name "afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0"
 set k_fmax -1
 set jitter_compensation 0.01
 set unused_clock_freq 10000
@@ -326,8 +326,8 @@ while { $timing_clean == 0 && $timing_loop_cnt <= $max_num_loops} {
     
     post_message "Generating acl_quartus_report.txt"
     set outfile   [open "acl_quartus_report.txt" w]
-    set aluts_l   [regsub "," [get_fitter_resource_usage -alut] "" ]
-    if {[catch {set aluts_m [regsub "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
+    set aluts_l   [regsub -all "," [get_fitter_resource_usage -alut] "" ]
+    if {[catch {set aluts_m [regsub -all "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
         set aluts_m 0
     }
     if { [string length $aluts_m] < 1 || ! [string is integer $aluts_m] } {
@@ -433,8 +433,8 @@ while { $timing_clean == 0 && $timing_loop_cnt <= $max_num_loops} {
     set sdcfile   [open "user_clock.sdc" w]
     puts $sdcfile "#updated user-clock.sdc assignments based on fmax from previous fit attempt."
     puts $sdcfile "puts \"Updated user-clock constraints based on fmax from previous fit attempt.\" "
-    puts $sdcfile "create_clock -name {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0} -period $period2 \[get_pins {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]}]"
-    puts $sdcfile "create_clock -name {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1} -period $period \[get_pins {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]}] "
+    puts $sdcfile "create_clock -name {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0} -period $period2 \[get_pins {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]}]"
+    puts $sdcfile "create_clock -name {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1} -period $period \[get_pins {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]}] "
     puts $sdcfile "$disable_mpw_sdccmd"
     close $sdcfile
     

--- a/fseries_dk/hardware/fseries_dk_usm/build/user_clock.sdc
+++ b/fseries_dk/hardware/fseries_dk_usm/build/user_clock.sdc
@@ -10,13 +10,13 @@
 #1.25ns 800mhz
 
 #remove existing constraints on the user clocks
-remove_clock afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0
-remove_clock afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]
-remove_clock afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1
-remove_clock afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]
+remove_clock afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0
+remove_clock afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]
+remove_clock afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1
+remove_clock afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]
 
 #kernel clk 1x / uClk_usrDiv2
-create_clock -name {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0} -period 1.5 [get_pins {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]}] 
+create_clock -name {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0} -period 1.5 [get_pins {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]}] 
 
 #kernel clk 2x / uClk_usr
-create_clock -name {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1} -period 1.5 [get_pins {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]}] 
+create_clock -name {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1} -period 1.5 [get_pins {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]}] 

--- a/fseries_dk/hardware/fseries_dk_usm_iopipes/build/opencl_bsp.sdc
+++ b/fseries_dk/hardware/fseries_dk_usm_iopipes/build/opencl_bsp.sdc
@@ -1,11 +1,11 @@
 #separate the PCIe/host, user/kernel, and DDR4-user clocks
 set_clock_groups -asynchronous  -group [get_clocks {sys_pll|iopll_0_clk_sys}] \
-                                -group [get_clocks {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
-                                                    afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
+                                -group [get_clocks {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
+                                                    afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
                                 -group [get_clocks {mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_0_core_usr_clk \
                                                     mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_1_core_usr_clk \
                                                     mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_2_core_usr_clk \
                                                     mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_3_core_usr_clk}]
 
 #false paths in the user_clock prescalar logic since it is locked-down during FIM-build
-set_false_path -from {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]} -to {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]}
+set_false_path -from {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]} -to {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]}

--- a/fseries_dk/hardware/fseries_dk_usm_iopipes/build/scripts/adjust_plls.tcl
+++ b/fseries_dk/hardware/fseries_dk_usm_iopipes/build/scripts/adjust_plls.tcl
@@ -9,9 +9,9 @@ package require ::quartus::flow
 
 # Definitions
 #normal/slow clock
-set k_clk_name "afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1"
+set k_clk_name "afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1"
 #double/fast clock
-set k_clk2x_name "afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0"
+set k_clk2x_name "afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0"
 set k_fmax -1
 set jitter_compensation 0.01
 set unused_clock_freq 10000
@@ -326,8 +326,8 @@ while { $timing_clean == 0 && $timing_loop_cnt <= $max_num_loops} {
     
     post_message "Generating acl_quartus_report.txt"
     set outfile   [open "acl_quartus_report.txt" w]
-    set aluts_l   [regsub "," [get_fitter_resource_usage -alut] "" ]
-    if {[catch {set aluts_m [regsub "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
+    set aluts_l   [regsub -all "," [get_fitter_resource_usage -alut] "" ]
+    if {[catch {set aluts_m [regsub -all "," [get_fitter_resource_usage -resource "Memory ALUT usage"] "" ]} result]} {
         set aluts_m 0
     }
     if { [string length $aluts_m] < 1 || ! [string is integer $aluts_m] } {
@@ -433,8 +433,8 @@ while { $timing_clean == 0 && $timing_loop_cnt <= $max_num_loops} {
     set sdcfile   [open "user_clock.sdc" w]
     puts $sdcfile "#updated user-clock.sdc assignments based on fmax from previous fit attempt."
     puts $sdcfile "puts \"Updated user-clock constraints based on fmax from previous fit attempt.\" "
-    puts $sdcfile "create_clock -name {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0} -period $period2 \[get_pins {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]}]"
-    puts $sdcfile "create_clock -name {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1} -period $period \[get_pins {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]}] "
+    puts $sdcfile "create_clock -name {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0} -period $period2 \[get_pins {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]}]"
+    puts $sdcfile "create_clock -name {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1} -period $period \[get_pins {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]}] "
     puts $sdcfile "$disable_mpw_sdccmd"
     close $sdcfile
     

--- a/fseries_dk/hardware/fseries_dk_usm_iopipes/build/user_clock.sdc
+++ b/fseries_dk/hardware/fseries_dk_usm_iopipes/build/user_clock.sdc
@@ -10,13 +10,13 @@
 #1.25ns 800mhz
 
 #remove existing constraints on the user clocks
-remove_clock afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0
-remove_clock afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]
-remove_clock afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1
-remove_clock afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]
+remove_clock afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0
+remove_clock afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]
+remove_clock afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1
+remove_clock afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]
 
 #kernel clk 1x / uClk_usrDiv2
-create_clock -name {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0} -period 1.5 [get_pins {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]}] 
+create_clock -name {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0} -period 1.5 [get_pins {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[1]}] 
 
 #kernel clk 2x / uClk_usr
-create_clock -name {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1} -period 1.5 [get_pins {afu_top|port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]}] 
+create_clock -name {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1} -period 1.5 [get_pins {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0|tennm_pll|outclk[2]}] 


### PR DESCRIPTION
A recent FIM change altered the hierarchy of the user/kernel clock, causing adjust_plls.tcl (and associated kernel-clock timing constraints) to fail. This work-around fixes takes that hierarchy change into account. A proper future fix should leverage the scripts within ofs_partial_reconfig from the FIM.