### PR TITLE
Move AVMM write-burst-splitting logic into own module

### DIFF
--- a/n6001/hardware/ofs_n6001_usm/build/bsp_design_files.tcl
+++ b/n6001/hardware/ofs_n6001_usm/build/bsp_design_files.tcl
@@ -32,6 +32,7 @@ set_global_assignment -name SYSTEMVERILOG_FILE "rtl/bsp_host_mem_if_mux.sv"
 set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_wr_ack_gen.sv"
 set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_wr_ack_burst_to_word.sv"
 set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_wr_ack_tracker.sv"
+set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_single_burst_partial_writes.sv"
 
 #--------------------
 # Search paths (for headers, etc)

--- a/n6001/hardware/ofs_n6001_usm/build/rtl/avmm_single_burst_partial_writes.v
+++ b/n6001/hardware/ofs_n6001_usm/build/rtl/avmm_single_burst_partial_writes.v
@@ -38,7 +38,7 @@ typedef struct packed {
     logic [(OPENCL_BSP_KERNEL_SVM_DATA_WIDTH/8)-1:0] byteenable;
     logic [OPENCL_BSP_KERNEL_SVM_DATA_WIDTH-1:0] writedata;
 } usm_avmm_cmd_t;
-usm_avmm_cmd_t usm_avmm_cmd_from_kernelsystem, usm_avmm_cmd_buf_out;
+usm_avmm_cmd_t usm_avmm_cmd_buf_in, usm_avmm_cmd_buf_out;
 
 typedef struct packed {
     logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] burstcount;
@@ -71,8 +71,12 @@ always_comb begin
 end
 
 always_comb begin
-    to_avmm_source.address    = to_avmm_source.write ? to_avmm_source.address + svm_addr_cnt : to_avmm_source.address;
-    to_avmm_source.burstcount = to_avmm_source.write ? 'h1 : to_avmm_source.burstcount;
+    usm_avmm_cmd_buf_in.address    = to_avmm_source.write ? to_avmm_source.address + svm_addr_cnt : to_avmm_source.address;
+    usm_avmm_cmd_buf_in.burstcount = to_avmm_source.write ? 'h1 : to_avmm_source.burstcount;
+    usm_avmm_cmd_buf_in.write      = to_avmm_source.write;
+    usm_avmm_cmd_buf_in.writedata  = to_avmm_source.writedata;
+    usm_avmm_cmd_buf_in.read       = to_avmm_source.read;
+    usm_avmm_cmd_buf_in.byteenable = to_avmm_source.byteenable;
 end
 
 always_ff @(posedge clk or negedge reset_n) begin
