### PR TITLE
[Fix] setup script cleanup and fix

### DIFF
--- a/d5005/scripts/setup-bsp.py
+++ b/d5005/scripts/setup-bsp.py
@@ -200,7 +200,7 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     #symlink the (i)ofs_top.qpf and (i)ofs_pr_afu.qsf file to bsp_dir
     if "n6001" in bsp:
         PR_AFU_QSF_FILENAME="ofs_pr_afu.qsf"
-        PR_AFU_QPF_FILENAME="ofs_pr_afu.qpf"
+        PR_AFU_QPF_FILENAME="ofs_top.qpf"
     else:
         PR_AFU_QSF_FILENAME="iofs_pr_afu.qsf"
         PR_AFU_QPF_FILENAME="d5005.qpf"

--- a/d5005/scripts/setup-bsp.py
+++ b/d5005/scripts/setup-bsp.py
@@ -128,8 +128,8 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     print("bsp_dir is %s\n" % bsp_dir)
     
     #preserve the pr-build-template folder
-    #delete_and_mkdir(os.path.join(bsp_dir, '../../pr_build_template'))
-    #copy_glob(deliverable_dir, os.path.join(bsp_dir, '../../'),verbose)
+    delete_and_mkdir(os.path.join(bsp_dir, '../../pr_build_template'))
+    copy_glob(deliverable_dir, os.path.join(bsp_dir, '../../'),verbose)
 
     #preserve the blue_bits folder from $OPAE_PLATFORM_ROOT/hw/
     delete_and_mkdir(os.path.join(bsp_dir, 'blue_bits'))

--- a/n6001/scripts/setup-bsp.py
+++ b/n6001/scripts/setup-bsp.py
@@ -200,10 +200,10 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     #symlink the (i)ofs_top.qpf and (i)ofs_pr_afu.qsf file to bsp_dir
     if "n6001" in bsp:
         PR_AFU_QSF_FILENAME="ofs_pr_afu.qsf"
-        PR_AFU_QPF_FILENAME="ofs_pr_afu.qpf"
+        PR_AFU_QPF_FILENAME="ofs_top.qpf"
     else:
         PR_AFU_QSF_FILENAME="iofs_pr_afu.qsf"
-        PR_AFU_QPF_FILENAME="iofs_pr_afu.qpf"
+        PR_AFU_QPF_FILENAME="d5005.qpf"
         
     rm_glob(os.path.join(bsp_dir, PR_AFU_QSF_FILENAME))
     OFS_PR_AFU_QSF_SYMLINK_CMD="cd " + bsp_dir + " && ln -s " + QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR + "/" + PR_AFU_QSF_FILENAME + " ."


### PR DESCRIPTION
### Description
Recent d5005 setup script changes incorrectly set the n6001 FIM qpf filename. This should fix that typo.

### Tests run:
Clean clone, setup, and build opencl+oneapi designs.