### PR TITLE
Preserve the FIM programming files in each variant folder

### DIFF
--- a/d5005/scripts/setup-bsp.py
+++ b/d5005/scripts/setup-bsp.py
@@ -135,8 +135,9 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
 
     libopae_c_root_dir = env_vars["LIBOPAE_C_ROOT"]
     packager_bin = get_packager_bin(libopae_c_root_dir)
-    deliverable_dir = env_vars["OPAE_PLATFORM_ROOT"]
+    deliverable_dir = env_vars["OPAE_PLATFORM_ROOT"].rstrip("/")
     deliverable_hw_dir = os.path.join(deliverable_dir, 'hw')
+    deliverable_bluebits_dir = os.path.join(deliverable_hw_dir, 'blue_bits')
     deliverable_hwlib_dir = os.path.join(deliverable_hw_dir, 'lib')
     intel_fpga_bbb_dir = env_vars["INTEL_FPGA_BBB"]
 
@@ -149,12 +150,16 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     bsp_dir = os.path.join(bsp_root,"hardware",bsp)
     bsp_qsf_dir = os.path.join(bsp_dir, 'build')
 
-    print("bsp_qsf_dir is %s\n" % bsp_qsf_dir)
+    print("bsp_dir is %s\n" % bsp_dir)
     
     #preserve the pr-build-template folder
     delete_and_mkdir(os.path.join(bsp_dir, '../../pr_build_template'))
     copy_glob(deliverable_dir, os.path.join(bsp_dir, '../../'),verbose)
 
+    #preserve the blue_bits folder from $OPAE_PLATFORM_ROOT/hw/
+    delete_and_mkdir(os.path.join(bsp_dir, 'blue_bits'))
+    copy_glob(deliverable_bluebits_dir, bsp_dir, verbose)
+    
     # copy the FIM FME information text files
     copy_glob(os.path.join(deliverable_hwlib_dir, 'fme*.txt'), bsp_qsf_dir, verbose)
     

--- a/n6001/scripts/setup-bsp.py
+++ b/n6001/scripts/setup-bsp.py
@@ -137,6 +137,7 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     packager_bin = get_packager_bin(libopae_c_root_dir)
     deliverable_dir = env_vars["OPAE_PLATFORM_ROOT"].rstrip("/")
     deliverable_hw_dir = os.path.join(deliverable_dir, 'hw')
+    deliverable_bluebits_dir = os.path.join(deliverable_hw_dir, 'blue_bits')
     deliverable_hwlib_dir = os.path.join(deliverable_hw_dir, 'lib')
     intel_fpga_bbb_dir = env_vars["INTEL_FPGA_BBB"]
 
@@ -154,6 +155,10 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     #preserve the pr-build-template folder
     delete_and_mkdir(os.path.join(bsp_dir, '../../pr_build_template'))
     copy_glob(deliverable_dir, os.path.join(bsp_dir, '../../'),verbose)
+    
+    #preserve the blue_bits folder from $OPAE_PLATFORM_ROOT/hw/
+    delete_and_mkdir(os.path.join(bsp_dir, 'blue_bits'))
+    copy_glob(deliverable_bluebits_dir, bsp_dir, verbose)
     
     # copy the FIM FME information text files
     copy_glob(os.path.join(deliverable_hwlib_dir, 'fme*.txt'), bsp_qsf_dir, verbose)


### PR DESCRIPTION
The pr-build-template folder is huge, but we really only need/want the blue_bits subfolder (~45MB) which contains the FIM's programming files. I'm leaving the pr-build-template copy in for now, but will eventually remove it and we'll be left with just the blue_bits folder in each variant. This allows different variants to use different FIMs.
Ran build-bsp.sh multiple times in the same place - the blue_bits folder get replaced each time the command is executed. 