@@ -80,19 +84,19 @@ always_ff @(posedge clk or negedge reset_n) begin
         svm_addr_cnt <= 'h0;
     end else begin
         if (svm_addr_cnt == (to_avmm_source.burstcount-'b1) ) begin
-            if (to_avmm_source.write) begin
+            if (usm_avmm_cmd_buf_in.write) begin
                 svm_addr_cnt <= 'b0;
             end else begin
                 svm_addr_cnt <= svm_addr_cnt;
             end
         end else begin
-            svm_addr_cnt <= svm_addr_cnt + to_avmm_source.write;
+            svm_addr_cnt <= svm_addr_cnt + usm_avmm_cmd_buf_in.write;
         end
     end
 end
 
 //due to WRA I need to add a buffer here, using almost-full to generate waitrequest to kernel.
-logic usm_avmm_buffer_full, usm_avmm_buffer_almfull, usm_avmm_buffer_empty;
+logic usm_avmm_buffer_full, usm_avmm_buffer_empty;
 logic [9:0] usm_avmm_buffer_usedw;
 scfifo
 #(
@@ -112,10 +116,10 @@ usm_avmm_buffer
     .clock(clk),
     .sclr(!reset_n),
 
-    .data(usm_avmm_cmd_from_kernelsystem),
-    .wrreq(to_avmm_source.write | to_avmm_source.read),
+    .data(usm_avmm_cmd_buf_in),
+    .wrreq(usm_avmm_cmd_buf_in.write | usm_avmm_cmd_buf_in.read),
     .full(usm_avmm_buffer_full),
-    .almost_full(usm_avmm_buffer_almfull),
+    .almost_full(to_avmm_source.waitrequest),
 
     .rdreq(usm_avmm_fifo_rd),
     .q(usm_avmm_cmd_buf_out),
@@ -126,9 +130,6 @@ usm_avmm_buffer
     .usedw(usm_avmm_buffer_usedw),
     .eccstatus()
 );
-
-//waitrequest is based on the almost-full signal from the scfifo
-assign to_avmm_source.waitrequest = usm_avmm_buffer_almfull;
 
 always_comb begin
     to_avmm_sink.write = usm_avmm_fifo_rd & usm_avmm_cmd_buf_out.write;
@@ -167,7 +168,7 @@ always_ff @(posedge clk) begin
         usm_burstcnt[1] <= usm_burstcnt[0];
         usm_burstcnt[0].valid <= 1'b0;
         //if it is a read req from the kernel-system, just use that burstcount value
-        if (to_avmm_source.read) begin
+        if (usm_avmm_cmd_buf_in.read) begin
             usm_burstcnt_wdog <= 'h0;
             //if we were tracking a write-burst and a read comes in, send both the write and read in order
             if (current_bcnt > 'h1) begin
@@ -182,7 +183,7 @@ always_ff @(posedge clk) begin
             usm_burstcnt[0].read <= 1'b1;
             current_bcnt <= 'h1;
         //if it is a write req from kernel-system, need to figure out the maximal burst
-        end else if (to_avmm_source.write) begin
+        end else if (usm_avmm_cmd_buf_in.write) begin
             usm_burstcnt_wdog <= 'h0;
             //if original burst-cnt is 1, leave it as 1
             if (to_avmm_source.burstcount == 'h1) begin
@@ -200,19 +201,19 @@ always_ff @(posedge clk) begin
                 current_bcnt <= 'h1;
             //original burst-cnt is not 1; this is the first word of the burst
             end else if (current_bcnt == 'h1) begin
-                if ( !(&to_avmm_source.byteenable) ) begin
+                if ( !(&usm_avmm_cmd_buf_in.byteenable) ) begin
                     usm_burstcnt[0].burstcount <= 'h1;
                     usm_burstcnt[0].valid <= 1'b1;
                     usm_burstcnt[0].write <= 1'b1;
                     usm_burstcnt[0].read <= 1'b0;
                 end else begin
-                    prev_address_plus1 <= to_avmm_source.address + 'h1;
+                    prev_address_plus1 <= usm_avmm_cmd_buf_in.address + 'h1;
                     current_bcnt <= 'h2;
                 end
             //if continuous address
-            end else if (prev_address_plus1 == to_avmm_source.address) begin
+            end else if (prev_address_plus1 == usm_avmm_cmd_buf_in.address) begin
                 //if partial write, send burst and singleton
-                if ( !(&to_avmm_source.byteenable) ) begin
+                if ( !(&usm_avmm_cmd_buf_in.byteenable) ) begin
                     usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
                     usm_burstcnt[1].valid <= 1'b1;
                     usm_burstcnt[1].write <= 1'b1;
@@ -233,11 +234,11 @@ always_ff @(posedge clk) begin
                     usm_burstcnt[0].read <= 1'b0;
                     current_bcnt <= 'h1;
                 end
-                prev_address_plus1 <= to_avmm_source.address + 'h1;
+                prev_address_plus1 <= usm_avmm_cmd_buf_in.address + 'h1;
             //not a continuous address, send the previous burst and start tracking the new one
             end else begin
                 //if partial write, send burst and singleton
-                if ( !(&to_avmm_source.byteenable) ) begin
+                if ( !(&usm_avmm_cmd_buf_in.byteenable) ) begin
                     usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
                     usm_burstcnt[1].valid <= 1'b1;
                     usm_burstcnt[1].write <= 1'b1;
@@ -254,7 +255,7 @@ always_ff @(posedge clk) begin
                     usm_burstcnt[0].write <= 1'b1;
                     usm_burstcnt[0].read <= 1'b0;
                     current_bcnt <= 'h1;
-                    prev_address_plus1 <= to_avmm_source.address + 'h1;
+                    prev_address_plus1 <= usm_avmm_cmd_buf_in.address + 'h1;
                 end
             end
         //watchdog to flush out any final write request. 
@@ -371,11 +372,4 @@ assign usm_avmm_fifo_rd = usm_avmm_fifo_rd_remaining && !to_avmm_sink.waitreques
 assign usm_bcnt_fifo_rd =   !usm_burstcnt_buffer_empty && !to_avmm_sink.waitrequest && (usm_bcnt_st_is_setbcnt || 
                             (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) );
 
-    //`else
-    //    always_comb begin
-    //        to_avmm_sink.address    = to_avmm_source.address;
-    //        to_avmm_sink.burstcount = to_avmm_source.burstcount;
-    //    end
-    //`endif
-    
 endmodule : avmm_single_burst_partial_writes

--- a/n6001/hardware/ofs_n6001_usm/build/rtl/avmm_single_burst_partial_writes.v
+++ b/n6001/hardware/ofs_n6001_usm/build/rtl/avmm_single_burst_partial_writes.v
@@ -1,0 +1,356 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: MIT
+//
+
+`include "platform_if.vh"
+`include "fpga_defines.vh"
+`include "opencl_bsp.vh"
+
+// avmm_single_burst_partial_writes
+// Split an AVMM interface's partial writes into a single partial-write and 
+//  a re-grouped burst. Handles partial writes on either/or end of the burst
+//  (start and/or end), as well as initial bursts of 1.
+
+module avmm_single_burst_partial_writes  
+import dc_bsp_pkg::*;
+(
+    input       clk,
+    input       reset_n,
+
+    ofs_plat_avalon_mem_if.to_source to_avmm_source,
+    ofs_plat_avalon_mem_if.to_sink to_avmm_sink
+);
+
+typedef struct packed {
+    logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] burstcount;
+    logic valid;
+    logic read;
+    logic write;
+} usm_avmm_burstcnt_t;
+localparam USM_BCNT_DWIDTH = OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH + 1 + 1 + 1;
+usm_avmm_burstcnt_t [1:0] usm_burstcnt;
+usm_avmm_burstcnt_t usm_burstcnt_dout;
+logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] current_bcnt;
+logic [OPENCL_SVM_QSYS_ADDR_WIDTH-1:0] prev_address_plus1;
+localparam USM_BCNT_WDOG_WIDTH = 10;
+logic [USM_BCNT_WDOG_WIDTH-1:0] usm_burstcnt_wdog;
+logic usm_burstcnt_buffer_full, usm_burstcnt_buffer_almfull, usm_burstcnt_buffer_empty;
+logic [9:0] usm_burstcnt_buffer_usedw;
+typedef enum {  ST_SET_BCNT,
+                ST_DO_WR_BURST,
+                XXX } usm_bcnt_st_e;
+usm_bcnt_st_e usm_bcnt_cs, usm_bcnt_ns;
+logic usm_bcnt_st_is_setbcnt, usm_bcnt_st_is_do_wr_burst;
+logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] usm_avmm_fifo_rd_remaining;
+logic usm_avmm_fifo_rd, usm_bcnt_fifo_rd;
+logic [7:0] svm_addr_cnt;
+
+//the readdata-path is just passed-through
+always_comb begin
+    to_avmm_source.readdata = to_avmm_sink.readdata;
+    to_avmm_source.readdatavalid = to_avmm_sink.readdatavalid;
+end
+
+always_comb begin
+    to_avmm_source.address    = to_avmm_source.write ? to_avmm_source.address + svm_addr_cnt : to_avmm_source.address;
+    to_avmm_source.burstcount = to_avmm_source.write ? 'h1 : to_avmm_source.burstcount;
+end
+
+always_ff @(posedge clk or negedge reset_n) begin
+    if (!reset_n) begin
+        svm_addr_cnt <= 'h0;
+    end else begin
+        if (svm_addr_cnt == (to_avmm_source.burstcount-'b1) ) begin
+            if (to_avmm_source.write) begin
+                svm_addr_cnt <= 'b0;
+            end else begin
+                svm_addr_cnt <= svm_addr_cnt;
+            end
+        end else begin
+            svm_addr_cnt <= svm_addr_cnt + to_avmm_source.write;
+        end
+    end
+end
+
+//due to WRA I need to add a buffer here, using almost-full to generate waitrequest to kernel.
+logic usm_avmm_buffer_full, usm_avmm_buffer_almfull, usm_avmm_buffer_empty;
+logic [9:0] usm_avmm_buffer_usedw;
+scfifo
+#(
+    .lpm_numwords(USM_AVMM_BUFFER_DEPTH),
+    .lpm_showahead("ON"),
+    .lpm_type("scfifo"),
+    .lpm_width(USM_AVMM_BUFFER_WIDTH),
+    .lpm_widthu($clog2(USM_AVMM_BUFFER_DEPTH)),
+    .almost_full_value(USM_AVMM_BUFFER_ALMFULL_VALUE),
+    .overflow_checking("OFF"),
+    .underflow_checking("OFF"),
+    .use_eab("ON"),
+    .add_ram_output_register("ON")
+    )
+usm_avmm_buffer
+(
+    .clock(clk),
+    .sclr(!reset_n),
+
+    .data(usm_avmm_cmd_from_kernelsystem),
+    .wrreq(to_avmm_source.write | to_avmm_source.read),
+    .full(usm_avmm_buffer_full),
+    .almost_full(usm_avmm_buffer_almfull),
+
+    .rdreq(usm_avmm_fifo_rd),
+    .q(usm_avmm_cmd_buf_out),
+    .empty(usm_avmm_buffer_empty),
+    .almost_empty(),
+
+    .aclr(),
+    .usedw(usm_avmm_buffer_usedw),
+    .eccstatus()
+);
+
+//waitrequest is based on the almost-full signal from the scfifo
+assign to_avmm_source.waitrequest = usm_avmm_buffer_almfull;
+
+always_comb begin
+    kernel_system_svm_write = usm_avmm_fifo_rd & usm_avmm_cmd_buf_out.write;
+    kernel_system_svm_read  = usm_avmm_fifo_rd & usm_avmm_cmd_buf_out.read;
+    
+    to_avmm_sink.address    = usm_avmm_cmd_buf_out.address;
+    to_avmm_sink.writedata  = usm_avmm_cmd_buf_out.writedata;
+    to_avmm_sink.burstcount = usm_avmm_cmd_buf_out.write ? usm_avmm_fifo_rd_remaining : usm_avmm_cmd_buf_out.burstcount;
+    to_avmm_sink.byteenable = usm_avmm_cmd_buf_out.byteenable;
+end
+
+//re-create the burst-count data based on byteenable, address, and original burst-count
+//Every partial-write (where byteenable is not all 1's) must result in be a burst-count of '1'.
+//Other writes should be grouped together into maximal-sized bursts.
+//
+//
+
+always_ff @(posedge clk) begin
+    if (!reset_n) begin
+        usm_burstcnt <= 'h0;
+        current_bcnt <= 'h1;
+        prev_address_plus1 <= 'b0;
+        usm_burstcnt_wdog <= 'b0;
+    end else begin
+        //when tracking a write-burst, we might need to flush it out because we don't know when the
+        //write from the kernel-system is actually complete.
+        usm_burstcnt_wdog <= current_bcnt > 'h1 ? {usm_burstcnt_wdog[0 +: (USM_BCNT_WDOG_WIDTH-1)], 1'b1} : '0;
+        //push in a 0 to create a pulse for a follow-up partial write burstcount of 1
+        //it will be over-written later in the block if/when necessary.
+        usm_burstcnt[1] <= usm_burstcnt[0];
+        usm_burstcnt[0].valid <= 1'b0;
+        //if it is a read req from the kernel-system, just use that burstcount value
+        if (to_avmm_source.read) begin
+            usm_burstcnt_wdog <= 'h0;
+            //if we were tracking a write-burst and a read comes in, send both the write and read in order
+            if (current_bcnt > 'h1) begin
+                usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
+                usm_burstcnt[1].valid <= 1'b1;
+                usm_burstcnt[1].write <= 1'b1;
+                usm_burstcnt[1].read <= 1'b0;
+            end
+            usm_burstcnt[0].burstcount <= to_avmm_source.burstcount;
+            usm_burstcnt[0].valid <= 1'b1;
+            usm_burstcnt[0].write <= 1'b0;
+            usm_burstcnt[0].read <= 1'b1;
+            current_bcnt <= 'h1;
+        //if it is a write req from kernel-system, need to figure out the maximal burst
+        end else if (to_avmm_source.write) begin
+            usm_burstcnt_wdog <= 'h0;
+            //if original burst-cnt is 1, leave it as 1
+            if (to_avmm_source.burstcount == 'h1) begin
+                //if need to send the previous burst, too.
+                if (current_bcnt > 'h1) begin
+                    usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
+                    usm_burstcnt[1].valid <= 1'b1;
+                    usm_burstcnt[1].write <= 1'b1;
+                    usm_burstcnt[1].read <= 1'b0;
+                end
+                usm_burstcnt[0].burstcount <= 'h1;
+                usm_burstcnt[0].valid <= 1'b1;
+                usm_burstcnt[0].write <= 1'b1;
+                usm_burstcnt[0].read  <= 1'b0;
+                current_bcnt <= 'h1;
+            //original burst-cnt is not 1; this is the first word of the burst
+            end else if (current_bcnt == 'h1) begin
+                if ( !(&to_avmm_source.byteenable) ) begin
+                    usm_burstcnt[0].burstcount <= 'h1;
+                    usm_burstcnt[0].valid <= 1'b1;
+                    usm_burstcnt[0].write <= 1'b1;
+                    usm_burstcnt[0].read <= 1'b0;
+                end else begin
+                    prev_address_plus1 <= to_avmm_source.address + 'h1;
+                    current_bcnt <= 'h2;
+                end
+            //if continuous address
+            end else if (prev_address_plus1 == to_avmm_source.address) begin
+                //if partial write, send burst and singleton
+                if ( !(&to_avmm_source.byteenable) ) begin
+                    usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
+                    usm_burstcnt[1].valid <= 1'b1;
+                    usm_burstcnt[1].write <= 1'b1;
+                    usm_burstcnt[1].read <= 1'b0;
+                    usm_burstcnt[0].burstcount <= 'h1;
+                    usm_burstcnt[0].valid <= 1'b1;
+                    usm_burstcnt[0].write <= 1'b1;
+                    usm_burstcnt[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                //not a partial write and not a full burst, so keep adding to burstcount
+                end else if (current_bcnt < OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_MAX) begin
+                    current_bcnt <= current_bcnt + 'h1;
+                //full burst, so send burst and start again
+                end else begin
+                    usm_burstcnt[0].burstcount <= current_bcnt;
+                    usm_burstcnt[0].valid <= 1'b1;
+                    usm_burstcnt[0].write <= 1'b1;
+                    usm_burstcnt[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                end
+                prev_address_plus1 <= to_avmm_source.address + 'h1;
+            //not a continuous address, send the previous burst and start tracking the new one
+            end else begin
+                //if partial write, send burst and singleton
+                if ( !(&to_avmm_source.byteenable) ) begin
+                    usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
+                    usm_burstcnt[1].valid <= 1'b1;
+                    usm_burstcnt[1].write <= 1'b1;
+                    usm_burstcnt[1].read <= 1'b0;
+                    usm_burstcnt[0].burstcount <= 'h1;
+                    usm_burstcnt[0].valid <= 1'b1;
+                    usm_burstcnt[0].write <= 1'b1;
+                    usm_burstcnt[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                //not partial burst, so send previous burst and continue tracking the new one
+                end else begin
+                    usm_burstcnt[0].burstcount <= current_bcnt - 'b1;
+                    usm_burstcnt[0].valid <= 1'b1;
+                    usm_burstcnt[0].write <= 1'b1;
+                    usm_burstcnt[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                    prev_address_plus1 <= to_avmm_source.address + 'h1;
+                end
+            end
+        //watchdog to flush out any final write request. 
+        end else if (&usm_burstcnt_wdog) begin
+            usm_burstcnt[0].burstcount <= current_bcnt - 'b1;
+            usm_burstcnt[0].valid <= 1'b1;
+            usm_burstcnt[0].write <= 1'b1;
+            usm_burstcnt[0].read <= 1'b0;
+            current_bcnt <= 'h1;
+            usm_burstcnt_wdog <= 'b0;
+        end
+    end
+end
+
+//push the burst-count info into a scFIFO
+scfifo
+#(
+    .lpm_numwords(USM_AVMM_BUFFER_DEPTH),
+    .lpm_showahead("ON"),
+    .lpm_type("scfifo"),
+    .lpm_width(USM_BCNT_DWIDTH),
+    .lpm_widthu($clog2(USM_AVMM_BUFFER_DEPTH)),
+    .almost_full_value(USM_AVMM_BUFFER_ALMFULL_VALUE),
+    .overflow_checking("OFF"),
+    .underflow_checking("OFF"),
+    .use_eab("ON"),
+    .add_ram_output_register("ON")
+    )
+usm_burstcnt_buffer
+(
+    .clock(clk),
+    .sclr(!reset_n),
+
+    .data(usm_burstcnt[1]),
+    .wrreq(usm_burstcnt[1].valid),
+    .full(usm_burstcnt_buffer_full),
+    .almost_full(usm_burstcnt_buffer_almfull),
+
+    .rdreq(usm_bcnt_fifo_rd),
+    .q(usm_burstcnt_dout),
+    .empty(usm_burstcnt_buffer_empty),
+    .almost_empty(),
+
+    .aclr(),
+    .usedw(usm_burstcnt_buffer_usedw),
+    .eccstatus()
+);
+
+
+//will require some state machine to track coordination of popping from the 2 FIFOs
+// can't pop from the main FIFO until something exists in the bcnt FIFO.
+// for each entry in the bcnt FIFO, pop that number of elements from the main FIFO.
+// the main FIFO is populated prior to the bcnt FIFO having data, so we are guaranteed
+//   the main FIFO will always have enough data in it to satisfy the bcnt size.
+always_ff @(posedge clk)
+    if (!reset_n)
+        usm_bcnt_cs <= ST_SET_BCNT;
+    else
+        usm_bcnt_cs <= usm_bcnt_ns;
+
+always_comb begin
+    usm_bcnt_ns = XXX;
+    case (usm_bcnt_cs)
+        ST_SET_BCNT:    if (!usm_burstcnt_buffer_empty && !to_avmm_sink.waitrequest) begin
+                            //if read or (bcnt == 1) stay here so we're ready 
+                            // for the next one on the next cycle
+                            if (usm_burstcnt_dout.read == 'b1 || 
+                                usm_burstcnt_dout.burstcount == 'h1) begin
+                                usm_bcnt_ns = ST_SET_BCNT;
+                            end else begin
+                                usm_bcnt_ns = ST_DO_WR_BURST;
+                            end
+                        end else begin
+                            usm_bcnt_ns = ST_SET_BCNT;
+                        end
+                        //if final word of this burst and not waitreq
+        ST_DO_WR_BURST: if (usm_avmm_fifo_rd_remaining == 'h1 && !to_avmm_sink.waitrequest) begin
+                            //if there is another burst waiting to go, stay here and start new burst
+                            if (!usm_burstcnt_buffer_empty && usm_burstcnt_dout.write == 'b1 && usm_burstcnt_dout.burstcount != 'h1) begin
+                                usm_bcnt_ns = ST_DO_WR_BURST;
+                            end else begin
+                                usm_bcnt_ns = ST_SET_BCNT;
+                            end
+                        end else begin
+                            usm_bcnt_ns = ST_DO_WR_BURST;
+                        end
+    endcase
+end
+
+assign usm_bcnt_st_is_setbcnt = usm_bcnt_cs == ST_SET_BCNT;
+assign usm_bcnt_st_is_do_wr_burst = usm_bcnt_cs == ST_DO_WR_BURST;
+
+//use a counter to manage popping from the usm_avmm FIFO.
+always_ff @(posedge clk)
+    if (!reset_n)
+        usm_avmm_fifo_rd_remaining <= 'b0;
+    else begin
+        //if burstcount fifo isn't empty and !waitreq
+        if (!usm_burstcnt_buffer_empty && !to_avmm_sink.waitrequest && (usm_bcnt_st_is_setbcnt || 
+           (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) ) ) begin
+            usm_avmm_fifo_rd_remaining <= usm_burstcnt_dout.read ? 'h1 : usm_burstcnt_dout.burstcount;
+        //pop from usm_avmm FIFO as long as the counter is non-zero and !waitreq
+        end else if (usm_avmm_fifo_rd)
+            usm_avmm_fifo_rd_remaining <= usm_avmm_fifo_rd_remaining - 'h1;
+        else 
+            usm_avmm_fifo_rd_remaining <= usm_avmm_fifo_rd_remaining;
+    end
+
+//we know there is sufficient data in the usm_avmm FIFO because the bcnt FIFO isn't written-to until the 
+// original burst has been pushed into the usm_avmm FIFO.
+assign usm_avmm_fifo_rd = usm_avmm_fifo_rd_remaining && !to_avmm_sink.waitrequest;
+//pop the next usm_bcnt value when? When it is first popped, so that the next value is already 
+// waiting on the FIFO output when we are done with the current burst.
+assign usm_bcnt_fifo_rd =   !usm_burstcnt_buffer_empty && !to_avmm_sink.waitrequest && (usm_bcnt_st_is_setbcnt || 
+                            (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) );
+
+    //`else
+    //    always_comb begin
+    //        to_avmm_sink.address    = to_avmm_source.address;
+    //        to_avmm_sink.burstcount = to_avmm_source.burstcount;
+    //    end
+    //`endif
+    
+endmodule : avmm_single_burst_partial_writes

--- a/n6001/hardware/ofs_n6001_usm/build/rtl/avmm_single_burst_partial_writes.v
+++ b/n6001/hardware/ofs_n6001_usm/build/rtl/avmm_single_burst_partial_writes.v
@@ -21,6 +21,25 @@ import dc_bsp_pkg::*;
     ofs_plat_avalon_mem_if.to_sink to_avmm_sink
 );
 
+localparam USM_AVMM_BUFFER_WIDTH =  OPENCL_SVM_QSYS_ADDR_WIDTH +
+                                    OPENCL_BSP_KERNEL_SVM_DATA_WIDTH +
+                                    OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH +
+                                    1 + //write req
+                                    1 + //read req
+                                    (OPENCL_BSP_KERNEL_SVM_DATA_WIDTH/8); //byteenable size
+localparam USM_AVMM_BUFFER_DEPTH = 1024;
+localparam USM_AVMM_BUFFER_SKID_SPACE = 64;
+localparam USM_AVMM_BUFFER_ALMFULL_VALUE = USM_AVMM_BUFFER_DEPTH - USM_AVMM_BUFFER_SKID_SPACE;
+
+typedef struct packed {
+    logic read, write;
+    logic [OPENCL_SVM_QSYS_ADDR_WIDTH-1:0] address;
+    logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] burstcount;
+    logic [(OPENCL_BSP_KERNEL_SVM_DATA_WIDTH/8)-1:0] byteenable;
+    logic [OPENCL_BSP_KERNEL_SVM_DATA_WIDTH-1:0] writedata;
+} usm_avmm_cmd_t;
+usm_avmm_cmd_t usm_avmm_cmd_from_kernelsystem, usm_avmm_cmd_buf_out;
+
 typedef struct packed {
     logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] burstcount;
     logic valid;
@@ -112,8 +131,14 @@ usm_avmm_buffer
 assign to_avmm_source.waitrequest = usm_avmm_buffer_almfull;
 
 always_comb begin
-    kernel_system_svm_write = usm_avmm_fifo_rd & usm_avmm_cmd_buf_out.write;
-    kernel_system_svm_read  = usm_avmm_fifo_rd & usm_avmm_cmd_buf_out.read;
+    to_avmm_sink.write = usm_avmm_fifo_rd & usm_avmm_cmd_buf_out.write;
+    to_avmm_sink.read  = usm_avmm_fifo_rd & usm_avmm_cmd_buf_out.read;
+    //higher-level interfaces don't like 'X' during simulation. Drive 0's when not driven
+    // by the kernel-system.
+    // synthesis translate off
+        to_avmm_sink.write = (usm_avmm_fifo_rd & usm_avmm_cmd_buf_out.write) === 'X ? 'b0 : kernel_system_svm_write;
+        to_avmm_sink.read  = (usm_avmm_fifo_rd & usm_avmm_cmd_buf_out.read)  === 'X ? 'b0 : kernel_system_svm_read;
+    // synthesis translate on
     
     to_avmm_sink.address    = usm_avmm_cmd_buf_out.address;
     to_avmm_sink.writedata  = usm_avmm_cmd_buf_out.writedata;

--- a/n6001/hardware/ofs_n6001_usm/build/rtl/kernel_wrapper.v
+++ b/n6001/hardware/ofs_n6001_usm/build/rtl/kernel_wrapper.v
@@ -22,6 +22,10 @@ import dc_bsp_pkg::*;
     `ifdef INCLUDE_USM_SUPPORT
         , ofs_plat_avalon_mem_if.to_sink kernel_svm
     `endif
+    `ifdef INCLUDE_UDP_OFFLOAD_ENGINE
+        ,shim_avst_if.source    udp_avst_from_kernel[IO_PIPES_NUM_CHAN-1:0],
+        shim_avst_if.sink       udp_avst_to_kernel[IO_PIPES_NUM_CHAN-1:0]
+    `endif
 );
 
 kernel_mem_intf mem_avmm_bridge [BSP_NUM_LOCAL_MEM_BANKS-1:0] ();
@@ -106,6 +110,12 @@ endgenerate
         .DATA_WIDTH (OPENCL_BSP_KERNEL_SVM_DATA_WIDTH),
         .BURST_CNT_WIDTH (OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH)
     ) svm_avmm_bridge ();
