### PR TITLE
Update build-default-aocx and create-tarball scripts

### DIFF
--- a/d5005/scripts/build-default-aocx.sh
+++ b/d5005/scripts/build-default-aocx.sh
@@ -68,8 +68,8 @@ echo "Starting aocx compile at: $(date)"
 echo -e "Using OpenCL version:\n$(aoc -version)\n"
 echo -e "Using Quartus version:\n$(quartus_sh --version)"
 echo "---------------------------------------------------------------"
-echo -e "aoc -board-package="$BSP_ROOT" -bsp-flow="$BSP_FLOW" -board="$BOARD" "$INTERLEAVE_OPTION" -v -o "$BOARD" "$BSP_ROOT/$CL_FILE""
-aoc -board-package="$BSP_ROOT" -bsp-flow="$BSP_FLOW" -board="$BOARD" "$INTERLEAVE_OPTION" -v -o "$BOARD" "$BSP_ROOT/$CL_FILE"
+echo -e "aoc -board-package="$BSP_ROOT" -no-env-check -bsp-flow="$BSP_FLOW" -board="$BOARD" "$INTERLEAVE_OPTION" -v -o "$BOARD" "$BSP_ROOT/$CL_FILE""
+aoc -board-package="$BSP_ROOT" -no-env-check -bsp-flow="$BSP_FLOW" -board="$BOARD" "$INTERLEAVE_OPTION" -v -o "$BOARD" "$BSP_ROOT/$CL_FILE"
 echo "Finished aocx compile at: $(date)"
 
 if [ -f "$BUILD_DIR/${BOARD}.aocx" ]; then

--- a/d5005/scripts/create-tarball.sh
+++ b/d5005/scripts/create-tarball.sh
@@ -20,12 +20,6 @@ cd "$BSP_ROOT" || exit
 
 bsp_files=("README.md" "scripts" "source" "hardware" "linux64" "board_env.xml" "pr_build_template")
 
