### PR TITLE
Moved comments such that they can be enabled by debug env variables (missed some in previous merge)

### DIFF
--- a/common/source/host/mmd_device.cpp
+++ b/common/source/host/mmd_device.cpp
@@ -522,7 +522,9 @@ bool Device::initialize_bsp() {
    */
   bool iopipes_enabled = find_iopipes_dfh_offsets();
   if(!diagnose && iopipes_enabled) {
-    DEBUG_LOG("DEBUG LOG : IO Pipes are enabled\n");
+    if(std::getenv("MMD_ENABLE_DEBUG")){
+      DEBUG_LOG("DEBUG LOG : IO Pipes are enabled\n");
+    }
     std::string local_ip_address;
     std::string local_mac_address;
     std::string local_netmask;
@@ -580,7 +582,9 @@ bool Device::initialize_bsp() {
       return false;   
     }
 
-    DEBUG_LOG("DEBUG LOG : Creating iopipes object and setting up iopipes\n");
+    if(std::getenv("MMD_ENABLE_DEBUG")){
+      DEBUG_LOG("DEBUG LOG : Creating iopipes object and setting up iopipes\n");
+    }
     io_pipes = new iopipes(mmd_handle, local_ip_address, local_mac_address, local_netmask, local_udp_port, remote_ip_address, remote_mac_address, remote_udp_port, iopipes_dfh_offset);
     if(!(io_pipes->setup_iopipes_asp(mmio_handle))){
       return false;

--- a/common/source/host/mmd_iopipes.cpp
+++ b/common/source/host/mmd_iopipes.cpp
@@ -74,7 +74,6 @@ bool iopipes::setup_iopipes_asp(fpga_handle afc_handle)
   if(std::getenv("MMD_ENABLE_DEBUG")){
     DEBUG_LOG("DEBUG LOG : IO-PIPES : Inside setup-iopipes_asp function");
   }
-  printf("** Inside setup-iopipes_asp function **\n");
   const uint64_t REG_UDPOE_BASE_ADDR       = iopipes::iopipes_dfh_offset_;
   const uint64_t REG_UDPOE_CSR_BASE_ADDR   = REG_UDPOE_BASE_ADDR + (0x10*0x8);
   const uint64_t CSR_SCRATCHPAD_ADDR           = REG_UDPOE_CSR_BASE_ADDR+(0x00*0x8);
@@ -250,15 +249,20 @@ bool iopipes::setup_iopipes_asp(fpga_handle afc_handle)
   }
   int i = 0x00;
   for(uint64_t loop=0; loop<number_of_channels; loop++) { 
-    printf("Looping on channel %ld, Writing CSRs for channel %ld\n", loop, loop); 
-    printf("Writing CSR_RESET_REG_ADDR for IO Pipe %ld\n", loop);
+    if(std::getenv("MMD_ENABLE_DEBUG")){
+      DEBUG_LOG("Looping on channel %ld, Writing CSRs for channel %ld\n", loop, loop);
+      DEBUG_LOG("Writing CSR_RESET_REG_ADDR for IO Pipe %ld\n", loop);
+    }
+
     if ((res = fpgaWriteMMIO64(afc_handle, mmio_num_, (IOPIPES_CSR_START_ADDR + (++i*0x8)), 0x1)) != FPGA_OK) {
       printf("Error:writing CSR_RESET_REG CSR");
       printf("%s \n",fpgaErrStr(res));
       return false;
     }
     i = i+CSR_ADDRESS_MAP_JUMP_1;
-    printf("Writing CSR_MISC_CTRL_REG for IO Pipe %ld\n", loop);
+    if(std::getenv("MMD_ENABLE_DEBUG")){
+      DEBUG_LOG("Writing CSR_MISC_CTRL_REG for IO Pipe %ld\n", loop);
+    }
     if ((res = fpgaWriteMMIO64(afc_handle, mmio_num_, (IOPIPES_CSR_START_ADDR + (i*0x8)), 0xFFFFFFFF)) != FPGA_OK) {
       printf("Error:writing CSR_MISC_CTRL_REG CSR");
       printf("%s \n",fpgaErrStr(res));


### PR DESCRIPTION
Removed default prints for iopipes, those prints/debug messages can be enabled by setting env variable MMD_ENABLE_DEBUG.
No functional changes.
MMD compile passing.