+    ofs_plat_avalon_mem_if
+    # (
+        .ADDR_WIDTH (OPENCL_SVM_QSYS_ADDR_WIDTH),
+        .DATA_WIDTH (OPENCL_BSP_KERNEL_SVM_DATA_WIDTH),
+        .BURST_CNT_WIDTH (OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH)
+    ) svm_avmm_kernelsystem ();
     
     always_comb begin
         kernel_svm.user  = 'b0;
@@ -246,354 +256,73 @@ kernel_system kernel_system_inst (
     .kernel_cra_debugaccess         (kernel_cra_avmm_bridge.kernel_cra_debugaccess)
     
     `ifdef INCLUDE_USM_SUPPORT
-        `ifdef USM_DO_SINGLE_BURST_PARTIAL_WRITES
-            ,.kernel_mem_waitrequest    (usm_avmm_buffer_almfull),
-            .kernel_mem_readdata        (svm_avmm_bridge.readdata),
-            .kernel_mem_readdatavalid   (svm_avmm_bridge.readdatavalid),
-            .kernel_mem_burstcount      (svm_avmm_bridge_burstcount),
-            .kernel_mem_writedata       (usm_avmm_cmd_from_kernelsystem.writedata),
-            .kernel_mem_address         ({svm_avmm_bridge_address,svm_addr_shift}),
-            .kernel_mem_write           (usm_avmm_cmd_from_kernelsystem.write),
-            .kernel_mem_read            (usm_avmm_cmd_from_kernelsystem.read),
-            .kernel_mem_byteenable      (usm_avmm_cmd_from_kernelsystem.byteenable)
-        `else // not USM_DO_SINGLE_BURST_PARTIAL_WRITES
-            ,.kernel_mem_waitrequest    (svm_avmm_bridge.waitrequest),
-            .kernel_mem_readdata        (svm_avmm_bridge.readdata),
-            .kernel_mem_readdatavalid   (svm_avmm_bridge.readdatavalid),
-            .kernel_mem_burstcount      (svm_avmm_bridge_burstcount),
-            .kernel_mem_writedata       (svm_avmm_bridge.writedata),
-            .kernel_mem_address         ({svm_avmm_bridge_address,svm_addr_shift}),
-            .kernel_mem_write           (kernel_system_svm_write),
-            .kernel_mem_read            (kernel_system_svm_read),
-            .kernel_mem_byteenable      (svm_avmm_bridge.byteenable)
-        `endif // USM_DO_SINGLE_BURST_PARTIAL_WRITES
+        ,.kernel_mem_waitrequest    (svm_avmm_kernelsystem.waitrequest),
+        .kernel_mem_readdata        (svm_avmm_kernelsystem.readdata),
+        .kernel_mem_readdatavalid   (svm_avmm_kernelsystem.readdatavalid),
+        .kernel_mem_burstcount      (svm_avmm_kernelsystem.burstcount),
+        .kernel_mem_writedata       (svm_avmm_kernelsystem.writedata),
+        .kernel_mem_address         ({svm_avmm_kernelsystem.address,svm_addr_shift}),
+        .kernel_mem_write           (svm_avmm_kernelsystem.write),
+        .kernel_mem_read            (svm_avmm_kernelsystem.read),
+        .kernel_mem_byteenable      (svm_avmm_kernelsystem.byteenable)
     `endif //INCLUDE_USM_SUPPORT
+    
+    `ifdef INCLUDE_UDP_OFFLOAD_ENGINE
+        ,.udp_out_valid        (udp_avst_from_kernel[0].valid),
+        .udp_out_data          (udp_avst_from_kernel[0].data),
+        .udp_out_ready         (udp_avst_from_kernel[0].ready),
+        .udp_in_valid          (udp_avst_to_kernel[0].valid),
+        .udp_in_data           (udp_avst_to_kernel[0].data),
+        .udp_in_ready          (udp_avst_to_kernel[0].ready)
+        `ifdef ASP_ENABLE_IOPIPE1
+            ,.udp_out_1_valid        (udp_avst_from_kernel[1].valid),
+            .udp_out_1_data          (udp_avst_from_kernel[1].data),
+            .udp_out_1_ready         (udp_avst_from_kernel[1].ready),
+            .udp_in_1_valid          (udp_avst_to_kernel[1].valid),
+            .udp_in_1_data           (udp_avst_to_kernel[1].data),
+            .udp_in_1_ready          (udp_avst_to_kernel[1].ready)
+        `endif //ASP_ENABLE_IOPIPE1
+        `ifdef ASP_ENABLE_IOPIPE2
+            ,.udp_out_2_valid        (udp_avst_from_kernel[2].valid),
+            .udp_out_2_data          (udp_avst_from_kernel[2].data),
+            .udp_out_2_ready         (udp_avst_from_kernel[2].ready),
+            .udp_in_2_valid          (udp_avst_to_kernel[2].valid),
+            .udp_in_2_data           (udp_avst_to_kernel[2].data),
+            .udp_in_2_ready          (udp_avst_to_kernel[2].ready)
+        `endif //ASP_ENABLE_IOPIPE2
+        `ifdef ASP_ENABLE_IOPIPE3
+            ,.udp_out_3_valid        (udp_avst_from_kernel[3].valid),
+            .udp_out_3_data          (udp_avst_from_kernel[3].data),
+            .udp_out_3_ready         (udp_avst_from_kernel[3].ready),
+            .udp_in_3_valid          (udp_avst_to_kernel[3].valid),
+            .udp_in_3_data           (udp_avst_to_kernel[3].data),
+            .udp_in_3_ready          (udp_avst_to_kernel[3].ready)
+        `endif //ASP_ENABLE_IOPIPE3
+    `endif
 );
 
 `ifdef INCLUDE_USM_SUPPORT
     `ifdef USM_DO_SINGLE_BURST_PARTIAL_WRITES
-        
-        typedef struct packed {
-            logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] burstcount;
-            logic valid;
-            logic read;
-            logic write;
-        } usm_avmm_burstcnt_t;
-        localparam USM_BCNT_DWIDTH = OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH + 1 + 1 + 1;
-        usm_avmm_burstcnt_t [1:0] usm_burstcnt;
-        usm_avmm_burstcnt_t usm_burstcnt_dout;
-        logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] current_bcnt;
-        logic [OPENCL_SVM_QSYS_ADDR_WIDTH-1:0] prev_address_plus1;
-        localparam USM_BCNT_WDOG_WIDTH = 10;
-        logic [USM_BCNT_WDOG_WIDTH-1:0] usm_burstcnt_wdog;
-        logic usm_burstcnt_buffer_full, usm_burstcnt_buffer_almfull, usm_burstcnt_buffer_empty;
-        logic [9:0] usm_burstcnt_buffer_usedw;
-        typedef enum {  ST_SET_BCNT,
-                        ST_DO_WR_BURST,
-                        XXX } usm_bcnt_st_e;
-        usm_bcnt_st_e usm_bcnt_cs, usm_bcnt_ns;
-        logic usm_bcnt_st_is_setbcnt, usm_bcnt_st_is_do_wr_burst;
-        logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] usm_avmm_fifo_rd_remaining;
-        logic usm_avmm_fifo_rd, usm_bcnt_fifo_rd;
-        logic [7:0] svm_addr_cnt;
-        
-        //Work around the PIM's partial-host-memory-write limitations
-        always_comb begin
-            usm_avmm_cmd_from_kernelsystem.address    = usm_avmm_cmd_from_kernelsystem.write ? svm_avmm_bridge_address + svm_addr_cnt : svm_avmm_bridge_address;
-            usm_avmm_cmd_from_kernelsystem.burstcount = usm_avmm_cmd_from_kernelsystem.write ? 'h1 : svm_avmm_bridge_burstcount;
-        end
-        
-        always_ff @(posedge clk or negedge reset_n) begin
-            if (!reset_n) begin
-                svm_addr_cnt <= 'h0;
-            end else begin
-                if (svm_addr_cnt == (svm_avmm_bridge_burstcount-'b1) ) begin
-                    if (usm_avmm_cmd_from_kernelsystem.write) begin
-                        svm_addr_cnt <= 'b0;
-                    end else begin
-                        svm_addr_cnt <= svm_addr_cnt;
-                    end
-                end else begin
-                    svm_addr_cnt <= svm_addr_cnt + usm_avmm_cmd_from_kernelsystem.write;
-                end
-            end
-        end
-        
-        //due to WRA I need to add a buffer here, using almost-full to generate waitrequest to kernel.
-        logic usm_avmm_buffer_full, usm_avmm_buffer_almfull, usm_avmm_buffer_empty;
-        logic [9:0] usm_avmm_buffer_usedw;
-        scfifo
-        #(
-            .lpm_numwords(USM_AVMM_BUFFER_DEPTH),
-            .lpm_showahead("ON"),
-            .lpm_type("scfifo"),
-            .lpm_width(USM_AVMM_BUFFER_WIDTH),
-            .lpm_widthu($clog2(USM_AVMM_BUFFER_DEPTH)),
-            .almost_full_value(USM_AVMM_BUFFER_ALMFULL_VALUE),
-            .overflow_checking("OFF"),
-            .underflow_checking("OFF"),
-            .use_eab("ON"),
-            .add_ram_output_register("ON")
-            )
-        usm_avmm_buffer
-        (
-            .clock(clk),
-            .sclr(!reset_n),
-    
-            .data(usm_avmm_cmd_from_kernelsystem),
-            .wrreq(usm_avmm_cmd_from_kernelsystem.write | usm_avmm_cmd_from_kernelsystem.read),
-            .full(usm_avmm_buffer_full),
-            .almost_full(usm_avmm_buffer_almfull),
-    
-            .rdreq(usm_avmm_fifo_rd),
-            .q(usm_avmm_cmd_buf_out),
-            .empty(usm_avmm_buffer_empty),
-            .almost_empty(),
-    
-            .aclr(),
-            .usedw(usm_avmm_buffer_usedw),
-            .eccstatus()
-        );
-        
-        always_comb begin
-            kernel_system_svm_write = usm_avmm_fifo_rd & usm_avmm_cmd_buf_out.write;
-            kernel_system_svm_read  = usm_avmm_fifo_rd & usm_avmm_cmd_buf_out.read;
-            
-            svm_avmm_bridge.address    = usm_avmm_cmd_buf_out.address;
-            svm_avmm_bridge.writedata  = usm_avmm_cmd_buf_out.writedata;
-            svm_avmm_bridge.burstcount = usm_avmm_cmd_buf_out.write ? usm_avmm_fifo_rd_remaining : usm_avmm_cmd_buf_out.burstcount;
-            svm_avmm_bridge.byteenable = usm_avmm_cmd_buf_out.byteenable;
-        end
-        
-        //re-create the burst-count data based on byteenable, address, and original burst-count
-        //Every partial-write (where byteenable is not all 1's) must result in be a burst-count of '1'.
-        //Other writes should be grouped together into maximal-sized bursts.
-        //
-        //
-        
-        always_ff @(posedge clk) begin
-            if (!reset_n) begin
-                usm_burstcnt <= 'h0;
-                current_bcnt <= 'h1;
-                prev_address_plus1 <= 'b0;
-                usm_burstcnt_wdog <= 'b0;
-            end else begin
-                //when tracking a write-burst, we might need to flush it out because we don't know when the
-                //write from the kernel-system is actually complete.
-                usm_burstcnt_wdog <= current_bcnt > 'h1 ? {usm_burstcnt_wdog[0 +: (USM_BCNT_WDOG_WIDTH-1)], 1'b1} : '0;
-                //push in a 0 to create a pulse for a follow-up partial write burstcount of 1
-                //it will be over-written later in the block if/when necessary.
-                usm_burstcnt[1] <= usm_burstcnt[0];
-                usm_burstcnt[0].valid <= 1'b0;
-                //if it is a read req from the kernel-system, just use that burstcount value
-                if (usm_avmm_cmd_from_kernelsystem.read) begin
-                    usm_burstcnt_wdog <= 'h0;
-                    //if we were tracking a write-burst and a read comes in, send both the write and read in order
-                    if (current_bcnt > 'h1) begin
-                        usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
-                        usm_burstcnt[1].valid <= 1'b1;
-                        usm_burstcnt[1].write <= 1'b1;
-                        usm_burstcnt[1].read <= 1'b0;
-                    end
-                    usm_burstcnt[0].burstcount <= svm_avmm_bridge_burstcount;
-                    usm_burstcnt[0].valid <= 1'b1;
-                    usm_burstcnt[0].write <= 1'b0;
-                    usm_burstcnt[0].read <= 1'b1;
-                    current_bcnt <= 'h1;
-                //if it is a write req from kernel-system, need to figure out the maximal burst
-                end else if (usm_avmm_cmd_from_kernelsystem.write) begin
-                    usm_burstcnt_wdog <= 'h0;
-                    //if original burst-cnt is 1, leave it as 1
-                    if (svm_avmm_bridge_burstcount == 'h1) begin
-                        //if need to send the previous burst, too.
-                        if (current_bcnt > 'h1) begin
-                            usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
-                            usm_burstcnt[1].valid <= 1'b1;
-                            usm_burstcnt[1].write <= 1'b1;
-                            usm_burstcnt[1].read <= 1'b0;
-                        end
-                        usm_burstcnt[0].burstcount <= 'h1;
-                        usm_burstcnt[0].valid <= 1'b1;
-                        usm_burstcnt[0].write <= 1'b1;
-                        usm_burstcnt[0].read  <= 1'b0;
-                        current_bcnt <= 'h1;
-                    //original burst-cnt is not 1; this is the first word of the burst
-                    end else if (current_bcnt == 'h1) begin
-                        if ( !(&usm_avmm_cmd_from_kernelsystem.byteenable) ) begin
-                            usm_burstcnt[0].burstcount <= 'h1;
-                            usm_burstcnt[0].valid <= 1'b1;
-                            usm_burstcnt[0].write <= 1'b1;
-                            usm_burstcnt[0].read <= 1'b0;
-                        end else begin
-                            prev_address_plus1 <= usm_avmm_cmd_from_kernelsystem.address + 'h1;
-                            current_bcnt <= 'h2;
-                        end
-                    //if continuous address
-                    end else if (prev_address_plus1 == usm_avmm_cmd_from_kernelsystem.address) begin
-                        //if partial write, send burst and singleton
-                        if ( !(&usm_avmm_cmd_from_kernelsystem.byteenable) ) begin
-                            usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
-                            usm_burstcnt[1].valid <= 1'b1;
-                            usm_burstcnt[1].write <= 1'b1;
-                            usm_burstcnt[1].read <= 1'b0;
-                            usm_burstcnt[0].burstcount <= 'h1;
-                            usm_burstcnt[0].valid <= 1'b1;
-                            usm_burstcnt[0].write <= 1'b1;
-                            usm_burstcnt[0].read <= 1'b0;
-                            current_bcnt <= 'h1;
-                        //not a partial write and not a full burst, so keep adding to burstcount
-                        end else if (current_bcnt < OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_MAX) begin
-                            current_bcnt <= current_bcnt + 'h1;
-                        //full burst, so send burst and start again
-                        end else begin
-                            usm_burstcnt[0].burstcount <= current_bcnt;
-                            usm_burstcnt[0].valid <= 1'b1;
-                            usm_burstcnt[0].write <= 1'b1;
-                            usm_burstcnt[0].read <= 1'b0;
-                            current_bcnt <= 'h1;
-                        end
-                        prev_address_plus1 <= usm_avmm_cmd_from_kernelsystem.address + 'h1;
-                    //not a continuous address, send the previous burst and start tracking the new one
-                    end else begin
-                        //if partial write, send burst and singleton
-                        if ( !(&usm_avmm_cmd_from_kernelsystem.byteenable) ) begin
-                            usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
-                            usm_burstcnt[1].valid <= 1'b1;
-                            usm_burstcnt[1].write <= 1'b1;
-                            usm_burstcnt[1].read <= 1'b0;
-                            usm_burstcnt[0].burstcount <= 'h1;
-                            usm_burstcnt[0].valid <= 1'b1;
-                            usm_burstcnt[0].write <= 1'b1;
-                            usm_burstcnt[0].read <= 1'b0;
-                            current_bcnt <= 'h1;
-                        //not partial burst, so send previous burst and continue tracking the new one
-                        end else begin
-                            usm_burstcnt[0].burstcount <= current_bcnt - 'b1;
-                            usm_burstcnt[0].valid <= 1'b1;
-                            usm_burstcnt[0].write <= 1'b1;
-                            usm_burstcnt[0].read <= 1'b0;
-                            current_bcnt <= 'h1;
-                            prev_address_plus1 <= usm_avmm_cmd_from_kernelsystem.address + 'h1;
-                        end
-                    end
-                //watchdog to flush out any final write request. 
-                end else if (&usm_burstcnt_wdog) begin
-                    usm_burstcnt[0].burstcount <= current_bcnt - 'b1;
-                    usm_burstcnt[0].valid <= 1'b1;
-                    usm_burstcnt[0].write <= 1'b1;
-                    usm_burstcnt[0].read <= 1'b0;
-                    current_bcnt <= 'h1;
-                    usm_burstcnt_wdog <= 'b0;
-                end
-            end
-        end
-        
-        //push the burst-count info into a scFIFO
-        scfifo
-        #(
-            .lpm_numwords(USM_AVMM_BUFFER_DEPTH),
-            .lpm_showahead("ON"),
-            .lpm_type("scfifo"),
-            .lpm_width(USM_BCNT_DWIDTH),
-            .lpm_widthu($clog2(USM_AVMM_BUFFER_DEPTH)),
-            .almost_full_value(USM_AVMM_BUFFER_ALMFULL_VALUE),
-            .overflow_checking("OFF"),
-            .underflow_checking("OFF"),
-            .use_eab("ON"),
-            .add_ram_output_register("ON")
-            )
-        usm_burstcnt_buffer
-        (
-            .clock(clk),
-            .sclr(!reset_n),
-    
-            .data(usm_burstcnt[1]),
-            .wrreq(usm_burstcnt[1].valid),
-            .full(usm_burstcnt_buffer_full),
-            .almost_full(usm_burstcnt_buffer_almfull),
-    
-            .rdreq(usm_bcnt_fifo_rd),
-            .q(usm_burstcnt_dout),
-            .empty(usm_burstcnt_buffer_empty),
-            .almost_empty(),
-    
-            .aclr(),
-            .usedw(usm_burstcnt_buffer_usedw),
-            .eccstatus()
-        );
-        
-        
-        //will require some state machine to track coordination of popping from the 2 FIFOs
-        // can't pop from the main FIFO until something exists in the bcnt FIFO.
-        // for each entry in the bcnt FIFO, pop that number of elements from the main FIFO.
-        // the main FIFO is populated prior to the bcnt FIFO having data, so we are guaranteed
-        //   the main FIFO will always have enough data in it to satisfy the bcnt size.
-        always_ff @(posedge clk)
-            if (!reset_n)
-                usm_bcnt_cs <= ST_SET_BCNT;
-            else
-                usm_bcnt_cs <= usm_bcnt_ns;
-        
-        always_comb begin
-            usm_bcnt_ns = XXX;
-            case (usm_bcnt_cs)
-                ST_SET_BCNT:    if (!usm_burstcnt_buffer_empty && !svm_avmm_bridge.waitrequest) begin
-                                    //if read or (bcnt == 1) stay here so we're ready 
-                                    // for the next one on the next cycle
-                                    if (usm_burstcnt_dout.read == 'b1 || 
-                                        usm_burstcnt_dout.burstcount == 'h1) begin
-                                        usm_bcnt_ns = ST_SET_BCNT;
-                                    end else begin
-                                        usm_bcnt_ns = ST_DO_WR_BURST;
-                                    end
-                                end else begin
-                                    usm_bcnt_ns = ST_SET_BCNT;
-                                end
-                                //if final word of this burst and not waitreq
-                ST_DO_WR_BURST: if (usm_avmm_fifo_rd_remaining == 'h1 && !svm_avmm_bridge.waitrequest) begin
-                                    //if there is another burst waiting to go, stay here and start new burst
-                                    if (!usm_burstcnt_buffer_empty && usm_burstcnt_dout.write == 'b1 && usm_burstcnt_dout.burstcount != 'h1) begin
-                                        usm_bcnt_ns = ST_DO_WR_BURST;
-                                    end else begin
-                                        usm_bcnt_ns = ST_SET_BCNT;
-                                    end
-                                end else begin
-                                    usm_bcnt_ns = ST_DO_WR_BURST;
-                                end
-            endcase
-        end
-        
-        assign usm_bcnt_st_is_setbcnt = usm_bcnt_cs == ST_SET_BCNT;
-        assign usm_bcnt_st_is_do_wr_burst = usm_bcnt_cs == ST_DO_WR_BURST;
-        
-        //use a counter to manage popping from the usm_avmm FIFO.
-        always_ff @(posedge clk)
-            if (!reset_n)
-                usm_avmm_fifo_rd_remaining <= 'b0;
-            else begin
-                //if burstcount fifo isn't empty and !waitreq
-                if (!usm_burstcnt_buffer_empty && !svm_avmm_bridge.waitrequest && (usm_bcnt_st_is_setbcnt || 
-                   (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) ) ) begin
-                    usm_avmm_fifo_rd_remaining <= usm_burstcnt_dout.read ? 'h1 : usm_burstcnt_dout.burstcount;
-                //pop from usm_avmm FIFO as long as the counter is non-zero and !waitreq
-                end else if (usm_avmm_fifo_rd)
-                    usm_avmm_fifo_rd_remaining <= usm_avmm_fifo_rd_remaining - 'h1;
-                else 
-                    usm_avmm_fifo_rd_remaining <= usm_avmm_fifo_rd_remaining;
-            end
-
-        //we know there is sufficient data in the usm_avmm FIFO because the bcnt FIFO isn't written-to until the 
-        // original burst has been pushed into the usm_avmm FIFO.
-        assign usm_avmm_fifo_rd = usm_avmm_fifo_rd_remaining && !svm_avmm_bridge.waitrequest;
-        //pop the next usm_bcnt value when? When it is first popped, so that the next value is already 
-        // waiting on the FIFO output when we are done with the current burst.
-        assign usm_bcnt_fifo_rd =   !usm_burstcnt_buffer_empty && !svm_avmm_bridge.waitrequest && (usm_bcnt_st_is_setbcnt || 
-                                    (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) );
-        
+        avmm_single_burst_partial_writes avmm_single_burst_partial_writes_inst
+        {
+            .clk      ,
+            .reset_n  ,
+            .avmm_to_source (svm_avmm_kernelsystem),
+            .avmm_to_sink   (svm_avmm_bridge)
+        };
     `else
+        //if not requiring partial-writes splitting, just pass the signals through
         always_comb begin
-            svm_avmm_bridge.address    = svm_avmm_bridge_address;
-            svm_avmm_bridge.burstcount = svm_avmm_bridge_burstcount;
+            svm_avmm_kernelsystem.waitrequest    = svm_avmm_bridge.waitrequest;
+            svm_avmm_kernelsystem.readdata       = svm_avmm_bridge.readdata;
+            svm_avmm_kernelsystem.readdatavalid  = svm_avmm_bridge.readdatavalid;
+            
+            svm_avmm_bridge.burstcount     = svm_avmm_kernelsystem.burstcount;
+            svm_avmm_bridge.writedata      = svm_avmm_kernelsystem.writedata ;
+            svm_avmm_bridge.address        = svm_avmm_kernelsystem.address   ;
+            svm_avmm_bridge.write          = svm_avmm_kernelsystem.write     ;
+            svm_avmm_bridge.read           = svm_avmm_kernelsystem.read      ;
+            svm_avmm_bridge.byteenable     = svm_avmm_kernelsystem.byteenable;
         end
     `endif
     

--- a/n6001/hardware/ofs_n6001_usm/build/rtl/kernel_wrapper.v
+++ b/n6001/hardware/ofs_n6001_usm/build/rtl/kernel_wrapper.v
@@ -30,7 +30,7 @@ import dc_bsp_pkg::*;
 
 kernel_mem_intf mem_avmm_bridge [BSP_NUM_LOCAL_MEM_BANKS-1:0] ();
 opencl_kernel_control_intf kernel_cra_avmm_bridge ();
-        
+
 always_comb begin
     opencl_kernel_control.kernel_irq                = kernel_cra_avmm_bridge.kernel_irq;
 end
@@ -286,8 +286,8 @@ kernel_system kernel_system_inst (
         (
             .clk      ,
             .reset_n  ,
-            .avmm_to_source (svm_avmm_kernelsystem),
-            .avmm_to_sink   (svm_avmm_bridge)
+            .to_avmm_source (svm_avmm_kernelsystem),
+            .to_avmm_sink   (svm_avmm_bridge)
         );
     `else
         //if not requiring partial-writes splitting, just pass the signals through

--- a/n6001/hardware/ofs_n6001_usm/build/rtl/kernel_wrapper.v
+++ b/n6001/hardware/ofs_n6001_usm/build/rtl/kernel_wrapper.v
@@ -81,7 +81,6 @@ endgenerate
 
 `ifdef INCLUDE_USM_SUPPORT
     logic [OPENCL_MEMORY_BYTE_OFFSET-1:0] svm_addr_shift;
-    logic kernel_system_svm_read, kernel_system_svm_write;
     
     ofs_plat_avalon_mem_if
     # (

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/bsp_design_files.tcl
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/bsp_design_files.tcl
@@ -37,6 +37,7 @@ set_global_assignment -name SYSTEMVERILOG_FILE "rtl/bsp_host_mem_if_mux.sv"
 set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_wr_ack_gen.sv"
 set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_wr_ack_burst_to_word.sv"
 set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_wr_ack_tracker.sv"
+set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_single_burst_partial_writes.sv"
 
 #--------------------
 # Search paths (for headers, etc)

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/avmm_single_burst_partial_writes.v
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/avmm_single_burst_partial_writes.v
@@ -1,0 +1,356 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: MIT
+//
+
+`include "platform_if.vh"
+`include "fpga_defines.vh"
+`include "opencl_bsp.vh"
+
+// avmm_single_burst_partial_writes
+// Split an AVMM interface's partial writes into a single partial-write and 
+//  a re-grouped burst. Handles partial writes on either/or end of the burst
+//  (start and/or end), as well as initial bursts of 1.
+
+module avmm_single_burst_partial_writes  
+import dc_bsp_pkg::*;
+(
+    input       clk,
+    input       reset_n,
+
+    ofs_plat_avalon_mem_if.to_source to_avmm_source,
+    ofs_plat_avalon_mem_if.to_sink to_avmm_sink
+);
+
+typedef struct packed {
+    logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] burstcount;
+    logic valid;
+    logic read;
+    logic write;
+} usm_avmm_burstcnt_t;
+localparam USM_BCNT_DWIDTH = OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH + 1 + 1 + 1;
+usm_avmm_burstcnt_t [1:0] usm_burstcnt;
+usm_avmm_burstcnt_t usm_burstcnt_dout;
+logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] current_bcnt;
+logic [OPENCL_SVM_QSYS_ADDR_WIDTH-1:0] prev_address_plus1;
+localparam USM_BCNT_WDOG_WIDTH = 10;
+logic [USM_BCNT_WDOG_WIDTH-1:0] usm_burstcnt_wdog;
+logic usm_burstcnt_buffer_full, usm_burstcnt_buffer_almfull, usm_burstcnt_buffer_empty;
+logic [9:0] usm_burstcnt_buffer_usedw;
+typedef enum {  ST_SET_BCNT,
+                ST_DO_WR_BURST,
+                XXX } usm_bcnt_st_e;
+usm_bcnt_st_e usm_bcnt_cs, usm_bcnt_ns;
+logic usm_bcnt_st_is_setbcnt, usm_bcnt_st_is_do_wr_burst;
+logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] usm_avmm_fifo_rd_remaining;
+logic usm_avmm_fifo_rd, usm_bcnt_fifo_rd;
+logic [7:0] svm_addr_cnt;
+
+//the readdata-path is just passed-through
+always_comb begin
+    to_avmm_source.readdata = to_avmm_sink.readdata;
+    to_avmm_source.readdatavalid = to_avmm_sink.readdatavalid;
+end
+
+always_comb begin
+    to_avmm_source.address    = to_avmm_source.write ? to_avmm_source.address + svm_addr_cnt : to_avmm_source.address;
+    to_avmm_source.burstcount = to_avmm_source.write ? 'h1 : to_avmm_source.burstcount;
+end
+
+always_ff @(posedge clk or negedge reset_n) begin
+    if (!reset_n) begin
+        svm_addr_cnt <= 'h0;
+    end else begin
+        if (svm_addr_cnt == (to_avmm_source.burstcount-'b1) ) begin
+            if (to_avmm_source.write) begin
+                svm_addr_cnt <= 'b0;
+            end else begin
+                svm_addr_cnt <= svm_addr_cnt;
+            end
+        end else begin
+            svm_addr_cnt <= svm_addr_cnt + to_avmm_source.write;
+        end
+    end
+end
+
+//due to WRA I need to add a buffer here, using almost-full to generate waitrequest to kernel.
+logic usm_avmm_buffer_full, usm_avmm_buffer_almfull, usm_avmm_buffer_empty;
+logic [9:0] usm_avmm_buffer_usedw;
+scfifo
+#(
+    .lpm_numwords(USM_AVMM_BUFFER_DEPTH),
+    .lpm_showahead("ON"),
+    .lpm_type("scfifo"),
+    .lpm_width(USM_AVMM_BUFFER_WIDTH),
+    .lpm_widthu($clog2(USM_AVMM_BUFFER_DEPTH)),
+    .almost_full_value(USM_AVMM_BUFFER_ALMFULL_VALUE),
+    .overflow_checking("OFF"),
+    .underflow_checking("OFF"),
+    .use_eab("ON"),
+    .add_ram_output_register("ON")
+    )
+usm_avmm_buffer
+(
+    .clock(clk),
+    .sclr(!reset_n),
+
+    .data(usm_avmm_cmd_from_kernelsystem),
+    .wrreq(to_avmm_source.write | to_avmm_source.read),
+    .full(usm_avmm_buffer_full),
+    .almost_full(usm_avmm_buffer_almfull),
+
+    .rdreq(usm_avmm_fifo_rd),
+    .q(usm_avmm_cmd_buf_out),
+    .empty(usm_avmm_buffer_empty),
+    .almost_empty(),
+
+    .aclr(),
+    .usedw(usm_avmm_buffer_usedw),
+    .eccstatus()
+);
+
+//waitrequest is based on the almost-full signal from the scfifo
+assign to_avmm_source.waitrequest = usm_avmm_buffer_almfull;
+
+always_comb begin
+    kernel_system_svm_write = usm_avmm_fifo_rd & usm_avmm_cmd_buf_out.write;
+    kernel_system_svm_read  = usm_avmm_fifo_rd & usm_avmm_cmd_buf_out.read;
+    
+    to_avmm_sink.address    = usm_avmm_cmd_buf_out.address;
+    to_avmm_sink.writedata  = usm_avmm_cmd_buf_out.writedata;
+    to_avmm_sink.burstcount = usm_avmm_cmd_buf_out.write ? usm_avmm_fifo_rd_remaining : usm_avmm_cmd_buf_out.burstcount;
+    to_avmm_sink.byteenable = usm_avmm_cmd_buf_out.byteenable;
+end
+
+//re-create the burst-count data based on byteenable, address, and original burst-count
+//Every partial-write (where byteenable is not all 1's) must result in be a burst-count of '1'.
+//Other writes should be grouped together into maximal-sized bursts.
+//
+//
+
+always_ff @(posedge clk) begin
+    if (!reset_n) begin
+        usm_burstcnt <= 'h0;
+        current_bcnt <= 'h1;
+        prev_address_plus1 <= 'b0;
+        usm_burstcnt_wdog <= 'b0;
+    end else begin
+        //when tracking a write-burst, we might need to flush it out because we don't know when the
+        //write from the kernel-system is actually complete.
+        usm_burstcnt_wdog <= current_bcnt > 'h1 ? {usm_burstcnt_wdog[0 +: (USM_BCNT_WDOG_WIDTH-1)], 1'b1} : '0;
+        //push in a 0 to create a pulse for a follow-up partial write burstcount of 1
+        //it will be over-written later in the block if/when necessary.
+        usm_burstcnt[1] <= usm_burstcnt[0];
+        usm_burstcnt[0].valid <= 1'b0;
+        //if it is a read req from the kernel-system, just use that burstcount value
+        if (to_avmm_source.read) begin
+            usm_burstcnt_wdog <= 'h0;
+            //if we were tracking a write-burst and a read comes in, send both the write and read in order
+            if (current_bcnt > 'h1) begin
+                usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
+                usm_burstcnt[1].valid <= 1'b1;
+                usm_burstcnt[1].write <= 1'b1;
+                usm_burstcnt[1].read <= 1'b0;
+            end
+            usm_burstcnt[0].burstcount <= to_avmm_source.burstcount;
+            usm_burstcnt[0].valid <= 1'b1;
+            usm_burstcnt[0].write <= 1'b0;
+            usm_burstcnt[0].read <= 1'b1;
+            current_bcnt <= 'h1;
+        //if it is a write req from kernel-system, need to figure out the maximal burst
+        end else if (to_avmm_source.write) begin
+            usm_burstcnt_wdog <= 'h0;
+            //if original burst-cnt is 1, leave it as 1
+            if (to_avmm_source.burstcount == 'h1) begin
+                //if need to send the previous burst, too.
+                if (current_bcnt > 'h1) begin
+                    usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
+                    usm_burstcnt[1].valid <= 1'b1;
+                    usm_burstcnt[1].write <= 1'b1;
+                    usm_burstcnt[1].read <= 1'b0;
+                end
+                usm_burstcnt[0].burstcount <= 'h1;
+                usm_burstcnt[0].valid <= 1'b1;
+                usm_burstcnt[0].write <= 1'b1;
+                usm_burstcnt[0].read  <= 1'b0;
+                current_bcnt <= 'h1;
+            //original burst-cnt is not 1; this is the first word of the burst
+            end else if (current_bcnt == 'h1) begin
+                if ( !(&to_avmm_source.byteenable) ) begin
+                    usm_burstcnt[0].burstcount <= 'h1;
+                    usm_burstcnt[0].valid <= 1'b1;
+                    usm_burstcnt[0].write <= 1'b1;
+                    usm_burstcnt[0].read <= 1'b0;
+                end else begin
+                    prev_address_plus1 <= to_avmm_source.address + 'h1;
+                    current_bcnt <= 'h2;
+                end
+            //if continuous address
+            end else if (prev_address_plus1 == to_avmm_source.address) begin
+                //if partial write, send burst and singleton
+                if ( !(&to_avmm_source.byteenable) ) begin
+                    usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
+                    usm_burstcnt[1].valid <= 1'b1;
+                    usm_burstcnt[1].write <= 1'b1;
+                    usm_burstcnt[1].read <= 1'b0;
+                    usm_burstcnt[0].burstcount <= 'h1;
+                    usm_burstcnt[0].valid <= 1'b1;
+                    usm_burstcnt[0].write <= 1'b1;
+                    usm_burstcnt[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                //not a partial write and not a full burst, so keep adding to burstcount
+                end else if (current_bcnt < OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_MAX) begin
+                    current_bcnt <= current_bcnt + 'h1;
+                //full burst, so send burst and start again
+                end else begin
+                    usm_burstcnt[0].burstcount <= current_bcnt;
+                    usm_burstcnt[0].valid <= 1'b1;
+                    usm_burstcnt[0].write <= 1'b1;
+                    usm_burstcnt[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                end
+                prev_address_plus1 <= to_avmm_source.address + 'h1;
+            //not a continuous address, send the previous burst and start tracking the new one
+            end else begin
+                //if partial write, send burst and singleton
+                if ( !(&to_avmm_source.byteenable) ) begin
+                    usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
+                    usm_burstcnt[1].valid <= 1'b1;
+                    usm_burstcnt[1].write <= 1'b1;
+                    usm_burstcnt[1].read <= 1'b0;
+                    usm_burstcnt[0].burstcount <= 'h1;
+                    usm_burstcnt[0].valid <= 1'b1;
+                    usm_burstcnt[0].write <= 1'b1;
+                    usm_burstcnt[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                //not partial burst, so send previous burst and continue tracking the new one
+                end else begin
+                    usm_burstcnt[0].burstcount <= current_bcnt - 'b1;
+                    usm_burstcnt[0].valid <= 1'b1;
+                    usm_burstcnt[0].write <= 1'b1;
+                    usm_burstcnt[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                    prev_address_plus1 <= to_avmm_source.address + 'h1;
+                end
+            end
+        //watchdog to flush out any final write request. 
+        end else if (&usm_burstcnt_wdog) begin
+            usm_burstcnt[0].burstcount <= current_bcnt - 'b1;
+            usm_burstcnt[0].valid <= 1'b1;
+            usm_burstcnt[0].write <= 1'b1;
+            usm_burstcnt[0].read <= 1'b0;
+            current_bcnt <= 'h1;
+            usm_burstcnt_wdog <= 'b0;
+        end
+    end
+end
+
+//push the burst-count info into a scFIFO
+scfifo
+#(
+    .lpm_numwords(USM_AVMM_BUFFER_DEPTH),
+    .lpm_showahead("ON"),
+    .lpm_type("scfifo"),
+    .lpm_width(USM_BCNT_DWIDTH),
+    .lpm_widthu($clog2(USM_AVMM_BUFFER_DEPTH)),
+    .almost_full_value(USM_AVMM_BUFFER_ALMFULL_VALUE),
+    .overflow_checking("OFF"),
+    .underflow_checking("OFF"),
+    .use_eab("ON"),
+    .add_ram_output_register("ON")
+    )
+usm_burstcnt_buffer
+(
+    .clock(clk),
+    .sclr(!reset_n),
+
+    .data(usm_burstcnt[1]),
+    .wrreq(usm_burstcnt[1].valid),
+    .full(usm_burstcnt_buffer_full),
+    .almost_full(usm_burstcnt_buffer_almfull),
+
+    .rdreq(usm_bcnt_fifo_rd),
+    .q(usm_burstcnt_dout),
+    .empty(usm_burstcnt_buffer_empty),
+    .almost_empty(),
+
+    .aclr(),
+    .usedw(usm_burstcnt_buffer_usedw),
+    .eccstatus()
+);
+
+
+//will require some state machine to track coordination of popping from the 2 FIFOs
+// can't pop from the main FIFO until something exists in the bcnt FIFO.
+// for each entry in the bcnt FIFO, pop that number of elements from the main FIFO.
+// the main FIFO is populated prior to the bcnt FIFO having data, so we are guaranteed
+//   the main FIFO will always have enough data in it to satisfy the bcnt size.
+always_ff @(posedge clk)
+    if (!reset_n)
+        usm_bcnt_cs <= ST_SET_BCNT;
+    else
+        usm_bcnt_cs <= usm_bcnt_ns;
+
+always_comb begin
+    usm_bcnt_ns = XXX;
+    case (usm_bcnt_cs)
+        ST_SET_BCNT:    if (!usm_burstcnt_buffer_empty && !to_avmm_sink.waitrequest) begin
+                            //if read or (bcnt == 1) stay here so we're ready 
+                            // for the next one on the next cycle
+                            if (usm_burstcnt_dout.read == 'b1 || 
+                                usm_burstcnt_dout.burstcount == 'h1) begin
+                                usm_bcnt_ns = ST_SET_BCNT;
+                            end else begin
+                                usm_bcnt_ns = ST_DO_WR_BURST;
+                            end
+                        end else begin
+                            usm_bcnt_ns = ST_SET_BCNT;
+                        end
+                        //if final word of this burst and not waitreq
+        ST_DO_WR_BURST: if (usm_avmm_fifo_rd_remaining == 'h1 && !to_avmm_sink.waitrequest) begin
+                            //if there is another burst waiting to go, stay here and start new burst
+                            if (!usm_burstcnt_buffer_empty && usm_burstcnt_dout.write == 'b1 && usm_burstcnt_dout.burstcount != 'h1) begin
+                                usm_bcnt_ns = ST_DO_WR_BURST;
+                            end else begin
+                                usm_bcnt_ns = ST_SET_BCNT;
+                            end
+                        end else begin
+                            usm_bcnt_ns = ST_DO_WR_BURST;
+                        end
+    endcase
+end
+
+assign usm_bcnt_st_is_setbcnt = usm_bcnt_cs == ST_SET_BCNT;
+assign usm_bcnt_st_is_do_wr_burst = usm_bcnt_cs == ST_DO_WR_BURST;
+
+//use a counter to manage popping from the usm_avmm FIFO.
+always_ff @(posedge clk)
+    if (!reset_n)
+        usm_avmm_fifo_rd_remaining <= 'b0;
+    else begin
+        //if burstcount fifo isn't empty and !waitreq
+        if (!usm_burstcnt_buffer_empty && !to_avmm_sink.waitrequest && (usm_bcnt_st_is_setbcnt || 
+           (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) ) ) begin
+            usm_avmm_fifo_rd_remaining <= usm_burstcnt_dout.read ? 'h1 : usm_burstcnt_dout.burstcount;
+        //pop from usm_avmm FIFO as long as the counter is non-zero and !waitreq
+        end else if (usm_avmm_fifo_rd)
+            usm_avmm_fifo_rd_remaining <= usm_avmm_fifo_rd_remaining - 'h1;
+        else 
+            usm_avmm_fifo_rd_remaining <= usm_avmm_fifo_rd_remaining;
+    end
+
+//we know there is sufficient data in the usm_avmm FIFO because the bcnt FIFO isn't written-to until the 
+// original burst has been pushed into the usm_avmm FIFO.
+assign usm_avmm_fifo_rd = usm_avmm_fifo_rd_remaining && !to_avmm_sink.waitrequest;
+//pop the next usm_bcnt value when? When it is first popped, so that the next value is already 
+// waiting on the FIFO output when we are done with the current burst.
+assign usm_bcnt_fifo_rd =   !usm_burstcnt_buffer_empty && !to_avmm_sink.waitrequest && (usm_bcnt_st_is_setbcnt || 
+                            (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) );
+
+    //`else
+    //    always_comb begin
+    //        to_avmm_sink.address    = to_avmm_source.address;
+    //        to_avmm_sink.burstcount = to_avmm_source.burstcount;
+    //    end
+    //`endif
+    
+endmodule : avmm_single_burst_partial_writes

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/kernel_wrapper.v
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/kernel_wrapper.v
@@ -286,8 +286,8 @@ kernel_system kernel_system_inst (
         (
             .clk      ,
             .reset_n  ,
-            .avmm_to_source (svm_avmm_kernelsystem),
-            .avmm_to_sink   (svm_avmm_bridge)
+            .to_avmm_source (svm_avmm_kernelsystem),
+            .to_avmm_sink   (svm_avmm_bridge)
         );
     `else
         //if not requiring partial-writes splitting, just pass the signals through

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/kernel_wrapper.v
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/kernel_wrapper.v
@@ -110,6 +110,12 @@ endgenerate
         .DATA_WIDTH (OPENCL_BSP_KERNEL_SVM_DATA_WIDTH),
         .BURST_CNT_WIDTH (OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH)
     ) svm_avmm_bridge ();
+    ofs_plat_avalon_mem_if
+    # (
+        .ADDR_WIDTH (OPENCL_SVM_QSYS_ADDR_WIDTH),
+        .DATA_WIDTH (OPENCL_BSP_KERNEL_SVM_DATA_WIDTH),
+        .BURST_CNT_WIDTH (OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH)
+    ) svm_avmm_kernelsystem ();
     
     always_comb begin
         kernel_svm.user  = 'b0;
@@ -250,28 +256,17 @@ kernel_system kernel_system_inst (
     .kernel_cra_debugaccess         (kernel_cra_avmm_bridge.kernel_cra_debugaccess)
     
     `ifdef INCLUDE_USM_SUPPORT
-        `ifdef USM_DO_SINGLE_BURST_PARTIAL_WRITES
-            ,.kernel_mem_waitrequest    (usm_avmm_buffer_almfull),
-            .kernel_mem_readdata        (svm_avmm_bridge.readdata),
-            .kernel_mem_readdatavalid   (svm_avmm_bridge.readdatavalid),
-            .kernel_mem_burstcount      (svm_avmm_bridge_burstcount),
-            .kernel_mem_writedata       (usm_avmm_cmd_from_kernelsystem.writedata),
-            .kernel_mem_address         ({svm_avmm_bridge_address,svm_addr_shift}),
-            .kernel_mem_write           (usm_avmm_cmd_from_kernelsystem.write),
-            .kernel_mem_read            (usm_avmm_cmd_from_kernelsystem.read),
-            .kernel_mem_byteenable      (usm_avmm_cmd_from_kernelsystem.byteenable)
-        `else // not USM_DO_SINGLE_BURST_PARTIAL_WRITES
-            ,.kernel_mem_waitrequest    (svm_avmm_bridge.waitrequest),
-            .kernel_mem_readdata        (svm_avmm_bridge.readdata),
-            .kernel_mem_readdatavalid   (svm_avmm_bridge.readdatavalid),
-            .kernel_mem_burstcount      (svm_avmm_bridge_burstcount),
-            .kernel_mem_writedata       (svm_avmm_bridge.writedata),
-            .kernel_mem_address         ({svm_avmm_bridge_address,svm_addr_shift}),
-            .kernel_mem_write           (kernel_system_svm_write),
-            .kernel_mem_read            (kernel_system_svm_read),
-            .kernel_mem_byteenable      (svm_avmm_bridge.byteenable)
-        `endif // USM_DO_SINGLE_BURST_PARTIAL_WRITES
+        ,.kernel_mem_waitrequest    (svm_avmm_kernelsystem.waitrequest),
+        .kernel_mem_readdata        (svm_avmm_kernelsystem.readdata),
+        .kernel_mem_readdatavalid   (svm_avmm_kernelsystem.readdatavalid),
+        .kernel_mem_burstcount      (svm_avmm_kernelsystem.burstcount),
+        .kernel_mem_writedata       (svm_avmm_kernelsystem.writedata),
+        .kernel_mem_address         ({svm_avmm_kernelsystem.address,svm_addr_shift}),
+        .kernel_mem_write           (svm_avmm_kernelsystem.write),
+        .kernel_mem_read            (svm_avmm_kernelsystem.read),
+        .kernel_mem_byteenable      (svm_avmm_kernelsystem.byteenable)
     `endif //INCLUDE_USM_SUPPORT
+    
     `ifdef INCLUDE_UDP_OFFLOAD_ENGINE
         ,.udp_out_valid        (udp_avst_from_kernel[0].valid),
         .udp_out_data          (udp_avst_from_kernel[0].data),
@@ -308,328 +303,26 @@ kernel_system kernel_system_inst (
 
 `ifdef INCLUDE_USM_SUPPORT
     `ifdef USM_DO_SINGLE_BURST_PARTIAL_WRITES
-        
-        typedef struct packed {
-            logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] burstcount;
-            logic valid;
-            logic read;
-            logic write;
-        } usm_avmm_burstcnt_t;
-        localparam USM_BCNT_DWIDTH = OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH + 1 + 1 + 1;
-        usm_avmm_burstcnt_t [1:0] usm_burstcnt;
-        usm_avmm_burstcnt_t usm_burstcnt_dout;
-        logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] current_bcnt;
-        logic [OPENCL_SVM_QSYS_ADDR_WIDTH-1:0] prev_address_plus1;
-        localparam USM_BCNT_WDOG_WIDTH = 10;
-        logic [USM_BCNT_WDOG_WIDTH-1:0] usm_burstcnt_wdog;
-        logic usm_burstcnt_buffer_full, usm_burstcnt_buffer_almfull, usm_burstcnt_buffer_empty;
-        logic [9:0] usm_burstcnt_buffer_usedw;
-        typedef enum {  ST_SET_BCNT,
-                        ST_DO_WR_BURST,
-                        XXX } usm_bcnt_st_e;
-        usm_bcnt_st_e usm_bcnt_cs, usm_bcnt_ns;
-        logic usm_bcnt_st_is_setbcnt, usm_bcnt_st_is_do_wr_burst;
-        logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] usm_avmm_fifo_rd_remaining;
-        logic usm_avmm_fifo_rd, usm_bcnt_fifo_rd;
-        logic [7:0] svm_addr_cnt;
-        
-        //Work around the PIM's partial-host-memory-write limitations
-        always_comb begin
-            usm_avmm_cmd_from_kernelsystem.address    = usm_avmm_cmd_from_kernelsystem.write ? svm_avmm_bridge_address + svm_addr_cnt : svm_avmm_bridge_address;
-            usm_avmm_cmd_from_kernelsystem.burstcount = usm_avmm_cmd_from_kernelsystem.write ? 'h1 : svm_avmm_bridge_burstcount;
-        end
-        
-        always_ff @(posedge clk or negedge reset_n) begin
-            if (!reset_n) begin
-                svm_addr_cnt <= 'h0;
-            end else begin
-                if (svm_addr_cnt == (svm_avmm_bridge_burstcount-'b1) ) begin
-                    if (usm_avmm_cmd_from_kernelsystem.write) begin
-                        svm_addr_cnt <= 'b0;
-                    end else begin
-                        svm_addr_cnt <= svm_addr_cnt;
-                    end
-                end else begin
-                    svm_addr_cnt <= svm_addr_cnt + usm_avmm_cmd_from_kernelsystem.write;
-                end
-            end
-        end
-        
-        //due to WRA I need to add a buffer here, using almost-full to generate waitrequest to kernel.
-        logic usm_avmm_buffer_full, usm_avmm_buffer_almfull, usm_avmm_buffer_empty;
-        logic [9:0] usm_avmm_buffer_usedw;
-        scfifo
-        #(
-            .lpm_numwords(USM_AVMM_BUFFER_DEPTH),
-            .lpm_showahead("ON"),
-            .lpm_type("scfifo"),
-            .lpm_width(USM_AVMM_BUFFER_WIDTH),
-            .lpm_widthu($clog2(USM_AVMM_BUFFER_DEPTH)),
-            .almost_full_value(USM_AVMM_BUFFER_ALMFULL_VALUE),
-            .overflow_checking("OFF"),
-            .underflow_checking("OFF"),
-            .use_eab("ON"),
-            .add_ram_output_register("ON")
-            )
-        usm_avmm_buffer
-        (
-            .clock(clk),
-            .sclr(!reset_n),
-    
-            .data(usm_avmm_cmd_from_kernelsystem),
-            .wrreq(usm_avmm_cmd_from_kernelsystem.write | usm_avmm_cmd_from_kernelsystem.read),
-            .full(usm_avmm_buffer_full),
-            .almost_full(usm_avmm_buffer_almfull),
-    
-            .rdreq(usm_avmm_fifo_rd),
-            .q(usm_avmm_cmd_buf_out),
-            .empty(usm_avmm_buffer_empty),
-            .almost_empty(),
-    
-            .aclr(),
-            .usedw(usm_avmm_buffer_usedw),
-            .eccstatus()
-        );
-        
-        always_comb begin
-            kernel_system_svm_write = usm_avmm_fifo_rd & usm_avmm_cmd_buf_out.write;
-            kernel_system_svm_read  = usm_avmm_fifo_rd & usm_avmm_cmd_buf_out.read;
-            
-            svm_avmm_bridge.address    = usm_avmm_cmd_buf_out.address;
-            svm_avmm_bridge.writedata  = usm_avmm_cmd_buf_out.writedata;
-            svm_avmm_bridge.burstcount = usm_avmm_cmd_buf_out.write ? usm_avmm_fifo_rd_remaining : usm_avmm_cmd_buf_out.burstcount;
-            svm_avmm_bridge.byteenable = usm_avmm_cmd_buf_out.byteenable;
-        end
-        
-        //re-create the burst-count data based on byteenable, address, and original burst-count
-        //Every partial-write (where byteenable is not all 1's) must result in be a burst-count of '1'.
-        //Other writes should be grouped together into maximal-sized bursts.
-        //
-        //
-        
-        always_ff @(posedge clk) begin
-            if (!reset_n) begin
-                usm_burstcnt <= 'h0;
-                current_bcnt <= 'h1;
-                prev_address_plus1 <= 'b0;
-                usm_burstcnt_wdog <= 'b0;
-            end else begin
-                //when tracking a write-burst, we might need to flush it out because we don't know when the
-                //write from the kernel-system is actually complete.
-                usm_burstcnt_wdog <= current_bcnt > 'h1 ? {usm_burstcnt_wdog[0 +: (USM_BCNT_WDOG_WIDTH-1)], 1'b1} : '0;
-                //push in a 0 to create a pulse for a follow-up partial write burstcount of 1
-                //it will be over-written later in the block if/when necessary.
-                usm_burstcnt[1] <= usm_burstcnt[0];
-                usm_burstcnt[0].valid <= 1'b0;
-                //if it is a read req from the kernel-system, just use that burstcount value
-                if (usm_avmm_cmd_from_kernelsystem.read) begin
-                    usm_burstcnt_wdog <= 'h0;
-                    //if we were tracking a write-burst and a read comes in, send both the write and read in order
-                    if (current_bcnt > 'h1) begin
-                        usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
-                        usm_burstcnt[1].valid <= 1'b1;
-                        usm_burstcnt[1].write <= 1'b1;
-                        usm_burstcnt[1].read <= 1'b0;
-                    end
-                    usm_burstcnt[0].burstcount <= svm_avmm_bridge_burstcount;
-                    usm_burstcnt[0].valid <= 1'b1;
-                    usm_burstcnt[0].write <= 1'b0;
-                    usm_burstcnt[0].read <= 1'b1;
-                    current_bcnt <= 'h1;
-                //if it is a write req from kernel-system, need to figure out the maximal burst
-                end else if (usm_avmm_cmd_from_kernelsystem.write) begin
-                    usm_burstcnt_wdog <= 'h0;
-                    //if original burst-cnt is 1, leave it as 1
-                    if (svm_avmm_bridge_burstcount == 'h1) begin
-                        //if need to send the previous burst, too.
-                        if (current_bcnt > 'h1) begin
-                            usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
-                            usm_burstcnt[1].valid <= 1'b1;
-                            usm_burstcnt[1].write <= 1'b1;
-                            usm_burstcnt[1].read <= 1'b0;
-                        end
-                        usm_burstcnt[0].burstcount <= 'h1;
-                        usm_burstcnt[0].valid <= 1'b1;
-                        usm_burstcnt[0].write <= 1'b1;
-                        usm_burstcnt[0].read  <= 1'b0;
-                        current_bcnt <= 'h1;
-                    //original burst-cnt is not 1; this is the first word of the burst
-                    end else if (current_bcnt == 'h1) begin
-                        if ( !(&usm_avmm_cmd_from_kernelsystem.byteenable) ) begin
-                            usm_burstcnt[0].burstcount <= 'h1;
-                            usm_burstcnt[0].valid <= 1'b1;
-                            usm_burstcnt[0].write <= 1'b1;
-                            usm_burstcnt[0].read <= 1'b0;
-                        end else begin
-                            prev_address_plus1 <= usm_avmm_cmd_from_kernelsystem.address + 'h1;
-                            current_bcnt <= 'h2;
-                        end
-                    //if continuous address
-                    end else if (prev_address_plus1 == usm_avmm_cmd_from_kernelsystem.address) begin
-                        //if partial write, send burst and singleton
-                        if ( !(&usm_avmm_cmd_from_kernelsystem.byteenable) ) begin
-                            usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
-                            usm_burstcnt[1].valid <= 1'b1;
-                            usm_burstcnt[1].write <= 1'b1;
-                            usm_burstcnt[1].read <= 1'b0;
-                            usm_burstcnt[0].burstcount <= 'h1;
-                            usm_burstcnt[0].valid <= 1'b1;
-                            usm_burstcnt[0].write <= 1'b1;
-                            usm_burstcnt[0].read <= 1'b0;
-                            current_bcnt <= 'h1;
-                        //not a partial write and not a full burst, so keep adding to burstcount
-                        end else if (current_bcnt < OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_MAX) begin
-                            current_bcnt <= current_bcnt + 'h1;
-                        //full burst, so send burst and start again
-                        end else begin
-                            usm_burstcnt[0].burstcount <= current_bcnt;
-                            usm_burstcnt[0].valid <= 1'b1;
-                            usm_burstcnt[0].write <= 1'b1;
-                            usm_burstcnt[0].read <= 1'b0;
-                            current_bcnt <= 'h1;
-                        end
-                        prev_address_plus1 <= usm_avmm_cmd_from_kernelsystem.address + 'h1;
-                    //not a continuous address, send the previous burst and start tracking the new one
-                    end else begin
-                        //if partial write, send burst and singleton
-                        if ( !(&usm_avmm_cmd_from_kernelsystem.byteenable) ) begin
-                            usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
-                            usm_burstcnt[1].valid <= 1'b1;
-                            usm_burstcnt[1].write <= 1'b1;
-                            usm_burstcnt[1].read <= 1'b0;
-                            usm_burstcnt[0].burstcount <= 'h1;
-                            usm_burstcnt[0].valid <= 1'b1;
-                            usm_burstcnt[0].write <= 1'b1;
-                            usm_burstcnt[0].read <= 1'b0;
-                            current_bcnt <= 'h1;
-                        //not partial burst, so send previous burst and continue tracking the new one
-                        end else begin
-                            usm_burstcnt[0].burstcount <= current_bcnt - 'b1;
-                            usm_burstcnt[0].valid <= 1'b1;
-                            usm_burstcnt[0].write <= 1'b1;
-                            usm_burstcnt[0].read <= 1'b0;
-                            current_bcnt <= 'h1;
-                            prev_address_plus1 <= usm_avmm_cmd_from_kernelsystem.address + 'h1;
-                        end
-                    end
-                //watchdog to flush out any final write request. 
-                end else if (&usm_burstcnt_wdog) begin
-                    usm_burstcnt[0].burstcount <= current_bcnt - 'b1;
-                    usm_burstcnt[0].valid <= 1'b1;
-                    usm_burstcnt[0].write <= 1'b1;
-                    usm_burstcnt[0].read <= 1'b0;
-                    current_bcnt <= 'h1;
-                    usm_burstcnt_wdog <= 'b0;
-                end
-            end
-        end
-        
-        //push the burst-count info into a scFIFO
-        scfifo
-        #(
-            .lpm_numwords(USM_AVMM_BUFFER_DEPTH),
-            .lpm_showahead("ON"),
-            .lpm_type("scfifo"),
-            .lpm_width(USM_BCNT_DWIDTH),
-            .lpm_widthu($clog2(USM_AVMM_BUFFER_DEPTH)),
-            .almost_full_value(USM_AVMM_BUFFER_ALMFULL_VALUE),
-            .overflow_checking("OFF"),
-            .underflow_checking("OFF"),
-            .use_eab("ON"),
-            .add_ram_output_register("ON")
-            )
-        usm_burstcnt_buffer
-        (
-            .clock(clk),
-            .sclr(!reset_n),
-    
-            .data(usm_burstcnt[1]),
-            .wrreq(usm_burstcnt[1].valid),
-            .full(usm_burstcnt_buffer_full),
-            .almost_full(usm_burstcnt_buffer_almfull),
-    
-            .rdreq(usm_bcnt_fifo_rd),
-            .q(usm_burstcnt_dout),
-            .empty(usm_burstcnt_buffer_empty),
-            .almost_empty(),
-    
-            .aclr(),
-            .usedw(usm_burstcnt_buffer_usedw),
-            .eccstatus()
-        );
-        
-        
-        //will require some state machine to track coordination of popping from the 2 FIFOs
-        // can't pop from the main FIFO until something exists in the bcnt FIFO.
-        // for each entry in the bcnt FIFO, pop that number of elements from the main FIFO.
-        // the main FIFO is populated prior to the bcnt FIFO having data, so we are guaranteed
-        //   the main FIFO will always have enough data in it to satisfy the bcnt size.
-        always_ff @(posedge clk)
-            if (!reset_n)
-                usm_bcnt_cs <= ST_SET_BCNT;
-            else
-                usm_bcnt_cs <= usm_bcnt_ns;
-        
-        always_comb begin
-            usm_bcnt_ns = XXX;
-            case (usm_bcnt_cs)
-                ST_SET_BCNT:    if (!usm_burstcnt_buffer_empty && !svm_avmm_bridge.waitrequest) begin
-                                    //if read or (bcnt == 1) stay here so we're ready 
-                                    // for the next one on the next cycle
-                                    if (usm_burstcnt_dout.read == 'b1 || 
-                                        usm_burstcnt_dout.burstcount == 'h1) begin
-                                        usm_bcnt_ns = ST_SET_BCNT;
-                                    end else begin
-                                        usm_bcnt_ns = ST_DO_WR_BURST;
-                                    end
-                                end else begin
-                                    usm_bcnt_ns = ST_SET_BCNT;
-                                end
-                                //if final word of this burst and not waitreq
-                ST_DO_WR_BURST: if (usm_avmm_fifo_rd_remaining == 'h1 && !svm_avmm_bridge.waitrequest) begin
-                                    //if there is another burst waiting to go, stay here and start new burst
-                                    if (!usm_burstcnt_buffer_empty && usm_burstcnt_dout.write == 'b1 && usm_burstcnt_dout.burstcount != 'h1) begin
-                                        usm_bcnt_ns = ST_DO_WR_BURST;
-                                    end else begin
-                                        usm_bcnt_ns = ST_SET_BCNT;
-                                    end
-                                end else begin
-                                    usm_bcnt_ns = ST_DO_WR_BURST;
-                                end
-            endcase
-        end
-        
-        assign usm_bcnt_st_is_setbcnt = usm_bcnt_cs == ST_SET_BCNT;
-        assign usm_bcnt_st_is_do_wr_burst = usm_bcnt_cs == ST_DO_WR_BURST;
-        
-        //use a counter to manage popping from the usm_avmm FIFO.
-        always_ff @(posedge clk)
-            if (!reset_n)
-                usm_avmm_fifo_rd_remaining <= 'b0;
-            else begin
-                //if burstcount fifo isn't empty and !waitreq
-                if (!usm_burstcnt_buffer_empty && !svm_avmm_bridge.waitrequest && (usm_bcnt_st_is_setbcnt || 
-                   (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) ) ) begin
-                    usm_avmm_fifo_rd_remaining <= usm_burstcnt_dout.read ? 'h1 : usm_burstcnt_dout.burstcount;
-                //pop from usm_avmm FIFO as long as the counter is non-zero and !waitreq
-                end else if (usm_avmm_fifo_rd)
-                    usm_avmm_fifo_rd_remaining <= usm_avmm_fifo_rd_remaining - 'h1;
-                else 
-                    usm_avmm_fifo_rd_remaining <= usm_avmm_fifo_rd_remaining;
-            end
-
-        //we know there is sufficient data in the usm_avmm FIFO because the bcnt FIFO isn't written-to until the 
-        // original burst has been pushed into the usm_avmm FIFO.
-        assign usm_avmm_fifo_rd = usm_avmm_fifo_rd_remaining && !svm_avmm_bridge.waitrequest;
-        //pop the next usm_bcnt value when? When it is first popped, so that the next value is already 
-        // waiting on the FIFO output when we are done with the current burst.
-        assign usm_bcnt_fifo_rd =   !usm_burstcnt_buffer_empty && !svm_avmm_bridge.waitrequest && (usm_bcnt_st_is_setbcnt || 
-                                    (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) );
-        
+        avmm_single_burst_partial_writes avmm_single_burst_partial_writes_inst
+        {
+            .clk      ,
+            .reset_n  ,
+            .avmm_to_source (svm_avmm_kernelsystem),
+            .avmm_to_sink   (svm_avmm_bridge)
+        };
     `else
+        //if not requiring partial-writes splitting, just pass the signals through
         always_comb begin
-            svm_avmm_bridge.address    = svm_avmm_bridge_address;
-            svm_avmm_bridge.burstcount = svm_avmm_bridge_burstcount;
+            svm_avmm_kernelsystem.waitrequest    = svm_avmm_bridge.waitrequest;
+            svm_avmm_kernelsystem.readdata       = svm_avmm_bridge.readdata;
+            svm_avmm_kernelsystem.readdatavalid  = svm_avmm_bridge.readdatavalid;
+            
+            svm_avmm_bridge.burstcount     = svm_avmm_kernelsystem.burstcount;
+            svm_avmm_bridge.writedata      = svm_avmm_kernelsystem.writedata ;
+            svm_avmm_bridge.address        = svm_avmm_kernelsystem.address   ;
+            svm_avmm_bridge.write          = svm_avmm_kernelsystem.write     ;
+            svm_avmm_bridge.read           = svm_avmm_kernelsystem.read      ;
+            svm_avmm_bridge.byteenable     = svm_avmm_kernelsystem.byteenable;
         end
     `endif
     

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/kernel_wrapper.v
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/kernel_wrapper.v
@@ -30,28 +30,7 @@ import dc_bsp_pkg::*;
 
 kernel_mem_intf mem_avmm_bridge [BSP_NUM_LOCAL_MEM_BANKS-1:0] ();
 opencl_kernel_control_intf kernel_cra_avmm_bridge ();
-logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] svm_avmm_bridge_burstcount;
-logic [OPENCL_SVM_QSYS_ADDR_WIDTH-1:0] svm_avmm_bridge_address;
 
-localparam USM_AVMM_BUFFER_WIDTH =  OPENCL_SVM_QSYS_ADDR_WIDTH +
-                                    OPENCL_BSP_KERNEL_SVM_DATA_WIDTH +
-                                    OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH +
-                                    1 + //write req
-                                    1 + //read req
-                                    (OPENCL_BSP_KERNEL_SVM_DATA_WIDTH/8); //byteenable size
-localparam USM_AVMM_BUFFER_DEPTH = 1024;
-localparam USM_AVMM_BUFFER_SKID_SPACE = 64;
-localparam USM_AVMM_BUFFER_ALMFULL_VALUE = USM_AVMM_BUFFER_DEPTH - USM_AVMM_BUFFER_SKID_SPACE;
-
-typedef struct packed {
-    logic read, write;
-    logic [OPENCL_SVM_QSYS_ADDR_WIDTH-1:0] address;
-    logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] burstcount;
-    logic [(OPENCL_BSP_KERNEL_SVM_DATA_WIDTH/8)-1:0] byteenable;
-    logic [OPENCL_BSP_KERNEL_SVM_DATA_WIDTH-1:0] writedata;
-} usm_avmm_cmd_t;
-usm_avmm_cmd_t usm_avmm_cmd_from_kernelsystem, usm_avmm_cmd_buf_out;
-        
 always_comb begin
     opencl_kernel_control.kernel_irq                = kernel_cra_avmm_bridge.kernel_irq;
 end
@@ -304,12 +283,12 @@ kernel_system kernel_system_inst (
 `ifdef INCLUDE_USM_SUPPORT
     `ifdef USM_DO_SINGLE_BURST_PARTIAL_WRITES
         avmm_single_burst_partial_writes avmm_single_burst_partial_writes_inst
-        {
+        (
             .clk      ,
             .reset_n  ,
             .avmm_to_source (svm_avmm_kernelsystem),
             .avmm_to_sink   (svm_avmm_bridge)
-        };
+        );
     `else
         //if not requiring partial-writes splitting, just pass the signals through
         always_comb begin
@@ -320,24 +299,18 @@ kernel_system kernel_system_inst (
             svm_avmm_bridge.burstcount     = svm_avmm_kernelsystem.burstcount;
             svm_avmm_bridge.writedata      = svm_avmm_kernelsystem.writedata ;
             svm_avmm_bridge.address        = svm_avmm_kernelsystem.address   ;
+            svm_avmm_bridge.byteenable     = svm_avmm_kernelsystem.byteenable;
             svm_avmm_bridge.write          = svm_avmm_kernelsystem.write     ;
             svm_avmm_bridge.read           = svm_avmm_kernelsystem.read      ;
-            svm_avmm_bridge.byteenable     = svm_avmm_kernelsystem.byteenable;
+            // Higher-level interfaces don't like 'X' during simulation. Drive 0's when not 
+            // driven by the kernel-system.
+            //drive with the modified version during simulation
+            // synthesis translate off
+                svm_avmm_bridge.write = svm_avmm_kernelsystem.write === 'X ? 'b0 : svm_avmm_kernelsystem.write;
+                svm_avmm_bridge.read  = svm_avmm_kernelsystem.read  === 'X ? 'b0 : svm_avmm_kernelsystem.read;
+            // synthesis translate on
         end
     `endif
-    
-    // Higher-level interfaces don't like 'X' during simulation. Drive 0's when not 
-    // driven by the kernel-system.
-    always_comb begin
-        //drive with the value from the kernel-system by default
-        svm_avmm_bridge.write = kernel_system_svm_write;
-        svm_avmm_bridge.read  = kernel_system_svm_read;
-        //drive with the modified version during simulation
-    // synthesis translate off
-        svm_avmm_bridge.write = kernel_system_svm_write === 'X ? 'b0 : kernel_system_svm_write;
-        svm_avmm_bridge.read  = kernel_system_svm_read  === 'X ? 'b0 : kernel_system_svm_read;
-    // synthesis translate on
-    end
 `endif
 
 endmodule : kernel_wrapper

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/kernel_wrapper.v
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/kernel_wrapper.v
@@ -81,7 +81,6 @@ endgenerate
 
 `ifdef INCLUDE_USM_SUPPORT
     logic [OPENCL_MEMORY_BYTE_OFFSET-1:0] svm_addr_shift;
-    logic kernel_system_svm_read, kernel_system_svm_write;
     
     ofs_plat_avalon_mem_if
     # (


### PR DESCRIPTION
Rather than clutter kernel-wrapper with the logic to handle USM burst-splitting, move it into a separate block.