### PR TITLE
Update create-tarball scripts to retain hierarchy

### DIFF
--- a/d5005/scripts/create-tarball.sh
+++ b/d5005/scripts/create-tarball.sh
@@ -5,11 +5,11 @@
 
 ###############################################################################
 # Script to generate the tarball used for distributing the OneAPI ASP.  Creates
-# tarball with directory prefix opencl-bsp and includes files for hardware
+# tarball with directory prefix oneapi-asp-d5005 and includes files for hardware
 # targets, MMD, and the default aocx in bringup directory.
 ###############################################################################
 
-if [ -n "$OFS_OCL_ENV_DEBUG_SCRIPTS" ]; then
+if [ -n "$OFS_ASP_ENV_DEBUG_SCRIPTS" ]; then
   set -x
 fi
 
@@ -18,7 +18,7 @@ BSP_ROOT="$(readlink -e "$SCRIPT_DIR_PATH/..")"
 
 cd "$BSP_ROOT" || exit
 
-bsp_files=("README.md" "scripts" "source" "hardware" "linux64/lib" "linux64/libexec" "board_env.xml" "build/opae/install" "build/json-c/install" "pr_build_template/hw/blue_bits")
+bsp_files=("README.md" "scripts" "source" "hardware" "linux64" "board_env.xml" "pr_build_template")
 
 search_dir=bringup/aocxs
 for entry in "$search_dir"/*.aocx
@@ -32,5 +32,19 @@ for i in "${!bsp_files[@]}"; do
   fi
 done
 
-tar --transform='s,^,oneapi-asp-d5005/,' --create --gzip \
-    --file="$BSP_ROOT/oneapi-asp-d5005.tar.gz" --owner=0 --group=0  "${bsp_files[@]}"
+if [ -d "$BSP_ROOT/oneapi-asp-d5005" ]; then
+    echo "$BSP_ROOT/oneapi-asp-d5005 exists; Removing it first"
+    rm -rf $BSP_ROOT/oneapi-asp-d5005
+fi
+
+mkdir $BSP_ROOT/oneapi-asp-d5005
+
+cp -rf "${bsp_files[@]}" $BSP_ROOT/oneapi-asp-d5005/
+
+#"build/opae/install" "build/json-c/install" 
+mkdir -p $BSP_ROOT/oneapi-asp-d5005/build/opae && cp -rf build/opae/install $BSP_ROOT/oneapi-asp-d5005/build/opae/
+mkdir -p $BSP_ROOT/oneapi-asp-d5005/build/json-c && cp -rf build/json-c/install $BSP_ROOT/oneapi-asp-d5005/build/json-c/
+
+tar czf oneapi-asp-d5005.tar.gz --owner=0 --group=0 --no-same-owner --no-same-permissions oneapi-asp-d5005
+
+rm -rf "$BSP_ROOT/oneapi-asp-d5005"

--- a/fseries_dk/scripts/create-tarball.sh
+++ b/fseries_dk/scripts/create-tarball.sh
@@ -47,4 +47,4 @@ mkdir -p $BSP_ROOT/oneapi-asp-fseriesdk/build/json-c && cp -rf build/json-c/inst
 
 tar czf oneapi-asp-fseriesdk.tar.gz --owner=0 --group=0 --no-same-owner --no-same-permissions oneapi-asp-fseriesdk
 
-rm -rf "$BSP_ROOT/oneapi-asp-n6001"
+rm -rf "$BSP_ROOT/oneapi-asp-fseriesdk"

--- a/fseries_dk/scripts/create-tarball.sh
+++ b/fseries_dk/scripts/create-tarball.sh
@@ -5,11 +5,11 @@
 
 ###############################################################################
 # Script to generate the tarball used for distributing the OneAPI ASP.  Creates
-# tarball with directory prefix opencl-bsp and includes files for hardware
+# tarball with directory prefix oneapi-asp-fseriesdk and includes files for hardware
 # targets, MMD, and the default aocx in bringup directory.
 ###############################################################################
 
-if [ -n "$OFS_OCL_ENV_DEBUG_SCRIPTS" ]; then
+if [ -n "$OFS_ASP_ENV_DEBUG_SCRIPTS" ]; then
   set -x
 fi
 
@@ -18,7 +18,7 @@ BSP_ROOT="$(readlink -e "$SCRIPT_DIR_PATH/..")"
 
 cd "$BSP_ROOT" || exit
 
-bsp_files=("README.md" "scripts" "source" "hardware" "linux64/lib" "linux64/libexec" "board_env.xml" "build/opae/install" "build/json-c/install" "pr_build_template/hw/blue_bits")
+bsp_files=("README.md" "scripts" "source" "hardware" "linux64" "board_env.xml" "pr_build_template")
 
 search_dir=bringup/aocxs
 for entry in "$search_dir"/*.aocx
@@ -32,5 +32,19 @@ for i in "${!bsp_files[@]}"; do
   fi
 done
 
-tar --transform='s,^,oneapi-asp-n6001/,' --create --gzip \
-    --file="$BSP_ROOT/oneapi-asp-n6001.tar.gz" --owner=0 --group=0  "${bsp_files[@]}"
+if [ -d "$BSP_ROOT/oneapi-asp-fseriesdk" ]; then
+    echo "$BSP_ROOT/oneapi-asp-fseriesdk exists; Removing it first"
+    rm -rf $BSP_ROOT/oneapi-asp-fseriesdk
+fi
+
+mkdir $BSP_ROOT/oneapi-asp-fseriesdk
+
+cp -rf "${bsp_files[@]}" $BSP_ROOT/oneapi-asp-fseriesdk/
+
+#"build/opae/install" "build/json-c/install" 
+mkdir -p $BSP_ROOT/oneapi-asp-fseriesdk/build/opae && cp -rf build/opae/install $BSP_ROOT/oneapi-asp-fseriesdk/build/opae/
+mkdir -p $BSP_ROOT/oneapi-asp-fseriesdk/build/json-c && cp -rf build/json-c/install $BSP_ROOT/oneapi-asp-fseriesdk/build/json-c/
+
+tar czf oneapi-asp-fseriesdk.tar.gz --owner=0 --group=0 --no-same-owner --no-same-permissions oneapi-asp-fseriesdk
+
+rm -rf "$BSP_ROOT/oneapi-asp-n6001"

--- a/n6001/scripts/create-tarball.sh
+++ b/n6001/scripts/create-tarball.sh
@@ -18,7 +18,7 @@ BSP_ROOT="$(readlink -e "$SCRIPT_DIR_PATH/..")"
 
 cd "$BSP_ROOT" || exit
 
-bsp_files=("README.md" "scripts" "source" "hardware" "linux64/lib" "linux64/libexec" "board_env.xml" "build/opae/install" "build/json-c/install" "pr_build_template/hw/blue_bits")
+bsp_files=("README.md" "scripts" "source" "hardware" "linux64" "board_env.xml" "pr_build_template")
 
 search_dir=bringup/aocxs
 for entry in "$search_dir"/*.aocx
@@ -40,6 +40,10 @@ fi
 mkdir $BSP_ROOT/oneapi-asp-n6001
 
 cp -rf "${bsp_files[@]}" $BSP_ROOT/oneapi-asp-n6001/
+
+#"build/opae/install" "build/json-c/install" 
+mkdir -p $BSP_ROOT/oneapi-asp-n6001/build/opae && cp -rf build/opae/install $BSP_ROOT/oneapi-asp-n6001/build/opae/
+mkdir -p $BSP_ROOT/oneapi-asp-n6001/build/json-c && cp -rf build/json-c/install $BSP_ROOT/oneapi-asp-n6001/build/json-c/
 
 tar czf oneapi-asp-n6001.tar.gz --owner=0 --group=0 --no-same-owner --no-same-permissions oneapi-asp-n6001
 

--- a/n6001/scripts/create-tarball.sh
+++ b/n6001/scripts/create-tarball.sh
@@ -5,7 +5,7 @@
 
 ###############################################################################
 # Script to generate the tarball used for distributing the OneAPI ASP.  Creates
-# tarball with directory prefix opencl-bsp and includes files for hardware
+# tarball with directory prefix oneapi-asp-n6001 and includes files for hardware
 # targets, MMD, and the default aocx in bringup directory.
 ###############################################################################
 


### PR DESCRIPTION
After removing the transform option to the tar command we lost the forced-hierarchy. This should get the proper hierarchy back.