-search_dir=bringup/aocxs
-for entry in "$search_dir"/*.aocx
-do
-  bsp_files+=($entry)
-done
-
 for i in "${!bsp_files[@]}"; do
   if [ ! -e "${bsp_files[i]}" ]; then
     unset 'bsp_files[i]'
@@ -42,8 +36,15 @@ mkdir $BSP_ROOT/oneapi-asp-d5005
 cp -rf "${bsp_files[@]}" $BSP_ROOT/oneapi-asp-d5005/
 
 #"build/opae/install" "build/json-c/install" 
-mkdir -p $BSP_ROOT/oneapi-asp-d5005/build/opae && cp -rf build/opae/install $BSP_ROOT/oneapi-asp-d5005/build/opae/
-mkdir -p $BSP_ROOT/oneapi-asp-d5005/build/json-c && cp -rf build/json-c/install $BSP_ROOT/oneapi-asp-d5005/build/json-c/
+if [ -d "build/opae/install" ]; then
+    mkdir -p $BSP_ROOT/oneapi-asp-d5005/build/opae && cp -rf build/opae/install $BSP_ROOT/oneapi-asp-d5005/build/opae/
+fi
+if [ -d "build/json-c/install" ]; then
+    mkdir -p $BSP_ROOT/oneapi-asp-d5005/build/json-c && cp -rf build/json-c/install $BSP_ROOT/oneapi-asp-d5005/build/json-c/
+fi
+if [ -e bringup/aocxs/*.aocx ]; then
+    mkdir -p $BSP_ROOT/oneapi-asp-d5005/bringup/aocxs && cp -f bringup/aocxs/*.aocx $BSP_ROOT/oneapi-asp-d5005/bringup/aocxs/
+fi
 
 tar czf oneapi-asp-d5005.tar.gz --owner=0 --group=0 --no-same-owner --no-same-permissions oneapi-asp-d5005
 

--- a/d5005/scripts/create-tarball.sh
+++ b/d5005/scripts/create-tarball.sh
@@ -35,14 +35,13 @@ mkdir $BSP_ROOT/oneapi-asp-d5005
 
 cp -rf "${bsp_files[@]}" $BSP_ROOT/oneapi-asp-d5005/
 
-#"build/opae/install" "build/json-c/install" 
 if [ -d "build/opae/install" ]; then
     mkdir -p $BSP_ROOT/oneapi-asp-d5005/build/opae && cp -rf build/opae/install $BSP_ROOT/oneapi-asp-d5005/build/opae/
 fi
 if [ -d "build/json-c/install" ]; then
     mkdir -p $BSP_ROOT/oneapi-asp-d5005/build/json-c && cp -rf build/json-c/install $BSP_ROOT/oneapi-asp-d5005/build/json-c/
 fi
-if [ -e bringup/aocxs/*.aocx ]; then
+if [ -n "$(find ./bringup/ -name *.aocx)" ]; then
     mkdir -p $BSP_ROOT/oneapi-asp-d5005/bringup/aocxs && cp -f bringup/aocxs/*.aocx $BSP_ROOT/oneapi-asp-d5005/bringup/aocxs/
 fi
 

--- a/n6001/scripts/build-default-aocx.sh
+++ b/n6001/scripts/build-default-aocx.sh
@@ -31,8 +31,9 @@ done
 
 # Check that board variant is configured
 BOARD=${BOARD:-ofs_n6001}
-if [ ! -f "$BSP_ROOT/hardware/$BOARD/build/ofs_top.qdb" ]; then
-  echo "Error: cannot find required OFS TOP QDB file for board '$BOARD'"
+QDB_FILES="$(find $BSP_ROOT/hardware -name ofs_top.qdb)"
+if [ -z "$QDB_FILES" ]; then
+  echo "Error: cannot find required OFS TOP QDB files. Please set up the ASP first."
   exit 1
 fi
 echo "Generating default aocx for board variant: $BOARD"
@@ -68,8 +69,8 @@ echo "Starting aocx compile at: $(date)"
 echo -e "Using OpenCL version:\n$(aoc -version)\n"
 echo -e "Using Quartus version:\n$(quartus_sh --version)"
 echo "---------------------------------------------------------------"
-echo -e "aoc -board-package="$BSP_ROOT" -bsp-flow="$BSP_FLOW" -board="$BOARD" "$INTERLEAVE_OPTION" -v -o "$BOARD" "$BSP_ROOT/$CL_FILE""
-aoc -board-package="$BSP_ROOT" -bsp-flow="$BSP_FLOW" -board="$BOARD" "$INTERLEAVE_OPTION" -v -o "$BOARD" "$BSP_ROOT/$CL_FILE"
+echo -e "aoc -board-package="$BSP_ROOT" -no-env-check -bsp-flow="$BSP_FLOW" -board="$BOARD" "$INTERLEAVE_OPTION" -v -o "$BOARD" "$BSP_ROOT/$CL_FILE""
+aoc -board-package="$BSP_ROOT" -no-env-check -bsp-flow="$BSP_FLOW" -board="$BOARD" "$INTERLEAVE_OPTION" -v -o "$BOARD" "$BSP_ROOT/$CL_FILE"
 echo "Finished aocx compile at: $(date)"
 
 if [ -f "$BUILD_DIR/${BOARD}.aocx" ]; then

--- a/n6001/scripts/create-tarball.sh
+++ b/n6001/scripts/create-tarball.sh
@@ -35,14 +35,13 @@ mkdir $BSP_ROOT/oneapi-asp-n6001
 
 cp -rf "${bsp_files[@]}" $BSP_ROOT/oneapi-asp-n6001/
 
-#"build/opae/install" "build/json-c/install" 
 if [ -d "build/opae/install" ]; then
     mkdir -p $BSP_ROOT/oneapi-asp-n6001/build/opae && cp -rf build/opae/install $BSP_ROOT/oneapi-asp-n6001/build/opae/
 fi
 if [ -d "build/json-c/install" ]; then
     mkdir -p $BSP_ROOT/oneapi-asp-n6001/build/json-c && cp -rf build/json-c/install $BSP_ROOT/oneapi-asp-n6001/build/json-c/
 fi
-if [ -e bringup/aocxs/*.aocx ]; then
+if [ -n "$(find ./bringup/ -name *.aocx)" ]; then
     mkdir -p $BSP_ROOT/oneapi-asp-n6001/bringup/aocxs && cp -f bringup/aocxs/*.aocx $BSP_ROOT/oneapi-asp-n6001/bringup/aocxs/
 fi
 

--- a/n6001/scripts/create-tarball.sh
+++ b/n6001/scripts/create-tarball.sh
@@ -20,12 +20,6 @@ cd "$BSP_ROOT" || exit
 
 bsp_files=("README.md" "scripts" "source" "hardware" "linux64" "board_env.xml" "pr_build_template")
 
-search_dir=bringup/aocxs
-for entry in "$search_dir"/*.aocx
-do
-  bsp_files+=($entry)
-done
-
 for i in "${!bsp_files[@]}"; do
   if [ ! -e "${bsp_files[i]}" ]; then
     unset 'bsp_files[i]'
@@ -42,8 +36,15 @@ mkdir $BSP_ROOT/oneapi-asp-n6001
 cp -rf "${bsp_files[@]}" $BSP_ROOT/oneapi-asp-n6001/
 
 #"build/opae/install" "build/json-c/install" 
-mkdir -p $BSP_ROOT/oneapi-asp-n6001/build/opae && cp -rf build/opae/install $BSP_ROOT/oneapi-asp-n6001/build/opae/
-mkdir -p $BSP_ROOT/oneapi-asp-n6001/build/json-c && cp -rf build/json-c/install $BSP_ROOT/oneapi-asp-n6001/build/json-c/
+if [ -d "build/opae/install" ]; then
+    mkdir -p $BSP_ROOT/oneapi-asp-n6001/build/opae && cp -rf build/opae/install $BSP_ROOT/oneapi-asp-n6001/build/opae/
+fi
+if [ -d "build/json-c/install" ]; then
+    mkdir -p $BSP_ROOT/oneapi-asp-n6001/build/json-c && cp -rf build/json-c/install $BSP_ROOT/oneapi-asp-n6001/build/json-c/
+fi
+if [ -e bringup/aocxs/*.aocx ]; then
+    mkdir -p $BSP_ROOT/oneapi-asp-n6001/bringup/aocxs && cp -f bringup/aocxs/*.aocx $BSP_ROOT/oneapi-asp-n6001/bringup/aocxs/
+fi
 
 tar czf oneapi-asp-n6001.tar.gz --owner=0 --group=0 --no-same-owner --no-same-permissions oneapi-asp-n6001
 


### PR DESCRIPTION
With the recent changes to file hierarchy the build-default-aocxs script needs an update; this, in turn, leads to an update in create-tarball.