### PR TITLE
[Fix] memory-clock clock-group hierarchy assignments

### DIFF
--- a/fseries_dk/hardware/fseries_dk/build/opencl_bsp.sdc
+++ b/fseries_dk/hardware/fseries_dk/build/opencl_bsp.sdc
@@ -2,10 +2,10 @@
 set_clock_groups -asynchronous  -group [get_clocks {sys_pll|iopll_0_clk_sys}] \
                                 -group [get_clocks {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
                                                     afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
-                                -group [get_clocks {mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_0_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_1_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_2_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_3_core_usr_clk}]
+                                -group [get_clocks {mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_0_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_1_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_2_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_3_core_usr_clk}]
 
 #false paths in the user_clock prescalar logic since it is locked-down during FIM-build
 set_false_path -from {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]} -to {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]}

--- a/fseries_dk/hardware/fseries_dk_iopipes/build/opencl_bsp.sdc
+++ b/fseries_dk/hardware/fseries_dk_iopipes/build/opencl_bsp.sdc
@@ -2,10 +2,10 @@
 set_clock_groups -asynchronous  -group [get_clocks {sys_pll|iopll_0_clk_sys}] \
                                 -group [get_clocks {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
                                                     afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
-                                -group [get_clocks {mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_0_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_1_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_2_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_3_core_usr_clk}]
+                                -group [get_clocks {mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_0_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_1_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_2_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_3_core_usr_clk}]
 
 #false paths in the user_clock prescalar logic since it is locked-down during FIM-build
 set_false_path -from {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]} -to {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]}

--- a/fseries_dk/hardware/fseries_dk_usm/build/opencl_bsp.sdc
+++ b/fseries_dk/hardware/fseries_dk_usm/build/opencl_bsp.sdc
@@ -2,10 +2,10 @@
 set_clock_groups -asynchronous  -group [get_clocks {sys_pll|iopll_0_clk_sys}] \
                                 -group [get_clocks {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
                                                     afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
-                                -group [get_clocks {mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_0_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_1_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_2_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_3_core_usr_clk}]
+                                -group [get_clocks {mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_0_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_1_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_2_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_3_core_usr_clk}]
 
 #false paths in the user_clock prescalar logic since it is locked-down during FIM-build
 set_false_path -from {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]} -to {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]}

--- a/fseries_dk/hardware/fseries_dk_usm_iopipes/build/opencl_bsp.sdc
+++ b/fseries_dk/hardware/fseries_dk_usm_iopipes/build/opencl_bsp.sdc
@@ -2,10 +2,10 @@
 set_clock_groups -asynchronous  -group [get_clocks {sys_pll|iopll_0_clk_sys}] \
                                 -group [get_clocks {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
                                                     afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
-                                -group [get_clocks {mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_0_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_1_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_2_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_3_core_usr_clk}]
+                                -group [get_clocks {mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_0_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_1_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_2_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_3_core_usr_clk}]
 
 #false paths in the user_clock prescalar logic since it is locked-down during FIM-build
 set_false_path -from {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]} -to {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]}

--- a/n6001/hardware/ofs_n6001/build/opencl_bsp.sdc
+++ b/n6001/hardware/ofs_n6001/build/opencl_bsp.sdc
@@ -2,10 +2,10 @@
 set_clock_groups -asynchronous  -group [get_clocks {sys_pll|iopll_0_clk_sys}] \
                                 -group [get_clocks {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
                                                     afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
-                                -group [get_clocks {mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_0_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_1_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_2_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_3_core_usr_clk}]
+                                -group [get_clocks {mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_0_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_1_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_2_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_3_core_usr_clk}]
 
 #false paths in the user_clock prescalar logic since it is locked-down during FIM-build
 set_false_path -from {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]} -to {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]}

--- a/n6001/hardware/ofs_n6001_iopipes/build/opencl_bsp.sdc
+++ b/n6001/hardware/ofs_n6001_iopipes/build/opencl_bsp.sdc
@@ -2,10 +2,10 @@
 set_clock_groups -asynchronous  -group [get_clocks {sys_pll|iopll_0_clk_sys}] \
                                 -group [get_clocks {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
                                                     afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
-                                -group [get_clocks {mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_0_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_1_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_2_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_3_core_usr_clk}]
+                                -group [get_clocks {mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_0_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_1_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_2_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_3_core_usr_clk}]
 
 #false paths in the user_clock prescalar logic since it is locked-down during FIM-build
 set_false_path -from {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]} -to {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]}

--- a/n6001/hardware/ofs_n6001_usm/build/opencl_bsp.sdc
+++ b/n6001/hardware/ofs_n6001_usm/build/opencl_bsp.sdc
@@ -2,10 +2,10 @@
 set_clock_groups -asynchronous  -group [get_clocks {sys_pll|iopll_0_clk_sys}] \
                                 -group [get_clocks {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
                                                     afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
-                                -group [get_clocks {mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_0_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_1_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_2_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_3_core_usr_clk}]
+                                -group [get_clocks {mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_0_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_1_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_2_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_3_core_usr_clk}]
 
 #false paths in the user_clock prescalar logic since it is locked-down during FIM-build
 set_false_path -from {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]} -to {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]}

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/opencl_bsp.sdc
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/opencl_bsp.sdc
@@ -2,10 +2,10 @@
 set_clock_groups -asynchronous  -group [get_clocks {sys_pll|iopll_0_clk_sys}] \
                                 -group [get_clocks {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
                                                     afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
-                                -group [get_clocks {mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_0_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_1_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_2_core_usr_clk \
-                                                    mem_ss_top|mem_ss_fm_inst|mem_ss_fm*|intf_3_core_usr_clk}]
+                                -group [get_clocks {mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_0_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_1_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_2_core_usr_clk \
+                                                    mem_ss_top|mem_ss_*inst|mem_ss_fm*|intf_3_core_usr_clk}]
 
 #false paths in the user_clock prescalar logic since it is locked-down during FIM-build
 set_false_path -from {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]} -to {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_freq|prescaler[?]}


### PR DESCRIPTION
### Description
The current n6001 master branch has problems with timing due to a hierarchy change in the memory-subsystems leading to an invalid clock-group assignment. This leads to recovery violations that can't be fixed by reducing the kernel-clock frequencies, and the kernel-clock being incorrectly reduced to a useless frequency.

### Tests run:
Manually modified the opencl_bsp.sdc file in-place using the Timing Analyzer GUI for a qri build that had timing violations, and all of the violations disappeared (they were all on CDC paths).

