### PR TITLE
[Update] commonizing all kernel_wrapper.v files for d5005 and n6001

### DIFF
--- a/d5005/hardware/ofs_d5005/build/bsp_design_files.tcl
+++ b/d5005/hardware/ofs_d5005/build/bsp_design_files.tcl
@@ -29,6 +29,10 @@ set_global_assignment -name SYSTEMVERILOG_FILE "rtl/bsp_logic.sv"
 set_global_assignment -name SYSTEMVERILOG_FILE "rtl/dc_bsp_interfaces.sv"
 set_global_assignment -name SYSTEMVERILOG_FILE "rtl/dc_bsp_pkg.sv"
 set_global_assignment -name SYSTEMVERILOG_FILE "rtl/bsp_host_mem_if_mux.sv"
+set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_wr_ack_gen.sv"
+set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_wr_ack_burst_to_word.sv"
+set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_wr_ack_tracker.sv"
+set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_single_burst_partial_writes.sv"
 
 #--------------------
 # Search paths (for headers, etc)

--- a/d5005/hardware/ofs_d5005/build/rtl/avmm_single_burst_partial_writes.v
+++ b/d5005/hardware/ofs_d5005/build/rtl/avmm_single_burst_partial_writes.v
@@ -1,0 +1,375 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: MIT
+//
+
+`include "platform_if.vh"
+`include "fpga_defines.vh"
+`include "opencl_bsp.vh"
+
+// avmm_single_burst_partial_writes
+// Split an AVMM interface's partial writes into a single partial-write and 
+//  a re-grouped burst. Handles partial writes on either/or end of the burst
+//  (start and/or end), as well as initial bursts of 1.
+
+module avmm_single_burst_partial_writes  
+import dc_bsp_pkg::*;
+(
+    input       clk,
+    input       reset_n,
+
+    ofs_plat_avalon_mem_if.to_source to_avmm_source,
+    ofs_plat_avalon_mem_if.to_sink to_avmm_sink
+);
+
+localparam AVMM_BUFFER_WIDTH =  OPENCL_SVM_QSYS_ADDR_WIDTH +
+                                OPENCL_BSP_KERNEL_SVM_DATA_WIDTH +
+                                OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH +
+                                1 + //write req
+                                1 + //read req
+                                (OPENCL_BSP_KERNEL_SVM_DATA_WIDTH/8); //byteenable size
+localparam AVMM_BUFFER_DEPTH = 1024;
+localparam AVMM_BUFFER_SKID_SPACE = 64;
+localparam AVMM_BUFFER_ALMFULL_VALUE = AVMM_BUFFER_DEPTH - AVMM_BUFFER_SKID_SPACE;
+
+typedef struct packed {
+    logic read, write;
+    logic [OPENCL_SVM_QSYS_ADDR_WIDTH-1:0] address;
+    logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] burstcount;
+    logic [(OPENCL_BSP_KERNEL_SVM_DATA_WIDTH/8)-1:0] byteenable;
+    logic [OPENCL_BSP_KERNEL_SVM_DATA_WIDTH-1:0] writedata;
+} avmm_cmd_t;
+avmm_cmd_t avmm_cmd_buf_in, avmm_cmd_buf_out;
+
+typedef struct packed {
+    logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] burstcount;
+    logic valid;
+    logic read;
+    logic write;
+} avmm_burstcnt_t;
+localparam USM_BCNT_DWIDTH = OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH + 1 + 1 + 1;
+avmm_burstcnt_t [1:0] burstcnt_data;
+avmm_burstcnt_t usm_burstcnt_dout;
+logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] current_bcnt;
+logic [OPENCL_SVM_QSYS_ADDR_WIDTH-1:0] prev_address_plus1;
+localparam BCNT_WDOG_WIDTH = 10;
+logic [BCNT_WDOG_WIDTH-1:0] burstcnt_wdog;
+logic burstcnt_buffer_full, burstcnt_buffer_almfull, burstcnt_buffer_empty;
+logic [9:0] usm_burstcnt_buffer_usedw;
+typedef enum {  ST_SET_BCNT,
+                ST_DO_WR_BURST,
+                XXX } usm_bcnt_st_e;
+usm_bcnt_st_e usm_bcnt_cs, usm_bcnt_ns;
+logic usm_bcnt_st_is_setbcnt, usm_bcnt_st_is_do_wr_burst;
+logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] usm_avmm_fifo_rd_remaining;
+logic usm_avmm_fifo_rd, usm_bcnt_fifo_rd;
+logic [7:0] svm_addr_cnt;
+
+//the readdata-path is just passed-through
+always_comb begin
+    to_avmm_source.readdata = to_avmm_sink.readdata;
+    to_avmm_source.readdatavalid = to_avmm_sink.readdatavalid;
+end
+
+always_comb begin
+    avmm_cmd_buf_in.address    = to_avmm_source.write ? to_avmm_source.address + svm_addr_cnt : to_avmm_source.address;
+    avmm_cmd_buf_in.burstcount = to_avmm_source.write ? 'h1 : to_avmm_source.burstcount;
+    avmm_cmd_buf_in.write      = to_avmm_source.write;
+    avmm_cmd_buf_in.writedata  = to_avmm_source.writedata;
+    avmm_cmd_buf_in.read       = to_avmm_source.read;
+    avmm_cmd_buf_in.byteenable = to_avmm_source.byteenable;
+end
+
+always_ff @(posedge clk or negedge reset_n) begin
+    if (!reset_n) begin
+        svm_addr_cnt <= 'h0;
+    end else begin
+        if (svm_addr_cnt == (to_avmm_source.burstcount-'b1) ) begin
+            if (avmm_cmd_buf_in.write) begin
+                svm_addr_cnt <= 'b0;
+            end else begin
+                svm_addr_cnt <= svm_addr_cnt;
+            end
+        end else begin
+            svm_addr_cnt <= svm_addr_cnt + avmm_cmd_buf_in.write;
+        end
+    end
+end
+
+//due to WRA I need to add a buffer here, using almost-full to generate waitrequest to kernel.
+logic avmm_buffer_full, avmm_buffer_empty;
+logic [9:0] usm_avmm_buffer_usedw;
+scfifo
+#(
+    .lpm_numwords(AVMM_BUFFER_DEPTH),
+    .lpm_showahead("ON"),
+    .lpm_type("scfifo"),
+    .lpm_width(AVMM_BUFFER_WIDTH),
+    .lpm_widthu($clog2(AVMM_BUFFER_DEPTH)),
+    .almost_full_value(AVMM_BUFFER_ALMFULL_VALUE),
+    .overflow_checking("OFF"),
+    .underflow_checking("OFF"),
+    .use_eab("ON"),
+    .add_ram_output_register("ON")
+    )
+usm_avmm_buffer
+(
+    .clock(clk),
+    .sclr(!reset_n),
+
+    .data(avmm_cmd_buf_in),
+    .wrreq(avmm_cmd_buf_in.write | avmm_cmd_buf_in.read),
+    .full(avmm_buffer_full),
+    .almost_full(to_avmm_source.waitrequest),
+
+    .rdreq(usm_avmm_fifo_rd),
+    .q(avmm_cmd_buf_out),
+    .empty(avmm_buffer_empty),
+    .almost_empty(),
+
+    .aclr(),
+    .usedw(usm_avmm_buffer_usedw),
+    .eccstatus()
+);
+
+always_comb begin
+    to_avmm_sink.write = usm_avmm_fifo_rd & avmm_cmd_buf_out.write;
+    to_avmm_sink.read  = usm_avmm_fifo_rd & avmm_cmd_buf_out.read;
+    //higher-level interfaces don't like 'X' during simulation. Drive 0's when not driven
+    // by the kernel-system.
+    // synthesis translate off
+        to_avmm_sink.write = (usm_avmm_fifo_rd & avmm_cmd_buf_out.write) === 'X ? 'b0 : (usm_avmm_fifo_rd & avmm_cmd_buf_out.write);
+        to_avmm_sink.read  = (usm_avmm_fifo_rd & avmm_cmd_buf_out.read)  === 'X ? 'b0 : (usm_avmm_fifo_rd & avmm_cmd_buf_out.read);
+    // synthesis translate on
+    
+    to_avmm_sink.address    = avmm_cmd_buf_out.address;
+    to_avmm_sink.writedata  = avmm_cmd_buf_out.writedata;
+    to_avmm_sink.burstcount = avmm_cmd_buf_out.write ? usm_avmm_fifo_rd_remaining : avmm_cmd_buf_out.burstcount;
+    to_avmm_sink.byteenable = avmm_cmd_buf_out.byteenable;
+end
+
+//re-create the burst-count data based on byteenable, address, and original burst-count
+//Every partial-write (where byteenable is not all 1's) must result in be a burst-count of '1'.
+//Other writes should be grouped together into maximal-sized bursts.
+//
+//
+
+always_ff @(posedge clk) begin
+    if (!reset_n) begin
+        burstcnt_data <= 'h0;
+        current_bcnt <= 'h1;
+        prev_address_plus1 <= 'b0;
+        burstcnt_wdog <= 'b0;
+    end else begin
+        //when tracking a write-burst, we might need to flush it out because we don't know when the
+        //write from the kernel-system is actually complete.
+        burstcnt_wdog <= current_bcnt > 'h1 ? {burstcnt_wdog[0 +: (BCNT_WDOG_WIDTH-1)], 1'b1} : '0;
+        //push in a 0 to create a pulse for a follow-up partial write burstcount of 1
+        //it will be over-written later in the block if/when necessary.
+        burstcnt_data[1] <= burstcnt_data[0];
+        burstcnt_data[0].valid <= 1'b0;
+        //if it is a read req from the kernel-system, just use that burstcount value
+        if (avmm_cmd_buf_in.read) begin
+            burstcnt_wdog <= 'h0;
+            //if we were tracking a write-burst and a read comes in, send both the write and read in order
+            if (current_bcnt > 'h1) begin
+                burstcnt_data[1].burstcount <= current_bcnt - 'b1;
+                burstcnt_data[1].valid <= 1'b1;
+                burstcnt_data[1].write <= 1'b1;
+                burstcnt_data[1].read <= 1'b0;
+            end
+            burstcnt_data[0].burstcount <= to_avmm_source.burstcount;
+            burstcnt_data[0].valid <= 1'b1;
+            burstcnt_data[0].write <= 1'b0;
+            burstcnt_data[0].read <= 1'b1;
+            current_bcnt <= 'h1;
+        //if it is a write req from kernel-system, need to figure out the maximal burst
+        end else if (avmm_cmd_buf_in.write) begin
+            burstcnt_wdog <= 'h0;
+            //if original burst-cnt is 1, leave it as 1
+            if (to_avmm_source.burstcount == 'h1) begin
+                //if need to send the previous burst, too.
+                if (current_bcnt > 'h1) begin
+                    burstcnt_data[1].burstcount <= current_bcnt - 'b1;
+                    burstcnt_data[1].valid <= 1'b1;
+                    burstcnt_data[1].write <= 1'b1;
+                    burstcnt_data[1].read <= 1'b0;
+                end
+                burstcnt_data[0].burstcount <= 'h1;
+                burstcnt_data[0].valid <= 1'b1;
+                burstcnt_data[0].write <= 1'b1;
+                burstcnt_data[0].read  <= 1'b0;
+                current_bcnt <= 'h1;
+            //original burst-cnt is not 1; this is the first word of the burst
+            end else if (current_bcnt == 'h1) begin
+                if ( !(&avmm_cmd_buf_in.byteenable) ) begin
+                    burstcnt_data[0].burstcount <= 'h1;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                end else begin
+                    prev_address_plus1 <= avmm_cmd_buf_in.address + 'h1;
+                    current_bcnt <= 'h2;
+                end
+            //if continuous address
+            end else if (prev_address_plus1 == avmm_cmd_buf_in.address) begin
+                //if partial write, send burst and singleton
+                if ( !(&avmm_cmd_buf_in.byteenable) ) begin
+                    burstcnt_data[1].burstcount <= current_bcnt - 'b1;
+                    burstcnt_data[1].valid <= 1'b1;
+                    burstcnt_data[1].write <= 1'b1;
+                    burstcnt_data[1].read <= 1'b0;
+                    burstcnt_data[0].burstcount <= 'h1;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                //not a partial write and not a full burst, so keep adding to burstcount
+                end else if (current_bcnt < OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_MAX) begin
+                    current_bcnt <= current_bcnt + 'h1;
+                //full burst, so send burst and start again
+                end else begin
+                    burstcnt_data[0].burstcount <= current_bcnt;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                end
+                prev_address_plus1 <= avmm_cmd_buf_in.address + 'h1;
+            //not a continuous address, send the previous burst and start tracking the new one
+            end else begin
+                //if partial write, send burst and singleton
+                if ( !(&avmm_cmd_buf_in.byteenable) ) begin
+                    burstcnt_data[1].burstcount <= current_bcnt - 'b1;
+                    burstcnt_data[1].valid <= 1'b1;
+                    burstcnt_data[1].write <= 1'b1;
+                    burstcnt_data[1].read <= 1'b0;
+                    burstcnt_data[0].burstcount <= 'h1;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                //not partial burst, so send previous burst and continue tracking the new one
+                end else begin
+                    burstcnt_data[0].burstcount <= current_bcnt - 'b1;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                    prev_address_plus1 <= avmm_cmd_buf_in.address + 'h1;
+                end
+            end
+        //watchdog to flush out any final write request. 
+        end else if (&burstcnt_wdog) begin
+            burstcnt_data[0].burstcount <= current_bcnt - 'b1;
+            burstcnt_data[0].valid <= 1'b1;
+            burstcnt_data[0].write <= 1'b1;
+            burstcnt_data[0].read <= 1'b0;
+            current_bcnt <= 'h1;
+            burstcnt_wdog <= 'b0;
+        end
+    end
+end
+
+//push the burst-count info into a scFIFO
+scfifo
+#(
+    .lpm_numwords(AVMM_BUFFER_DEPTH),
+    .lpm_showahead("ON"),
+    .lpm_type("scfifo"),
+    .lpm_width(USM_BCNT_DWIDTH),
+    .lpm_widthu($clog2(AVMM_BUFFER_DEPTH)),
+    .almost_full_value(AVMM_BUFFER_ALMFULL_VALUE),
+    .overflow_checking("OFF"),
+    .underflow_checking("OFF"),
+    .use_eab("ON"),
+    .add_ram_output_register("ON")
+    )
+burstcnt_buffer
+(
+    .clock(clk),
+    .sclr(!reset_n),
+
+    .data(burstcnt_data[1]),
+    .wrreq(burstcnt_data[1].valid),
+    .full(burstcnt_buffer_full),
+    .almost_full(burstcnt_buffer_almfull),
+
+    .rdreq(usm_bcnt_fifo_rd),
+    .q(usm_burstcnt_dout),
+    .empty(burstcnt_buffer_empty),
+    .almost_empty(),
+
+    .aclr(),
+    .usedw(usm_burstcnt_buffer_usedw),
+    .eccstatus()
+);
+
+
+//will require some state machine to track coordination of popping from the 2 FIFOs
+// can't pop from the main FIFO until something exists in the bcnt FIFO.
+// for each entry in the bcnt FIFO, pop that number of elements from the main FIFO.
+// the main FIFO is populated prior to the bcnt FIFO having data, so we are guaranteed
+//   the main FIFO will always have enough data in it to satisfy the bcnt size.
+always_ff @(posedge clk)
+    if (!reset_n)
+        usm_bcnt_cs <= ST_SET_BCNT;
+    else
+        usm_bcnt_cs <= usm_bcnt_ns;
+
+always_comb begin
+    usm_bcnt_ns = XXX;
+    case (usm_bcnt_cs)
+        ST_SET_BCNT:    if (!burstcnt_buffer_empty && !to_avmm_sink.waitrequest) begin
+                            //if read or (bcnt == 1) stay here so we're ready 
+                            // for the next one on the next cycle
+                            if (usm_burstcnt_dout.read == 'b1 || 
+                                usm_burstcnt_dout.burstcount == 'h1) begin
+                                usm_bcnt_ns = ST_SET_BCNT;
+                            end else begin
+                                usm_bcnt_ns = ST_DO_WR_BURST;
+                            end
+                        end else begin
+                            usm_bcnt_ns = ST_SET_BCNT;
+                        end
+                        //if final word of this burst and not waitreq
+        ST_DO_WR_BURST: if (usm_avmm_fifo_rd_remaining == 'h1 && !to_avmm_sink.waitrequest) begin
+                            //if there is another burst waiting to go, stay here and start new burst
+                            if (!burstcnt_buffer_empty && usm_burstcnt_dout.write == 'b1 && usm_burstcnt_dout.burstcount != 'h1) begin
+                                usm_bcnt_ns = ST_DO_WR_BURST;
+                            end else begin
+                                usm_bcnt_ns = ST_SET_BCNT;
+                            end
+                        end else begin
+                            usm_bcnt_ns = ST_DO_WR_BURST;
+                        end
+    endcase
+end
+
+assign usm_bcnt_st_is_setbcnt = usm_bcnt_cs == ST_SET_BCNT;
+assign usm_bcnt_st_is_do_wr_burst = usm_bcnt_cs == ST_DO_WR_BURST;
+
+//use a counter to manage popping from the usm_avmm FIFO.
+always_ff @(posedge clk)
+    if (!reset_n)
+        usm_avmm_fifo_rd_remaining <= 'b0;
+    else begin
+        //if burstcount fifo isn't empty and !waitreq
+        if (!burstcnt_buffer_empty && !to_avmm_sink.waitrequest && (usm_bcnt_st_is_setbcnt || 
+           (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) ) ) begin
+            usm_avmm_fifo_rd_remaining <= usm_burstcnt_dout.read ? 'h1 : usm_burstcnt_dout.burstcount;
+        //pop from usm_avmm FIFO as long as the counter is non-zero and !waitreq
+        end else if (usm_avmm_fifo_rd)
+            usm_avmm_fifo_rd_remaining <= usm_avmm_fifo_rd_remaining - 'h1;
+        else 
+            usm_avmm_fifo_rd_remaining <= usm_avmm_fifo_rd_remaining;
+    end
+
+//we know there is sufficient data in the usm_avmm FIFO because the bcnt FIFO isn't written-to until the 
+// original burst has been pushed into the usm_avmm FIFO.
+assign usm_avmm_fifo_rd = usm_avmm_fifo_rd_remaining && !to_avmm_sink.waitrequest;
+//pop the next usm_bcnt value when? When it is first popped, so that the next value is already 
+// waiting on the FIFO output when we are done with the current burst.
+assign usm_bcnt_fifo_rd =   !burstcnt_buffer_empty && !to_avmm_sink.waitrequest && (usm_bcnt_st_is_setbcnt || 
+                            (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) );
+
+endmodule : avmm_single_burst_partial_writes

--- a/d5005/hardware/ofs_d5005/build/rtl/avmm_wr_ack_burst_to_word.sv
+++ b/d5005/hardware/ofs_d5005/build/rtl/avmm_wr_ack_burst_to_word.sv
@@ -1,0 +1,82 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: MIT
+//
+
+//
+//This module will convert a per-burst write-ack into a per-word write-ack
+//
+
+`include "ofs_plat_if.vh"
+
+module avmm_wr_ack_burst_to_word
+import dc_bsp_pkg::*;
+import local_mem_cfg_pkg::*;
+#(
+    parameter AVMM_ADDR_WIDTH=LOCAL_MEM_ADDR_WIDTH,
+    parameter AVMM_BURSTCNT_WIDTH=LOCAL_MEM_BURST_CNT_WIDTH
+)
+(
+    input logic clk,
+    input logic reset,
+    
+    input logic [AVMM_BURSTCNT_WIDTH-1:0] burstcnt,
+    input logic per_burst_write_ack_in,
+    
+    output logic per_word_write_ack_out
+);
+
+//Theory of operation:
+// Add burstcnt to the per_word_ack_counter upon reception of 
+//   per_burst_write_ack_in.
+// Decrement per_burst_write_ack_in each time we send a write-ack to 
+//   the kernel-system.
+// Don't forget about the case of simultaneous ack-in / ack-out.
+//
+
+logic [9:0] per_word_ack_counter;
+logic per_burst_write_ack_in_d;
+logic [AVMM_BURSTCNT_WIDTH-1:0] burstcnt_d;
+
+//register the incoming write-ack and burst-count
+always_ff @(posedge clk)
+begin
+    per_burst_write_ack_in_d    <= per_burst_write_ack_in;
+    burstcnt_d                  <= burstcnt;
+    if (reset) begin
+        per_burst_write_ack_in_d    <= 'b0;
+        burstcnt_d                  <= 'b0;
+    end
+end
+
+//manage the per-word write-ack counter
+// if ack-in and ack-out: add (burstcnt_d - 2)
+// else if ack-in: add (burstcnt_d - 1)
+// else if ack-out: decrement burstcnt_d
+always_ff @(posedge clk)
+begin
+    if (per_burst_write_ack_in_d & !per_word_ack_counter)
+        per_word_ack_counter <= burstcnt_d;
+    else if (per_burst_write_ack_in_d)
+        per_word_ack_counter <= per_word_ack_counter + burstcnt_d - per_word_write_ack_out;
+    else if (per_word_write_ack_out && (|per_word_ack_counter) )
+        per_word_ack_counter <= per_word_ack_counter - 1'b1;
+    
+    if (reset) 
+        per_word_ack_counter <= 'b0;
+end
+
+//generate a per-word write-ack when the counter is non-zero
+//always_ff @(posedge clk)
+//begin
+//    per_word_write_ack_out <= 1'b0;
+//    if (|per_word_ack_counter)
+//        per_word_write_ack_out <= 1'b1;
+//    if (reset)
+//        per_word_write_ack_out <= 1'b0;
+//end
+always_comb
+begin
+    per_word_write_ack_out = |per_word_ack_counter;
+end
+
+endmodule : avmm_wr_ack_burst_to_word

--- a/d5005/hardware/ofs_d5005/build/rtl/avmm_wr_ack_gen.sv
+++ b/d5005/hardware/ofs_d5005/build/rtl/avmm_wr_ack_gen.sv
@@ -1,0 +1,95 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: MIT
+//
+
+//
+//This module will track the per-burst write-acks from the AVMM-AXI conversion
+//  and generate the appropriate number of per-word write-acks to the
+//  kernel-system.
+//
+
+`include "ofs_plat_if.vh"
+
+module avmm_wr_ack_gen
+import dc_bsp_pkg::*;
+import local_mem_cfg_pkg::*;
+#(
+    parameter AVMM_ADDR_WIDTH=LOCAL_MEM_ADDR_WIDTH,
+    parameter AVMM_BURSTCNT_WIDTH=LOCAL_MEM_BURST_CNT_WIDTH
+)
+(
+    //in-channel 0
+    input logic kernel_avmm_clk,
+    input logic kernel_avmm_reset,
+    input logic kernel_avmm_waitreq,
+    input logic kernel_avmm_wr,
+    input logic [AVMM_BURSTCNT_WIDTH-1:0] kernel_avmm_burstcnt,
+    input logic [AVMM_ADDR_WIDTH-1:0] kernel_avmm_address,
+    output logic kernel_avmm_wr_ack,
+    
+    //out-channel
+    input logic emif_avmm_clk,
+    input logic emif_avmm_reset,
+    input logic emif_avmm_waitreq,
+    input logic emif_avmm_wr,
+    input logic [AVMM_BURSTCNT_WIDTH-1:0] emif_avmm_burstcnt,
+    input logic [AVMM_ADDR_WIDTH-1:0] emif_avmm_address,
+    input logic emif_avmm_wr_ack
+);
+
+//register kernel clock for local use
+logic [1:0] kernel_avmm_reset_d;
+logic kernel_avmm_reset_lcl;
+always_ff @(posedge kernel_avmm_clk or posedge kernel_avmm_reset) begin
+    kernel_avmm_reset_d <= {kernel_avmm_reset_d[0], 1'b0};
+    if (kernel_avmm_reset) kernel_avmm_reset_d <= 2'b11;
+end
+assign kernel_avmm_reset_lcl = kernel_avmm_reset_d[1];
+
+//Theory of operation:
+// Two sub-blocks - one to track the order of write-events between
+//  the kernel-system and DMA controller and associated burst-count,
+//  and one to generate the appropriate number of write-acks for the
+//  kernel-system. The AVMM-AXI conversion generates one write-ack
+//  per burst while the kernel-system expects one write-ack per word.
+//
+logic kernel_avmm_wr_ack_per_burst;
+logic [AVMM_BURSTCNT_WIDTH-1:0] kernel_avmm_wr_ack_burstcnt;
+
+// local-memory/DDR write-ack tracking
+avmm_wr_ack_tracker avmm_wr_ack_tracker_inst (
+    //in-channel 0
+    .kernel_avmm_clk        ,
+    .kernel_avmm_reset      (kernel_avmm_reset_lcl),
+    .kernel_avmm_waitreq    ,
+    .kernel_avmm_wr         ,
+    .kernel_avmm_burstcnt   ,
+    .kernel_avmm_address    ,
+    .kernel_avmm_wr_ack         (kernel_avmm_wr_ack_per_burst),
+    .kernel_avmm_wr_ack_burstcnt(kernel_avmm_wr_ack_burstcnt),
+    
+    //AVMM channel up to PIM (AVMM-AXI conversion with write-ack)
+    .emif_avmm_clk          ,
+    .emif_avmm_reset        ,
+    .emif_avmm_waitreq      ,
+    .emif_avmm_wr           ,
+    .emif_avmm_burstcnt     ,
+    .emif_avmm_address      ,
+    .emif_avmm_wr_ack      
+);
+
+
+//write-ack multiplier
+// write-acks from AVMM-AXI conversion was per-burst; kernel-system expets
+//  per-word.
+avmm_wr_ack_burst_to_word avmm_wr_ack_burst_to_word_inst
+(
+    .clk                    (kernel_avmm_clk),
+    .reset                  (kernel_avmm_reset_lcl),
+    .per_burst_write_ack_in (kernel_avmm_wr_ack_per_burst),
+    .burstcnt               (kernel_avmm_wr_ack_burstcnt),
+    .per_word_write_ack_out (kernel_avmm_wr_ack)
+);
+
+
+endmodule : avmm_wr_ack_gen

--- a/d5005/hardware/ofs_d5005/build/rtl/avmm_wr_ack_tracker.sv
+++ b/d5005/hardware/ofs_d5005/build/rtl/avmm_wr_ack_tracker.sv
@@ -1,0 +1,309 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: MIT
+//
+
+//This module will track the AVMM write-requests from 1 of 2 multiplexed 
+// channels and manage send single wr-ack signal back to the appropriate 
+// source.
+// a-ch ---
+//        |---c-ch
+// b-ch ---
+//
+
+`include "ofs_plat_if.vh"
+
+module avmm_wr_ack_tracker
+import dc_bsp_pkg::*;
+import local_mem_cfg_pkg::*;
+#(
+    parameter AVMM_ADDR_WIDTH=LOCAL_MEM_ADDR_WIDTH,
+    parameter AVMM_BURSTCNT_WIDTH=LOCAL_MEM_BURST_CNT_WIDTH
+)
+(
+    //in-channel 0
+    input logic kernel_avmm_clk,
+    input logic kernel_avmm_reset,
+    input logic kernel_avmm_waitreq,
+    input logic kernel_avmm_wr,
+    input logic [AVMM_BURSTCNT_WIDTH-1:0] kernel_avmm_burstcnt,
+    input logic [AVMM_ADDR_WIDTH-1:0] kernel_avmm_address,
+    //per-burst write-ack and burstcnt information for ack-multiplier
+    output logic kernel_avmm_wr_ack,
+    output logic [AVMM_BURSTCNT_WIDTH-1:0] kernel_avmm_wr_ack_burstcnt,
+    
+    //out-channel
+    input logic emif_avmm_clk,
+    input logic emif_avmm_reset,
+    input logic emif_avmm_waitreq,
+    input logic emif_avmm_wr,
+    input logic [AVMM_BURSTCNT_WIDTH-1:0] emif_avmm_burstcnt,
+    input logic [AVMM_ADDR_WIDTH-1:0] emif_avmm_address,
+    input logic emif_avmm_wr_ack
+);
+
+//Theory of operation:
+//  - push the in-channel write event into a FIFO
+//      - store the address, burstcnt
+//  - push the out-channel write event into another DCFIFO
+//      - store the address, burstcnt
+//      - read-side is in channel-0 clock domain
+//      - write-side is in out-channel clock domain
+//  - push the  write-ack into a DCFIFO
+//      - write-side is in out-channel clock domain
+//      - read-side is in channel-0 clock domain
+//  - pop the write-ack from the FIFO (ch0 clk domain)
+//  - use the popped-wrack to pop from the out-channel FIFO.
+//      - compare the address on the burst-channel Q output with
+//        the output on the channel-0 Q output.
+//          - if match, output the burstcnt and wrack signals to ch0
+//          - else, output the burstcnt and wrack signals to ch1 (unused)
+typedef struct packed {
+    logic [AVMM_BURSTCNT_WIDTH-1:0] burstcnt;
+    logic [AVMM_ADDR_WIDTH-1:0]     address;
+} write_event_data;
+
+localparam KERNEL_AVMM_WR_EVENT_FIFO_DEPTH = 512;
+localparam KERNEL_AVMM_WR_EVENT_ALMOSTFULL_THRESHOLD = 10;
+typedef enum {  ST_IDLE,
+                ST_BURST,
+                ST_XXX} write_event_state;
+write_event_state we_cs, we_ns;
+
+write_event_data kernel_avmm_wr_event_data;
+write_event_data kernel_avmm_wr_event_data_q;
+logic kernel_avmm_start_of_write;
+logic kernel_avmm_wr_event_notFull;
+logic kernel_avmm_wr_event_almostFull;
+logic kernel_avmm_wr_event_deq;
+logic kernel_avmm_wr_event_ff_notEmpty;
+logic [AVMM_BURSTCNT_WIDTH-1:0] kernel_avmm_burstcntr;
+logic kernel_avmm_valid_wr_req;
+
+//two states to track the initial write-events - idle and in-burst
+always_ff @(posedge kernel_avmm_clk)
+begin
+    we_cs  <= we_ns;
+    if (kernel_avmm_reset) we_cs <= ST_IDLE;
+end
+
+always_comb
+begin
+    we_ns = ST_XXX;
+    kernel_avmm_start_of_write = 'b0;
+    case (we_cs)
+        ST_IDLE:    if (kernel_avmm_valid_wr_req) begin
+                        //this is the start of a write-event
+                        kernel_avmm_start_of_write = 'b1;
+                        //if burstcnt is > 1
+                        if ( |(kernel_avmm_burstcnt>>1) ) begin
+                            we_ns = ST_BURST;
+                        end else begin
+                            we_ns = ST_IDLE;
+                        end
+                    end else begin
+                        we_ns = ST_IDLE;
+                    end
+        ST_BURST:   if (kernel_avmm_valid_wr_req) begin
+                        if (kernel_avmm_burstcntr=='h1) begin
+                            we_ns = ST_IDLE;
+                        end else begin
+                            we_ns = ST_BURST;
+                        end
+                    end else begin
+                        we_ns = ST_BURST;
+                    end
+    endcase
+end
+
+//kernel-system has WRA>0, so wait-request doesn't negate the wr signal
+assign kernel_avmm_valid_wr_req = kernel_avmm_wr;
+
+always_ff @(posedge kernel_avmm_clk) 
+begin
+    if (kernel_avmm_start_of_write)
+        kernel_avmm_burstcntr <= kernel_avmm_burstcnt - 1'b1;
+    else if (kernel_avmm_valid_wr_req)
+        kernel_avmm_burstcntr <= kernel_avmm_burstcntr - 1'b1;
+    if (kernel_avmm_reset)
+        kernel_avmm_burstcntr <= '1;
+end
+
+assign kernel_avmm_wr_event_data.burstcnt = kernel_avmm_burstcnt;
+assign kernel_avmm_wr_event_data.address  = kernel_avmm_address;
+
+ofs_plat_prim_fifo_dc 
+#(
+    .N_DATA_BITS(AVMM_ADDR_WIDTH+AVMM_BURSTCNT_WIDTH),
+    .N_ENTRIES  (KERNEL_AVMM_WR_EVENT_FIFO_DEPTH),
+    .THRESHOLD  (KERNEL_AVMM_WR_EVENT_ALMOSTFULL_THRESHOLD)
+)
+kernel_avmm_write_event_fifo
+(
+    .enq_clk    (kernel_avmm_clk),
+    .enq_reset_n(!kernel_avmm_reset),
+    .enq_data   (kernel_avmm_wr_event_data),
+    .enq_en     (kernel_avmm_start_of_write),
+    .notFull    (kernel_avmm_wr_event_notFull),
+    .almostFull (kernel_avmm_wr_event_almostFull),
+
+    .deq_clk    (kernel_avmm_clk),
+    .deq_reset_n(!kernel_avmm_reset),
+    .first      (kernel_avmm_wr_event_data_q),
+    .deq_en     (kernel_avmm_wr_event_deq),
+    .notEmpty   (kernel_avmm_wr_event_ff_notEmpty)
+);
+
+
+
+//
+//Capture the local-memory write events
+//
+
+localparam EMIF_AVMM_WR_EVENT_FIFO_DEPTH = 512;
+localparam EMIF_AVMM_WR_EVENT_ALMOSTFULL_THRESHOLD = 10;
+write_event_state lwe_cs, lwe_ns;
+
+write_event_data emif_avmm_wr_event_data;
+write_event_data emif_avmm_wr_event_data_q;
+logic emif_avmm_start_of_write;
+logic emif_avmm_wr_event_notFull;
+logic emif_avmm_wr_event_almostFull;
+logic emif_avmm_wr_event_ff_deq;
+logic emif_avmm_wr_event_ff_notEmpty;
+logic emif_avmm_decrement_burstcntr;
+logic [AVMM_BURSTCNT_WIDTH-1:0] emif_avmm_burstcntr;
+logic emif_avmm_valid_wr_req;
+
+//two states to track the initial write-events - idle and in-burst
+always_ff @(posedge emif_avmm_clk)
+begin
+    lwe_cs  <= lwe_ns;
+    if (emif_avmm_reset) lwe_cs <= ST_IDLE;
+end
+
+always_comb
+begin
+    lwe_ns = ST_XXX;
+    emif_avmm_start_of_write = 'b0;
+    case (lwe_cs)
+        ST_IDLE:    if (emif_avmm_valid_wr_req) begin
+                        //this is the start of a write-event
+                        emif_avmm_start_of_write = 'b1;
+                        //if burstcnt is > 1
+                        if ( |(emif_avmm_burstcnt>>1) ) begin
+                            lwe_ns = ST_BURST;
+                        end else begin
+                            lwe_ns = ST_IDLE;
+                        end
+                    end else begin
+                        lwe_ns = ST_IDLE;
+                    end
+        ST_BURST:   if (emif_avmm_valid_wr_req) begin
+                        if (emif_avmm_burstcntr=='h1) begin
+                            lwe_ns = ST_IDLE;
+                        end else begin
+                            lwe_ns = ST_BURST;
+                        end
+                    end else begin
+                        lwe_ns = ST_BURST;
+                    end
+    endcase
+end
+
+assign emif_avmm_valid_wr_req = emif_avmm_wr && !emif_avmm_waitreq;
+always_ff @(posedge emif_avmm_clk) 
+begin
+    if (emif_avmm_start_of_write)
+        emif_avmm_burstcntr <= emif_avmm_burstcnt - 1'b1;
+    else if (emif_avmm_valid_wr_req)
+        emif_avmm_burstcntr <= emif_avmm_burstcntr - 1'b1;
+    if (emif_avmm_reset)
+        emif_avmm_burstcntr <= '0;
+end
+
+assign emif_avmm_wr_event_data.address  = emif_avmm_address;
+assign emif_avmm_wr_event_data.burstcnt = emif_avmm_burstcnt;
+
+ofs_plat_prim_fifo_dc 
+#(
+    .N_DATA_BITS(AVMM_ADDR_WIDTH+AVMM_BURSTCNT_WIDTH),
+    .N_ENTRIES  (EMIF_AVMM_WR_EVENT_FIFO_DEPTH),
+    .THRESHOLD  (EMIF_AVMM_WR_EVENT_ALMOSTFULL_THRESHOLD)
+)
+emif_avmm_write_event_fifo
+(
+    .enq_clk    (emif_avmm_clk),
+    .enq_reset_n(!emif_avmm_reset),
+    .enq_data   (emif_avmm_wr_event_data),
+    .enq_en     (emif_avmm_start_of_write),
+    .notFull    (emif_avmm_wr_event_notFull),
+    .almostFull (emif_avmm_wr_event_almostFull),
+
+    .deq_clk    (kernel_avmm_clk),
+    .deq_reset_n(!kernel_avmm_reset),
+    .first      (emif_avmm_wr_event_data_q),
+    .deq_en     (emif_avmm_wr_event_ff_deq),
+    .notEmpty   (emif_avmm_wr_event_ff_notEmpty)
+);
+
+//sync the incoming emif_avmm_wr_ack signal into the kernel-clock domain
+logic emif_avmm_wr_ack_ff_notFull;
+logic emif_avmm_wr_ack_ff_almostFull;
+logic emif_avmm_wr_ack_ff_notEmpty;
+logic emif_avmm_wr_ack_ff_deq;
+ofs_plat_prim_fifo_dc 
+#(
+    .N_DATA_BITS(1),
+    .N_ENTRIES  (256),
+    .THRESHOLD  (2)
+)
+emif_avmm_write_ack_fifo
+(
+    .enq_clk    (emif_avmm_clk),
+    .enq_reset_n(!emif_avmm_reset),
+    .enq_data   (1'b1),
+    .enq_en     (emif_avmm_wr_ack),
+    .notFull    (emif_avmm_wr_ack_ff_notFull),
+    .almostFull (emif_avmm_wr_ack_ff_almostFull),
+
+    .deq_clk    (kernel_avmm_clk),
+    .deq_reset_n(!kernel_avmm_reset),
+    .first      (), //unused; just the notEmpty flag is needed
+    .deq_en     (emif_avmm_wr_ack_ff_deq),
+    .notEmpty   (emif_avmm_wr_ack_ff_notEmpty)
+);
+assign emif_avmm_wr_ack_ff_deq = emif_avmm_wr_ack_ff_notEmpty;
+
+//
+//the above two blocks capture the burst-cnt information for the kernel-system and local-memory requests
+//
+assign emif_avmm_wr_event_ff_deq = emif_avmm_wr_event_ff_notEmpty && emif_avmm_wr_ack_ff_notEmpty;
+
+always_ff @(posedge kernel_avmm_clk)
+begin
+    kernel_avmm_wr_ack <= 'b0;
+    
+    if (emif_avmm_wr_ack_ff_notEmpty & emif_avmm_wr_event_ff_notEmpty & kernel_avmm_wr_event_ff_notEmpty) begin
+        if (kernel_avmm_wr_event_data_q.address == emif_avmm_wr_event_data_q.address) begin
+            kernel_avmm_wr_ack <= 'b1;
+            kernel_avmm_wr_ack_burstcnt <= emif_avmm_wr_event_data_q.burstcnt;
+        end
+    end
+    if (kernel_avmm_reset) begin
+        kernel_avmm_wr_ack <= 'b0;
+        kernel_avmm_wr_ack_burstcnt <= 'b0;
+    end
+end
+
+//popping from the kernel's AVMM write-event FIFO needs to happen immediately
+//assign kernel_avmm_wr_event_deq = kernel_avmm_wr_ack;
+always_comb
+begin
+    if (emif_avmm_wr_ack_ff_notEmpty & emif_avmm_wr_event_ff_notEmpty & kernel_avmm_wr_event_ff_notEmpty &
+        (kernel_avmm_wr_event_data_q.address == emif_avmm_wr_event_data_q.address) )
+            kernel_avmm_wr_event_deq = 'b1;
+    else
+            kernel_avmm_wr_event_deq = 'b0;
+end
+
+endmodule : avmm_wr_ack_tracker

--- a/d5005/hardware/ofs_d5005/quartus.ini
+++ b/d5005/hardware/ofs_d5005/quartus.ini
@@ -1,8 +1,0 @@
-#from BBS build for DC
-pgm_allow_mt25q=on
-
-# Workaround that uses hssi_device.json in project's directory to display transceiver tile in Chip Planner
-acvq_use_project_path_hssi_json = on
-
-# Workaround to reduce timing errors introduced by crosstalk between static and PR regions
-route_xtalk_high_criticality=0.9

--- a/d5005/hardware/ofs_d5005_usm/build/bsp_design_files.tcl
+++ b/d5005/hardware/ofs_d5005_usm/build/bsp_design_files.tcl
@@ -29,6 +29,10 @@ set_global_assignment -name SYSTEMVERILOG_FILE "rtl/bsp_logic.sv"
 set_global_assignment -name SYSTEMVERILOG_FILE "rtl/dc_bsp_interfaces.sv"
 set_global_assignment -name SYSTEMVERILOG_FILE "rtl/dc_bsp_pkg.sv"
 set_global_assignment -name SYSTEMVERILOG_FILE "rtl/bsp_host_mem_if_mux.sv"
+set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_wr_ack_gen.sv"
+set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_wr_ack_burst_to_word.sv"
+set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_wr_ack_tracker.sv"
+set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_single_burst_partial_writes.sv"
 
 #--------------------
 # Search paths (for headers, etc)

--- a/d5005/hardware/ofs_d5005_usm/build/rtl/avmm_single_burst_partial_writes.v
+++ b/d5005/hardware/ofs_d5005_usm/build/rtl/avmm_single_burst_partial_writes.v
@@ -1,0 +1,375 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: MIT
+//
+
+`include "platform_if.vh"
+`include "fpga_defines.vh"
+`include "opencl_bsp.vh"
+
+// avmm_single_burst_partial_writes
+// Split an AVMM interface's partial writes into a single partial-write and 
+//  a re-grouped burst. Handles partial writes on either/or end of the burst
+//  (start and/or end), as well as initial bursts of 1.
+
+module avmm_single_burst_partial_writes  
+import dc_bsp_pkg::*;
+(
+    input       clk,
+    input       reset_n,
+
+    ofs_plat_avalon_mem_if.to_source to_avmm_source,
+    ofs_plat_avalon_mem_if.to_sink to_avmm_sink
+);
+
+localparam AVMM_BUFFER_WIDTH =  OPENCL_SVM_QSYS_ADDR_WIDTH +
+                                OPENCL_BSP_KERNEL_SVM_DATA_WIDTH +
+                                OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH +
+                                1 + //write req
+                                1 + //read req
+                                (OPENCL_BSP_KERNEL_SVM_DATA_WIDTH/8); //byteenable size
+localparam AVMM_BUFFER_DEPTH = 1024;
+localparam AVMM_BUFFER_SKID_SPACE = 64;
+localparam AVMM_BUFFER_ALMFULL_VALUE = AVMM_BUFFER_DEPTH - AVMM_BUFFER_SKID_SPACE;
+
+typedef struct packed {
+    logic read, write;
+    logic [OPENCL_SVM_QSYS_ADDR_WIDTH-1:0] address;
+    logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] burstcount;
+    logic [(OPENCL_BSP_KERNEL_SVM_DATA_WIDTH/8)-1:0] byteenable;
+    logic [OPENCL_BSP_KERNEL_SVM_DATA_WIDTH-1:0] writedata;
+} avmm_cmd_t;
+avmm_cmd_t avmm_cmd_buf_in, avmm_cmd_buf_out;
+
+typedef struct packed {
+    logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] burstcount;
+    logic valid;
+    logic read;
+    logic write;
+} avmm_burstcnt_t;
+localparam USM_BCNT_DWIDTH = OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH + 1 + 1 + 1;
+avmm_burstcnt_t [1:0] burstcnt_data;
+avmm_burstcnt_t usm_burstcnt_dout;
+logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] current_bcnt;
+logic [OPENCL_SVM_QSYS_ADDR_WIDTH-1:0] prev_address_plus1;
+localparam BCNT_WDOG_WIDTH = 10;
+logic [BCNT_WDOG_WIDTH-1:0] burstcnt_wdog;
+logic burstcnt_buffer_full, burstcnt_buffer_almfull, burstcnt_buffer_empty;
+logic [9:0] usm_burstcnt_buffer_usedw;
+typedef enum {  ST_SET_BCNT,
+                ST_DO_WR_BURST,
+                XXX } usm_bcnt_st_e;
+usm_bcnt_st_e usm_bcnt_cs, usm_bcnt_ns;
+logic usm_bcnt_st_is_setbcnt, usm_bcnt_st_is_do_wr_burst;
+logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] usm_avmm_fifo_rd_remaining;
+logic usm_avmm_fifo_rd, usm_bcnt_fifo_rd;
+logic [7:0] svm_addr_cnt;
+
+//the readdata-path is just passed-through
+always_comb begin
+    to_avmm_source.readdata = to_avmm_sink.readdata;
+    to_avmm_source.readdatavalid = to_avmm_sink.readdatavalid;
+end
+
+always_comb begin
+    avmm_cmd_buf_in.address    = to_avmm_source.write ? to_avmm_source.address + svm_addr_cnt : to_avmm_source.address;
+    avmm_cmd_buf_in.burstcount = to_avmm_source.write ? 'h1 : to_avmm_source.burstcount;
+    avmm_cmd_buf_in.write      = to_avmm_source.write;
+    avmm_cmd_buf_in.writedata  = to_avmm_source.writedata;
+    avmm_cmd_buf_in.read       = to_avmm_source.read;
+    avmm_cmd_buf_in.byteenable = to_avmm_source.byteenable;
+end
+
+always_ff @(posedge clk or negedge reset_n) begin
+    if (!reset_n) begin
+        svm_addr_cnt <= 'h0;
+    end else begin
+        if (svm_addr_cnt == (to_avmm_source.burstcount-'b1) ) begin
+            if (avmm_cmd_buf_in.write) begin
+                svm_addr_cnt <= 'b0;
+            end else begin
+                svm_addr_cnt <= svm_addr_cnt;
+            end
+        end else begin
+            svm_addr_cnt <= svm_addr_cnt + avmm_cmd_buf_in.write;
+        end
+    end
+end
+
+//due to WRA I need to add a buffer here, using almost-full to generate waitrequest to kernel.
+logic avmm_buffer_full, avmm_buffer_empty;
+logic [9:0] usm_avmm_buffer_usedw;
+scfifo
+#(
+    .lpm_numwords(AVMM_BUFFER_DEPTH),
+    .lpm_showahead("ON"),
+    .lpm_type("scfifo"),
+    .lpm_width(AVMM_BUFFER_WIDTH),
+    .lpm_widthu($clog2(AVMM_BUFFER_DEPTH)),
+    .almost_full_value(AVMM_BUFFER_ALMFULL_VALUE),
+    .overflow_checking("OFF"),
+    .underflow_checking("OFF"),
+    .use_eab("ON"),
+    .add_ram_output_register("ON")
+    )
+usm_avmm_buffer
+(
+    .clock(clk),
+    .sclr(!reset_n),
+
+    .data(avmm_cmd_buf_in),
+    .wrreq(avmm_cmd_buf_in.write | avmm_cmd_buf_in.read),
+    .full(avmm_buffer_full),
+    .almost_full(to_avmm_source.waitrequest),
+
+    .rdreq(usm_avmm_fifo_rd),
+    .q(avmm_cmd_buf_out),
+    .empty(avmm_buffer_empty),
+    .almost_empty(),
+
+    .aclr(),
+    .usedw(usm_avmm_buffer_usedw),
+    .eccstatus()
+);
+
+always_comb begin
+    to_avmm_sink.write = usm_avmm_fifo_rd & avmm_cmd_buf_out.write;
+    to_avmm_sink.read  = usm_avmm_fifo_rd & avmm_cmd_buf_out.read;
+    //higher-level interfaces don't like 'X' during simulation. Drive 0's when not driven
+    // by the kernel-system.
+    // synthesis translate off
+        to_avmm_sink.write = (usm_avmm_fifo_rd & avmm_cmd_buf_out.write) === 'X ? 'b0 : (usm_avmm_fifo_rd & avmm_cmd_buf_out.write);
+        to_avmm_sink.read  = (usm_avmm_fifo_rd & avmm_cmd_buf_out.read)  === 'X ? 'b0 : (usm_avmm_fifo_rd & avmm_cmd_buf_out.read);
+    // synthesis translate on
+    
+    to_avmm_sink.address    = avmm_cmd_buf_out.address;
+    to_avmm_sink.writedata  = avmm_cmd_buf_out.writedata;
+    to_avmm_sink.burstcount = avmm_cmd_buf_out.write ? usm_avmm_fifo_rd_remaining : avmm_cmd_buf_out.burstcount;
+    to_avmm_sink.byteenable = avmm_cmd_buf_out.byteenable;
+end
+
+//re-create the burst-count data based on byteenable, address, and original burst-count
+//Every partial-write (where byteenable is not all 1's) must result in be a burst-count of '1'.
+//Other writes should be grouped together into maximal-sized bursts.
+//
+//
+
+always_ff @(posedge clk) begin
+    if (!reset_n) begin
+        burstcnt_data <= 'h0;
+        current_bcnt <= 'h1;
+        prev_address_plus1 <= 'b0;
+        burstcnt_wdog <= 'b0;
+    end else begin
+        //when tracking a write-burst, we might need to flush it out because we don't know when the
+        //write from the kernel-system is actually complete.
+        burstcnt_wdog <= current_bcnt > 'h1 ? {burstcnt_wdog[0 +: (BCNT_WDOG_WIDTH-1)], 1'b1} : '0;
+        //push in a 0 to create a pulse for a follow-up partial write burstcount of 1
+        //it will be over-written later in the block if/when necessary.
+        burstcnt_data[1] <= burstcnt_data[0];
+        burstcnt_data[0].valid <= 1'b0;
+        //if it is a read req from the kernel-system, just use that burstcount value
+        if (avmm_cmd_buf_in.read) begin
+            burstcnt_wdog <= 'h0;
+            //if we were tracking a write-burst and a read comes in, send both the write and read in order
+            if (current_bcnt > 'h1) begin
+                burstcnt_data[1].burstcount <= current_bcnt - 'b1;
+                burstcnt_data[1].valid <= 1'b1;
+                burstcnt_data[1].write <= 1'b1;
+                burstcnt_data[1].read <= 1'b0;
+            end
+            burstcnt_data[0].burstcount <= to_avmm_source.burstcount;
+            burstcnt_data[0].valid <= 1'b1;
+            burstcnt_data[0].write <= 1'b0;
+            burstcnt_data[0].read <= 1'b1;
+            current_bcnt <= 'h1;
+        //if it is a write req from kernel-system, need to figure out the maximal burst
+        end else if (avmm_cmd_buf_in.write) begin
+            burstcnt_wdog <= 'h0;
+            //if original burst-cnt is 1, leave it as 1
+            if (to_avmm_source.burstcount == 'h1) begin
+                //if need to send the previous burst, too.
+                if (current_bcnt > 'h1) begin
+                    burstcnt_data[1].burstcount <= current_bcnt - 'b1;
+                    burstcnt_data[1].valid <= 1'b1;
+                    burstcnt_data[1].write <= 1'b1;
+                    burstcnt_data[1].read <= 1'b0;
+                end
+                burstcnt_data[0].burstcount <= 'h1;
+                burstcnt_data[0].valid <= 1'b1;
+                burstcnt_data[0].write <= 1'b1;
+                burstcnt_data[0].read  <= 1'b0;
+                current_bcnt <= 'h1;
+            //original burst-cnt is not 1; this is the first word of the burst
+            end else if (current_bcnt == 'h1) begin
+                if ( !(&avmm_cmd_buf_in.byteenable) ) begin
+                    burstcnt_data[0].burstcount <= 'h1;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                end else begin
+                    prev_address_plus1 <= avmm_cmd_buf_in.address + 'h1;
+                    current_bcnt <= 'h2;
+                end
+            //if continuous address
+            end else if (prev_address_plus1 == avmm_cmd_buf_in.address) begin
+                //if partial write, send burst and singleton
+                if ( !(&avmm_cmd_buf_in.byteenable) ) begin
+                    burstcnt_data[1].burstcount <= current_bcnt - 'b1;
+                    burstcnt_data[1].valid <= 1'b1;
+                    burstcnt_data[1].write <= 1'b1;
+                    burstcnt_data[1].read <= 1'b0;
+                    burstcnt_data[0].burstcount <= 'h1;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                //not a partial write and not a full burst, so keep adding to burstcount
+                end else if (current_bcnt < OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_MAX) begin
+                    current_bcnt <= current_bcnt + 'h1;
+                //full burst, so send burst and start again
+                end else begin
+                    burstcnt_data[0].burstcount <= current_bcnt;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                end
+                prev_address_plus1 <= avmm_cmd_buf_in.address + 'h1;
+            //not a continuous address, send the previous burst and start tracking the new one
+            end else begin
+                //if partial write, send burst and singleton
+                if ( !(&avmm_cmd_buf_in.byteenable) ) begin
+                    burstcnt_data[1].burstcount <= current_bcnt - 'b1;
+                    burstcnt_data[1].valid <= 1'b1;
+                    burstcnt_data[1].write <= 1'b1;
+                    burstcnt_data[1].read <= 1'b0;
+                    burstcnt_data[0].burstcount <= 'h1;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                //not partial burst, so send previous burst and continue tracking the new one
+                end else begin
+                    burstcnt_data[0].burstcount <= current_bcnt - 'b1;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                    prev_address_plus1 <= avmm_cmd_buf_in.address + 'h1;
+                end
+            end
+        //watchdog to flush out any final write request. 
+        end else if (&burstcnt_wdog) begin
+            burstcnt_data[0].burstcount <= current_bcnt - 'b1;
+            burstcnt_data[0].valid <= 1'b1;
+            burstcnt_data[0].write <= 1'b1;
+            burstcnt_data[0].read <= 1'b0;
+            current_bcnt <= 'h1;
+            burstcnt_wdog <= 'b0;
+        end
+    end
+end
+
+//push the burst-count info into a scFIFO
+scfifo
+#(
+    .lpm_numwords(AVMM_BUFFER_DEPTH),
+    .lpm_showahead("ON"),
+    .lpm_type("scfifo"),
+    .lpm_width(USM_BCNT_DWIDTH),
+    .lpm_widthu($clog2(AVMM_BUFFER_DEPTH)),
+    .almost_full_value(AVMM_BUFFER_ALMFULL_VALUE),
+    .overflow_checking("OFF"),
+    .underflow_checking("OFF"),
+    .use_eab("ON"),
+    .add_ram_output_register("ON")
+    )
+burstcnt_buffer
+(
+    .clock(clk),
+    .sclr(!reset_n),
+
+    .data(burstcnt_data[1]),
+    .wrreq(burstcnt_data[1].valid),
+    .full(burstcnt_buffer_full),
+    .almost_full(burstcnt_buffer_almfull),
+
+    .rdreq(usm_bcnt_fifo_rd),
+    .q(usm_burstcnt_dout),
+    .empty(burstcnt_buffer_empty),
+    .almost_empty(),
+
+    .aclr(),
+    .usedw(usm_burstcnt_buffer_usedw),
+    .eccstatus()
+);
+
+
+//will require some state machine to track coordination of popping from the 2 FIFOs
+// can't pop from the main FIFO until something exists in the bcnt FIFO.
+// for each entry in the bcnt FIFO, pop that number of elements from the main FIFO.
+// the main FIFO is populated prior to the bcnt FIFO having data, so we are guaranteed
+//   the main FIFO will always have enough data in it to satisfy the bcnt size.
+always_ff @(posedge clk)
+    if (!reset_n)
+        usm_bcnt_cs <= ST_SET_BCNT;
+    else
+        usm_bcnt_cs <= usm_bcnt_ns;
+
+always_comb begin
+    usm_bcnt_ns = XXX;
+    case (usm_bcnt_cs)
+        ST_SET_BCNT:    if (!burstcnt_buffer_empty && !to_avmm_sink.waitrequest) begin
+                            //if read or (bcnt == 1) stay here so we're ready 
+                            // for the next one on the next cycle
+                            if (usm_burstcnt_dout.read == 'b1 || 
+                                usm_burstcnt_dout.burstcount == 'h1) begin
+                                usm_bcnt_ns = ST_SET_BCNT;
+                            end else begin
+                                usm_bcnt_ns = ST_DO_WR_BURST;
+                            end
+                        end else begin
+                            usm_bcnt_ns = ST_SET_BCNT;
+                        end
+                        //if final word of this burst and not waitreq
+        ST_DO_WR_BURST: if (usm_avmm_fifo_rd_remaining == 'h1 && !to_avmm_sink.waitrequest) begin
+                            //if there is another burst waiting to go, stay here and start new burst
+                            if (!burstcnt_buffer_empty && usm_burstcnt_dout.write == 'b1 && usm_burstcnt_dout.burstcount != 'h1) begin
+                                usm_bcnt_ns = ST_DO_WR_BURST;
+                            end else begin
+                                usm_bcnt_ns = ST_SET_BCNT;
+                            end
+                        end else begin
+                            usm_bcnt_ns = ST_DO_WR_BURST;
+                        end
+    endcase
+end
+
+assign usm_bcnt_st_is_setbcnt = usm_bcnt_cs == ST_SET_BCNT;
+assign usm_bcnt_st_is_do_wr_burst = usm_bcnt_cs == ST_DO_WR_BURST;
+
+//use a counter to manage popping from the usm_avmm FIFO.
+always_ff @(posedge clk)
+    if (!reset_n)
+        usm_avmm_fifo_rd_remaining <= 'b0;
+    else begin
+        //if burstcount fifo isn't empty and !waitreq
+        if (!burstcnt_buffer_empty && !to_avmm_sink.waitrequest && (usm_bcnt_st_is_setbcnt || 
+           (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) ) ) begin
+            usm_avmm_fifo_rd_remaining <= usm_burstcnt_dout.read ? 'h1 : usm_burstcnt_dout.burstcount;
+        //pop from usm_avmm FIFO as long as the counter is non-zero and !waitreq
+        end else if (usm_avmm_fifo_rd)
+            usm_avmm_fifo_rd_remaining <= usm_avmm_fifo_rd_remaining - 'h1;
+        else 
+            usm_avmm_fifo_rd_remaining <= usm_avmm_fifo_rd_remaining;
+    end
+
+//we know there is sufficient data in the usm_avmm FIFO because the bcnt FIFO isn't written-to until the 
+// original burst has been pushed into the usm_avmm FIFO.
+assign usm_avmm_fifo_rd = usm_avmm_fifo_rd_remaining && !to_avmm_sink.waitrequest;
+//pop the next usm_bcnt value when? When it is first popped, so that the next value is already 
+// waiting on the FIFO output when we are done with the current burst.
+assign usm_bcnt_fifo_rd =   !burstcnt_buffer_empty && !to_avmm_sink.waitrequest && (usm_bcnt_st_is_setbcnt || 
+                            (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) );
+
+endmodule : avmm_single_burst_partial_writes

--- a/d5005/hardware/ofs_d5005_usm/build/rtl/avmm_wr_ack_burst_to_word.sv
+++ b/d5005/hardware/ofs_d5005_usm/build/rtl/avmm_wr_ack_burst_to_word.sv
@@ -1,0 +1,82 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: MIT
+//
+
+//
+//This module will convert a per-burst write-ack into a per-word write-ack
+//
+
+`include "ofs_plat_if.vh"
+
+module avmm_wr_ack_burst_to_word
+import dc_bsp_pkg::*;
+import local_mem_cfg_pkg::*;
+#(
+    parameter AVMM_ADDR_WIDTH=LOCAL_MEM_ADDR_WIDTH,
+    parameter AVMM_BURSTCNT_WIDTH=LOCAL_MEM_BURST_CNT_WIDTH
+)
+(
+    input logic clk,
+    input logic reset,
+    
+    input logic [AVMM_BURSTCNT_WIDTH-1:0] burstcnt,
+    input logic per_burst_write_ack_in,
+    
+    output logic per_word_write_ack_out
+);
+
+//Theory of operation:
+// Add burstcnt to the per_word_ack_counter upon reception of 
+//   per_burst_write_ack_in.
+// Decrement per_burst_write_ack_in each time we send a write-ack to 
+//   the kernel-system.
+// Don't forget about the case of simultaneous ack-in / ack-out.
+//
+
+logic [9:0] per_word_ack_counter;
+logic per_burst_write_ack_in_d;
+logic [AVMM_BURSTCNT_WIDTH-1:0] burstcnt_d;
+
+//register the incoming write-ack and burst-count
+always_ff @(posedge clk)
+begin
+    per_burst_write_ack_in_d    <= per_burst_write_ack_in;
+    burstcnt_d                  <= burstcnt;
+    if (reset) begin
+        per_burst_write_ack_in_d    <= 'b0;
+        burstcnt_d                  <= 'b0;
+    end
+end
+
+//manage the per-word write-ack counter
+// if ack-in and ack-out: add (burstcnt_d - 2)
+// else if ack-in: add (burstcnt_d - 1)
+// else if ack-out: decrement burstcnt_d
+always_ff @(posedge clk)
+begin
+    if (per_burst_write_ack_in_d & !per_word_ack_counter)
+        per_word_ack_counter <= burstcnt_d;
+    else if (per_burst_write_ack_in_d)
+        per_word_ack_counter <= per_word_ack_counter + burstcnt_d - per_word_write_ack_out;
+    else if (per_word_write_ack_out && (|per_word_ack_counter) )
+        per_word_ack_counter <= per_word_ack_counter - 1'b1;
+    
+    if (reset) 
+        per_word_ack_counter <= 'b0;
+end
+
+//generate a per-word write-ack when the counter is non-zero
+//always_ff @(posedge clk)
+//begin
+//    per_word_write_ack_out <= 1'b0;
+//    if (|per_word_ack_counter)
+//        per_word_write_ack_out <= 1'b1;
+//    if (reset)
+//        per_word_write_ack_out <= 1'b0;
+//end
+always_comb
+begin
+    per_word_write_ack_out = |per_word_ack_counter;
+end
+
+endmodule : avmm_wr_ack_burst_to_word

--- a/d5005/hardware/ofs_d5005_usm/build/rtl/avmm_wr_ack_gen.sv
+++ b/d5005/hardware/ofs_d5005_usm/build/rtl/avmm_wr_ack_gen.sv
@@ -1,0 +1,95 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: MIT
+//
+
+//
+//This module will track the per-burst write-acks from the AVMM-AXI conversion
+//  and generate the appropriate number of per-word write-acks to the
+//  kernel-system.
+//
+
+`include "ofs_plat_if.vh"
+
+module avmm_wr_ack_gen
+import dc_bsp_pkg::*;
+import local_mem_cfg_pkg::*;
+#(
+    parameter AVMM_ADDR_WIDTH=LOCAL_MEM_ADDR_WIDTH,
+    parameter AVMM_BURSTCNT_WIDTH=LOCAL_MEM_BURST_CNT_WIDTH
+)
+(
+    //in-channel 0
+    input logic kernel_avmm_clk,
+    input logic kernel_avmm_reset,
+    input logic kernel_avmm_waitreq,
+    input logic kernel_avmm_wr,
+    input logic [AVMM_BURSTCNT_WIDTH-1:0] kernel_avmm_burstcnt,
+    input logic [AVMM_ADDR_WIDTH-1:0] kernel_avmm_address,
+    output logic kernel_avmm_wr_ack,
+    
+    //out-channel
+    input logic emif_avmm_clk,
+    input logic emif_avmm_reset,
+    input logic emif_avmm_waitreq,
+    input logic emif_avmm_wr,
+    input logic [AVMM_BURSTCNT_WIDTH-1:0] emif_avmm_burstcnt,
+    input logic [AVMM_ADDR_WIDTH-1:0] emif_avmm_address,
+    input logic emif_avmm_wr_ack
+);
+
+//register kernel clock for local use
+logic [1:0] kernel_avmm_reset_d;
+logic kernel_avmm_reset_lcl;
+always_ff @(posedge kernel_avmm_clk or posedge kernel_avmm_reset) begin
+    kernel_avmm_reset_d <= {kernel_avmm_reset_d[0], 1'b0};
+    if (kernel_avmm_reset) kernel_avmm_reset_d <= 2'b11;
+end
+assign kernel_avmm_reset_lcl = kernel_avmm_reset_d[1];
+
+//Theory of operation:
+// Two sub-blocks - one to track the order of write-events between
+//  the kernel-system and DMA controller and associated burst-count,
+//  and one to generate the appropriate number of write-acks for the
+//  kernel-system. The AVMM-AXI conversion generates one write-ack
+//  per burst while the kernel-system expects one write-ack per word.
+//
+logic kernel_avmm_wr_ack_per_burst;
+logic [AVMM_BURSTCNT_WIDTH-1:0] kernel_avmm_wr_ack_burstcnt;
+
+// local-memory/DDR write-ack tracking
+avmm_wr_ack_tracker avmm_wr_ack_tracker_inst (
+    //in-channel 0
+    .kernel_avmm_clk        ,
+    .kernel_avmm_reset      (kernel_avmm_reset_lcl),
+    .kernel_avmm_waitreq    ,
+    .kernel_avmm_wr         ,
+    .kernel_avmm_burstcnt   ,
+    .kernel_avmm_address    ,
+    .kernel_avmm_wr_ack         (kernel_avmm_wr_ack_per_burst),
+    .kernel_avmm_wr_ack_burstcnt(kernel_avmm_wr_ack_burstcnt),
+    
+    //AVMM channel up to PIM (AVMM-AXI conversion with write-ack)
+    .emif_avmm_clk          ,
+    .emif_avmm_reset        ,
+    .emif_avmm_waitreq      ,
+    .emif_avmm_wr           ,
+    .emif_avmm_burstcnt     ,
+    .emif_avmm_address      ,
+    .emif_avmm_wr_ack      
+);
+
+
+//write-ack multiplier
+// write-acks from AVMM-AXI conversion was per-burst; kernel-system expets
+//  per-word.
+avmm_wr_ack_burst_to_word avmm_wr_ack_burst_to_word_inst
+(
+    .clk                    (kernel_avmm_clk),
+    .reset                  (kernel_avmm_reset_lcl),
+    .per_burst_write_ack_in (kernel_avmm_wr_ack_per_burst),
+    .burstcnt               (kernel_avmm_wr_ack_burstcnt),
+    .per_word_write_ack_out (kernel_avmm_wr_ack)
+);
+
+
+endmodule : avmm_wr_ack_gen

--- a/d5005/hardware/ofs_d5005_usm/build/rtl/avmm_wr_ack_tracker.sv
+++ b/d5005/hardware/ofs_d5005_usm/build/rtl/avmm_wr_ack_tracker.sv
@@ -1,0 +1,309 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: MIT
+//
+
+//This module will track the AVMM write-requests from 1 of 2 multiplexed 
+// channels and manage send single wr-ack signal back to the appropriate 
+// source.
+// a-ch ---
+//        |---c-ch
+// b-ch ---
+//
+
+`include "ofs_plat_if.vh"
+
+module avmm_wr_ack_tracker
+import dc_bsp_pkg::*;
+import local_mem_cfg_pkg::*;
+#(
+    parameter AVMM_ADDR_WIDTH=LOCAL_MEM_ADDR_WIDTH,
+    parameter AVMM_BURSTCNT_WIDTH=LOCAL_MEM_BURST_CNT_WIDTH
+)
+(
+    //in-channel 0
+    input logic kernel_avmm_clk,
+    input logic kernel_avmm_reset,
+    input logic kernel_avmm_waitreq,
+    input logic kernel_avmm_wr,
+    input logic [AVMM_BURSTCNT_WIDTH-1:0] kernel_avmm_burstcnt,
+    input logic [AVMM_ADDR_WIDTH-1:0] kernel_avmm_address,
+    //per-burst write-ack and burstcnt information for ack-multiplier
+    output logic kernel_avmm_wr_ack,
+    output logic [AVMM_BURSTCNT_WIDTH-1:0] kernel_avmm_wr_ack_burstcnt,
+    
+    //out-channel
+    input logic emif_avmm_clk,
+    input logic emif_avmm_reset,
+    input logic emif_avmm_waitreq,
+    input logic emif_avmm_wr,
+    input logic [AVMM_BURSTCNT_WIDTH-1:0] emif_avmm_burstcnt,
+    input logic [AVMM_ADDR_WIDTH-1:0] emif_avmm_address,
+    input logic emif_avmm_wr_ack
+);
+
+//Theory of operation:
+//  - push the in-channel write event into a FIFO
+//      - store the address, burstcnt
+//  - push the out-channel write event into another DCFIFO
+//      - store the address, burstcnt
+//      - read-side is in channel-0 clock domain
+//      - write-side is in out-channel clock domain
+//  - push the  write-ack into a DCFIFO
+//      - write-side is in out-channel clock domain
+//      - read-side is in channel-0 clock domain
+//  - pop the write-ack from the FIFO (ch0 clk domain)
+//  - use the popped-wrack to pop from the out-channel FIFO.
+//      - compare the address on the burst-channel Q output with
+//        the output on the channel-0 Q output.
+//          - if match, output the burstcnt and wrack signals to ch0
+//          - else, output the burstcnt and wrack signals to ch1 (unused)
+typedef struct packed {
+    logic [AVMM_BURSTCNT_WIDTH-1:0] burstcnt;
+    logic [AVMM_ADDR_WIDTH-1:0]     address;
+} write_event_data;
+
+localparam KERNEL_AVMM_WR_EVENT_FIFO_DEPTH = 512;
+localparam KERNEL_AVMM_WR_EVENT_ALMOSTFULL_THRESHOLD = 10;
+typedef enum {  ST_IDLE,
+                ST_BURST,
+                ST_XXX} write_event_state;
+write_event_state we_cs, we_ns;
+
+write_event_data kernel_avmm_wr_event_data;
+write_event_data kernel_avmm_wr_event_data_q;
+logic kernel_avmm_start_of_write;
+logic kernel_avmm_wr_event_notFull;
+logic kernel_avmm_wr_event_almostFull;
+logic kernel_avmm_wr_event_deq;
+logic kernel_avmm_wr_event_ff_notEmpty;
+logic [AVMM_BURSTCNT_WIDTH-1:0] kernel_avmm_burstcntr;
+logic kernel_avmm_valid_wr_req;
+
+//two states to track the initial write-events - idle and in-burst
+always_ff @(posedge kernel_avmm_clk)
+begin
+    we_cs  <= we_ns;
+    if (kernel_avmm_reset) we_cs <= ST_IDLE;
+end
+
+always_comb
+begin
+    we_ns = ST_XXX;
+    kernel_avmm_start_of_write = 'b0;
+    case (we_cs)
+        ST_IDLE:    if (kernel_avmm_valid_wr_req) begin
+                        //this is the start of a write-event
+                        kernel_avmm_start_of_write = 'b1;
+                        //if burstcnt is > 1
+                        if ( |(kernel_avmm_burstcnt>>1) ) begin
+                            we_ns = ST_BURST;
+                        end else begin
+                            we_ns = ST_IDLE;
+                        end
+                    end else begin
+                        we_ns = ST_IDLE;
+                    end
+        ST_BURST:   if (kernel_avmm_valid_wr_req) begin
+                        if (kernel_avmm_burstcntr=='h1) begin
+                            we_ns = ST_IDLE;
+                        end else begin
+                            we_ns = ST_BURST;
+                        end
+                    end else begin
+                        we_ns = ST_BURST;
+                    end
+    endcase
+end
+
+//kernel-system has WRA>0, so wait-request doesn't negate the wr signal
+assign kernel_avmm_valid_wr_req = kernel_avmm_wr;
+
+always_ff @(posedge kernel_avmm_clk) 
+begin
+    if (kernel_avmm_start_of_write)
+        kernel_avmm_burstcntr <= kernel_avmm_burstcnt - 1'b1;
+    else if (kernel_avmm_valid_wr_req)
+        kernel_avmm_burstcntr <= kernel_avmm_burstcntr - 1'b1;
+    if (kernel_avmm_reset)
+        kernel_avmm_burstcntr <= '1;
+end
+
+assign kernel_avmm_wr_event_data.burstcnt = kernel_avmm_burstcnt;
+assign kernel_avmm_wr_event_data.address  = kernel_avmm_address;
+
+ofs_plat_prim_fifo_dc 
+#(
+    .N_DATA_BITS(AVMM_ADDR_WIDTH+AVMM_BURSTCNT_WIDTH),
+    .N_ENTRIES  (KERNEL_AVMM_WR_EVENT_FIFO_DEPTH),
+    .THRESHOLD  (KERNEL_AVMM_WR_EVENT_ALMOSTFULL_THRESHOLD)
+)
+kernel_avmm_write_event_fifo
+(
+    .enq_clk    (kernel_avmm_clk),
+    .enq_reset_n(!kernel_avmm_reset),
+    .enq_data   (kernel_avmm_wr_event_data),
+    .enq_en     (kernel_avmm_start_of_write),
+    .notFull    (kernel_avmm_wr_event_notFull),
+    .almostFull (kernel_avmm_wr_event_almostFull),
+
+    .deq_clk    (kernel_avmm_clk),
+    .deq_reset_n(!kernel_avmm_reset),
+    .first      (kernel_avmm_wr_event_data_q),
+    .deq_en     (kernel_avmm_wr_event_deq),
+    .notEmpty   (kernel_avmm_wr_event_ff_notEmpty)
+);
+
+
+
+//
+//Capture the local-memory write events
+//
+
+localparam EMIF_AVMM_WR_EVENT_FIFO_DEPTH = 512;
+localparam EMIF_AVMM_WR_EVENT_ALMOSTFULL_THRESHOLD = 10;
+write_event_state lwe_cs, lwe_ns;
+
+write_event_data emif_avmm_wr_event_data;
+write_event_data emif_avmm_wr_event_data_q;
+logic emif_avmm_start_of_write;
+logic emif_avmm_wr_event_notFull;
+logic emif_avmm_wr_event_almostFull;
+logic emif_avmm_wr_event_ff_deq;
+logic emif_avmm_wr_event_ff_notEmpty;
+logic emif_avmm_decrement_burstcntr;
+logic [AVMM_BURSTCNT_WIDTH-1:0] emif_avmm_burstcntr;
+logic emif_avmm_valid_wr_req;
+
+//two states to track the initial write-events - idle and in-burst
+always_ff @(posedge emif_avmm_clk)
+begin
+    lwe_cs  <= lwe_ns;
+    if (emif_avmm_reset) lwe_cs <= ST_IDLE;
+end
+
+always_comb
+begin
+    lwe_ns = ST_XXX;
+    emif_avmm_start_of_write = 'b0;
+    case (lwe_cs)
+        ST_IDLE:    if (emif_avmm_valid_wr_req) begin
+                        //this is the start of a write-event
+                        emif_avmm_start_of_write = 'b1;
+                        //if burstcnt is > 1
+                        if ( |(emif_avmm_burstcnt>>1) ) begin
+                            lwe_ns = ST_BURST;
+                        end else begin
+                            lwe_ns = ST_IDLE;
+                        end
+                    end else begin
+                        lwe_ns = ST_IDLE;
+                    end
+        ST_BURST:   if (emif_avmm_valid_wr_req) begin
+                        if (emif_avmm_burstcntr=='h1) begin
+                            lwe_ns = ST_IDLE;
+                        end else begin
+                            lwe_ns = ST_BURST;
+                        end
+                    end else begin
+                        lwe_ns = ST_BURST;
+                    end
+    endcase
+end
+
+assign emif_avmm_valid_wr_req = emif_avmm_wr && !emif_avmm_waitreq;
+always_ff @(posedge emif_avmm_clk) 
+begin
+    if (emif_avmm_start_of_write)
+        emif_avmm_burstcntr <= emif_avmm_burstcnt - 1'b1;
+    else if (emif_avmm_valid_wr_req)
+        emif_avmm_burstcntr <= emif_avmm_burstcntr - 1'b1;
+    if (emif_avmm_reset)
+        emif_avmm_burstcntr <= '0;
+end
+
+assign emif_avmm_wr_event_data.address  = emif_avmm_address;
+assign emif_avmm_wr_event_data.burstcnt = emif_avmm_burstcnt;
+
+ofs_plat_prim_fifo_dc 
+#(
+    .N_DATA_BITS(AVMM_ADDR_WIDTH+AVMM_BURSTCNT_WIDTH),
+    .N_ENTRIES  (EMIF_AVMM_WR_EVENT_FIFO_DEPTH),
+    .THRESHOLD  (EMIF_AVMM_WR_EVENT_ALMOSTFULL_THRESHOLD)
+)
+emif_avmm_write_event_fifo
+(
+    .enq_clk    (emif_avmm_clk),
+    .enq_reset_n(!emif_avmm_reset),
+    .enq_data   (emif_avmm_wr_event_data),
+    .enq_en     (emif_avmm_start_of_write),
+    .notFull    (emif_avmm_wr_event_notFull),
+    .almostFull (emif_avmm_wr_event_almostFull),
+
+    .deq_clk    (kernel_avmm_clk),
+    .deq_reset_n(!kernel_avmm_reset),
+    .first      (emif_avmm_wr_event_data_q),
+    .deq_en     (emif_avmm_wr_event_ff_deq),
+    .notEmpty   (emif_avmm_wr_event_ff_notEmpty)
+);
+
+//sync the incoming emif_avmm_wr_ack signal into the kernel-clock domain
+logic emif_avmm_wr_ack_ff_notFull;
+logic emif_avmm_wr_ack_ff_almostFull;
+logic emif_avmm_wr_ack_ff_notEmpty;
+logic emif_avmm_wr_ack_ff_deq;
+ofs_plat_prim_fifo_dc 
+#(
+    .N_DATA_BITS(1),
+    .N_ENTRIES  (256),
+    .THRESHOLD  (2)
+)
+emif_avmm_write_ack_fifo
+(
+    .enq_clk    (emif_avmm_clk),
+    .enq_reset_n(!emif_avmm_reset),
+    .enq_data   (1'b1),
+    .enq_en     (emif_avmm_wr_ack),
+    .notFull    (emif_avmm_wr_ack_ff_notFull),
+    .almostFull (emif_avmm_wr_ack_ff_almostFull),
+
+    .deq_clk    (kernel_avmm_clk),
+    .deq_reset_n(!kernel_avmm_reset),
+    .first      (), //unused; just the notEmpty flag is needed
+    .deq_en     (emif_avmm_wr_ack_ff_deq),
+    .notEmpty   (emif_avmm_wr_ack_ff_notEmpty)
+);
+assign emif_avmm_wr_ack_ff_deq = emif_avmm_wr_ack_ff_notEmpty;
+
+//
+//the above two blocks capture the burst-cnt information for the kernel-system and local-memory requests
+//
+assign emif_avmm_wr_event_ff_deq = emif_avmm_wr_event_ff_notEmpty && emif_avmm_wr_ack_ff_notEmpty;
+
+always_ff @(posedge kernel_avmm_clk)
+begin
+    kernel_avmm_wr_ack <= 'b0;
+    
+    if (emif_avmm_wr_ack_ff_notEmpty & emif_avmm_wr_event_ff_notEmpty & kernel_avmm_wr_event_ff_notEmpty) begin
+        if (kernel_avmm_wr_event_data_q.address == emif_avmm_wr_event_data_q.address) begin
+            kernel_avmm_wr_ack <= 'b1;
+            kernel_avmm_wr_ack_burstcnt <= emif_avmm_wr_event_data_q.burstcnt;
+        end
+    end
+    if (kernel_avmm_reset) begin
+        kernel_avmm_wr_ack <= 'b0;
+        kernel_avmm_wr_ack_burstcnt <= 'b0;
+    end
+end
+
+//popping from the kernel's AVMM write-event FIFO needs to happen immediately
+//assign kernel_avmm_wr_event_deq = kernel_avmm_wr_ack;
+always_comb
+begin
+    if (emif_avmm_wr_ack_ff_notEmpty & emif_avmm_wr_event_ff_notEmpty & kernel_avmm_wr_event_ff_notEmpty &
+        (kernel_avmm_wr_event_data_q.address == emif_avmm_wr_event_data_q.address) )
+            kernel_avmm_wr_event_deq = 'b1;
+    else
+            kernel_avmm_wr_event_deq = 'b0;
+end
+
+endmodule : avmm_wr_ack_tracker

--- a/d5005/hardware/ofs_d5005_usm/build/rtl/kernel_wrapper.v
+++ b/d5005/hardware/ofs_d5005_usm/build/rtl/kernel_wrapper.v
@@ -22,32 +22,15 @@ import dc_bsp_pkg::*;
     `ifdef INCLUDE_USM_SUPPORT
         , ofs_plat_avalon_mem_if.to_sink kernel_svm
     `endif
+    `ifdef INCLUDE_UDP_OFFLOAD_ENGINE
+        ,shim_avst_if.source    udp_avst_from_kernel[IO_PIPES_NUM_CHAN-1:0],
+        shim_avst_if.sink       udp_avst_to_kernel[IO_PIPES_NUM_CHAN-1:0]
+    `endif
 );
 
 kernel_mem_intf mem_avmm_bridge [BSP_NUM_LOCAL_MEM_BANKS-1:0] ();
 opencl_kernel_control_intf kernel_cra_avmm_bridge ();
-logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] svm_avmm_bridge_burstcount;
-logic [OPENCL_SVM_QSYS_ADDR_WIDTH-1:0] svm_avmm_bridge_address;
 
-localparam USM_AVMM_BUFFER_WIDTH =  OPENCL_SVM_QSYS_ADDR_WIDTH +
-                                    OPENCL_BSP_KERNEL_SVM_DATA_WIDTH +
-                                    OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH +
-                                    1 + //write req
-                                    1 + //read req
-                                    (OPENCL_BSP_KERNEL_SVM_DATA_WIDTH/8); //byteenable size
-localparam USM_AVMM_BUFFER_DEPTH = 1024;
-localparam USM_AVMM_BUFFER_SKID_SPACE = 64;
-localparam USM_AVMM_BUFFER_ALMFULL_VALUE = USM_AVMM_BUFFER_DEPTH - USM_AVMM_BUFFER_SKID_SPACE;
-
-typedef struct packed {
-    logic read, write;
-    logic [OPENCL_SVM_QSYS_ADDR_WIDTH-1:0] address;
-    logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] burstcount;
-    logic [(OPENCL_BSP_KERNEL_SVM_DATA_WIDTH/8)-1:0] byteenable;
-    logic [OPENCL_BSP_KERNEL_SVM_DATA_WIDTH-1:0] writedata;
-} usm_avmm_cmd_t;
-usm_avmm_cmd_t usm_avmm_cmd_from_kernelsystem, usm_avmm_cmd_buf_out;
-        
 always_comb begin
     opencl_kernel_control.kernel_irq                = kernel_cra_avmm_bridge.kernel_irq;
 end
@@ -88,12 +71,16 @@ generate
             .m0_read           (kernel_mem[m].read         ),
             .m0_byteenable     (kernel_mem[m].byteenable   )
         );
+        
+        always_ff @(posedge clk) begin
+            mem_avmm_bridge[m].writeack <= kernel_mem[m].writeack;
+            if (!reset_n) mem_avmm_bridge[m].writeack <= 'b0;
+        end
     end : mem_pipes
 endgenerate
 
 `ifdef INCLUDE_USM_SUPPORT
     logic [OPENCL_MEMORY_BYTE_OFFSET-1:0] svm_addr_shift;
-    logic kernel_system_svm_read, kernel_system_svm_write;
     
     ofs_plat_avalon_mem_if
     # (
@@ -101,6 +88,12 @@ endgenerate
         .DATA_WIDTH (OPENCL_BSP_KERNEL_SVM_DATA_WIDTH),
         .BURST_CNT_WIDTH (OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH)
     ) svm_avmm_bridge ();
+    ofs_plat_avalon_mem_if
+    # (
+        .ADDR_WIDTH (OPENCL_SVM_QSYS_ADDR_WIDTH),
+        .DATA_WIDTH (OPENCL_BSP_KERNEL_SVM_DATA_WIDTH),
+        .BURST_CNT_WIDTH (OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH)
+    ) svm_avmm_kernelsystem ();
     
     always_comb begin
         kernel_svm.user  = 'b0;
@@ -189,6 +182,9 @@ kernel_system kernel_system_inst (
         .kernel_ddr4a_write           (mem_avmm_bridge[0].write        ),
         .kernel_ddr4a_read            (mem_avmm_bridge[0].read         ),
         .kernel_ddr4a_byteenable      (mem_avmm_bridge[0].byteenable   ),
+	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+	    .kernel_ddr4a_writeack        (mem_avmm_bridge[0].writeack     ),
+	`endif
     `endif
     `ifdef PAC_BSP_ENABLE_DDR4_BANK2
         .kernel_ddr4b_waitrequest     (mem_avmm_bridge[1].waitrequest  ),
@@ -200,6 +196,9 @@ kernel_system kernel_system_inst (
         .kernel_ddr4b_write           (mem_avmm_bridge[1].write        ),
         .kernel_ddr4b_read            (mem_avmm_bridge[1].read         ),
         .kernel_ddr4b_byteenable      (mem_avmm_bridge[1].byteenable   ),
+    	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+	    .kernel_ddr4b_writeack        (mem_avmm_bridge[1].writeack     ),
+	`endif
     `endif
     `ifdef PAC_BSP_ENABLE_DDR4_BANK3
         .kernel_ddr4c_waitrequest     (mem_avmm_bridge[2].waitrequest  ),
@@ -211,6 +210,9 @@ kernel_system kernel_system_inst (
         .kernel_ddr4c_write           (mem_avmm_bridge[2].write        ),
         .kernel_ddr4c_read            (mem_avmm_bridge[2].read         ),
         .kernel_ddr4c_byteenable      (mem_avmm_bridge[2].byteenable   ),
+	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+            .kernel_ddr4c_writeack        (mem_avmm_bridge[2].writeack     ),
+	`endif
     `endif
     `ifdef PAC_BSP_ENABLE_DDR4_BANK4
         .kernel_ddr4d_waitrequest     (mem_avmm_bridge[3].waitrequest  ),
@@ -222,6 +224,9 @@ kernel_system kernel_system_inst (
         .kernel_ddr4d_write           (mem_avmm_bridge[3].write        ),
         .kernel_ddr4d_read            (mem_avmm_bridge[3].read         ),
         .kernel_ddr4d_byteenable      (mem_avmm_bridge[3].byteenable   ),
+	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+	    .kernel_ddr4d_writeack        (mem_avmm_bridge[3].writeack     ),
+    	`endif
     `endif
 
     .kernel_irq_irq                 (kernel_cra_avmm_bridge.kernel_irq),
@@ -237,369 +242,178 @@ kernel_system kernel_system_inst (
     .kernel_cra_debugaccess         (kernel_cra_avmm_bridge.kernel_cra_debugaccess)
     
     `ifdef INCLUDE_USM_SUPPORT
-        `ifdef USM_DO_SINGLE_BURST_PARTIAL_WRITES
-            ,.kernel_mem_waitrequest    (usm_avmm_buffer_almfull),
-            .kernel_mem_readdata        (svm_avmm_bridge.readdata),
-            .kernel_mem_readdatavalid   (svm_avmm_bridge.readdatavalid),
-            .kernel_mem_burstcount      (svm_avmm_bridge_burstcount),
-            .kernel_mem_writedata       (usm_avmm_cmd_from_kernelsystem.writedata),
-            .kernel_mem_address         ({svm_avmm_bridge_address,svm_addr_shift}),
-            .kernel_mem_write           (usm_avmm_cmd_from_kernelsystem.write),
-            .kernel_mem_read            (usm_avmm_cmd_from_kernelsystem.read),
-            .kernel_mem_byteenable      (usm_avmm_cmd_from_kernelsystem.byteenable)
-        `else // not USM_DO_SINGLE_BURST_PARTIAL_WRITES
-            ,.kernel_mem_waitrequest    (svm_avmm_bridge.waitrequest),
-            .kernel_mem_readdata        (svm_avmm_bridge.readdata),
-            .kernel_mem_readdatavalid   (svm_avmm_bridge.readdatavalid),
-            .kernel_mem_burstcount      (svm_avmm_bridge_burstcount),
-            .kernel_mem_writedata       (svm_avmm_bridge.writedata),
-            .kernel_mem_address         ({svm_avmm_bridge_address,svm_addr_shift}),
-            .kernel_mem_write           (kernel_system_svm_write),
-            .kernel_mem_read            (kernel_system_svm_read),
-            .kernel_mem_byteenable      (svm_avmm_bridge.byteenable)
-        `endif // USM_DO_SINGLE_BURST_PARTIAL_WRITES
+        ,.kernel_mem_waitrequest    (svm_avmm_kernelsystem.waitrequest),
+        .kernel_mem_readdata        (svm_avmm_kernelsystem.readdata),
+        .kernel_mem_readdatavalid   (svm_avmm_kernelsystem.readdatavalid),
+        .kernel_mem_burstcount      (svm_avmm_kernelsystem.burstcount),
+        .kernel_mem_writedata       (svm_avmm_kernelsystem.writedata),
+        .kernel_mem_address         ({svm_avmm_kernelsystem.address,svm_addr_shift}),
+        .kernel_mem_write           (svm_avmm_kernelsystem.write),
+        .kernel_mem_read            (svm_avmm_kernelsystem.read),
+        .kernel_mem_byteenable      (svm_avmm_kernelsystem.byteenable)
     `endif //INCLUDE_USM_SUPPORT
+    
+    `ifdef INCLUDE_UDP_OFFLOAD_ENGINE
+        ,.udp_out_valid        (udp_avst_from_kernel[0].valid),
+        .udp_out_data          (udp_avst_from_kernel[0].data),
+        .udp_out_ready         (udp_avst_from_kernel[0].ready),
+        .udp_in_valid          (udp_avst_to_kernel[0].valid),
+        .udp_in_data           (udp_avst_to_kernel[0].data),
+        .udp_in_ready          (udp_avst_to_kernel[0].ready)
+        `ifdef ASP_ENABLE_IOPIPE1
+            ,.udp_out_1_valid        (udp_avst_from_kernel[1].valid),
+            .udp_out_1_data          (udp_avst_from_kernel[1].data),
+            .udp_out_1_ready         (udp_avst_from_kernel[1].ready),
+            .udp_in_1_valid          (udp_avst_to_kernel[1].valid),
+            .udp_in_1_data           (udp_avst_to_kernel[1].data),
+            .udp_in_1_ready          (udp_avst_to_kernel[1].ready)
+        `endif //ASP_ENABLE_IOPIPE1
+        `ifdef ASP_ENABLE_IOPIPE2
+            ,.udp_out_2_valid        (udp_avst_from_kernel[2].valid),
+            .udp_out_2_data          (udp_avst_from_kernel[2].data),
+            .udp_out_2_ready         (udp_avst_from_kernel[2].ready),
+            .udp_in_2_valid          (udp_avst_to_kernel[2].valid),
+            .udp_in_2_data           (udp_avst_to_kernel[2].data),
+            .udp_in_2_ready          (udp_avst_to_kernel[2].ready)
+        `endif //ASP_ENABLE_IOPIPE2
+        `ifdef ASP_ENABLE_IOPIPE3
+            ,.udp_out_3_valid        (udp_avst_from_kernel[3].valid),
+            .udp_out_3_data          (udp_avst_from_kernel[3].data),
+            .udp_out_3_ready         (udp_avst_from_kernel[3].ready),
+            .udp_in_3_valid          (udp_avst_to_kernel[3].valid),
+            .udp_in_3_data           (udp_avst_to_kernel[3].data),
+            .udp_in_3_ready          (udp_avst_to_kernel[3].ready)
+        `endif //ASP_ENABLE_IOPIPE3
+        `ifdef ASP_ENABLE_IOPIPE4
+            ,.udp_out_4_valid        (udp_avst_from_kernel[4].valid),
+            .udp_out_4_data          (udp_avst_from_kernel[4].data),
+            .udp_out_4_ready         (udp_avst_from_kernel[4].ready),
+            .udp_in_4_valid          (udp_avst_to_kernel[4].valid),
+            .udp_in_4_data           (udp_avst_to_kernel[4].data),
+            .udp_in_4_ready          (udp_avst_to_kernel[4].ready)
+        `endif //ASP_ENABLE_IOPIPE4
+        `ifdef ASP_ENABLE_IOPIPE5
+            ,.udp_out_5_valid        (udp_avst_from_kernel[5].valid),
+            .udp_out_5_data          (udp_avst_from_kernel[5].data),
+            .udp_out_5_ready         (udp_avst_from_kernel[5].ready),
+            .udp_in_5_valid          (udp_avst_to_kernel[5].valid),
+            .udp_in_5_data           (udp_avst_to_kernel[5].data),
+            .udp_in_5_ready          (udp_avst_to_kernel[5].ready)
+        `endif //ASP_ENABLE_IOPIPE5
+        `ifdef ASP_ENABLE_IOPIPE6
+            ,.udp_out_6_valid        (udp_avst_from_kernel[6].valid),
+            .udp_out_6_data          (udp_avst_from_kernel[6].data),
+            .udp_out_6_ready         (udp_avst_from_kernel[6].ready),
+            .udp_in_6_valid          (udp_avst_to_kernel[6].valid),
+            .udp_in_6_data           (udp_avst_to_kernel[6].data),
+            .udp_in_6_ready          (udp_avst_to_kernel[6].ready)
+        `endif //ASP_ENABLE_IOPIPE6
+        `ifdef ASP_ENABLE_IOPIPE7
+            ,.udp_out_7_valid        (udp_avst_from_kernel[7].valid),
+            .udp_out_7_data          (udp_avst_from_kernel[7].data),
+            .udp_out_7_ready         (udp_avst_from_kernel[7].ready),
+            .udp_in_7_valid          (udp_avst_to_kernel[7].valid),
+            .udp_in_7_data           (udp_avst_to_kernel[7].data),
+            .udp_in_7_ready          (udp_avst_to_kernel[7].ready)
+        `endif //ASP_ENABLE_IOPIPE7
+        `ifdef ASP_ENABLE_IOPIPE8
+            ,.udp_out_8_valid        (udp_avst_from_kernel[8].valid),
+            .udp_out_8_data          (udp_avst_from_kernel[8].data),
+            .udp_out_8_ready         (udp_avst_from_kernel[8].ready),
+            .udp_in_8_valid          (udp_avst_to_kernel[8].valid),
+            .udp_in_8_data           (udp_avst_to_kernel[8].data),
+            .udp_in_8_ready          (udp_avst_to_kernel[8].ready)
+        `endif //ASP_ENABLE_IOPIPE8
+        `ifdef ASP_ENABLE_IOPIPE9
+            ,.udp_out_9_valid        (udp_avst_from_kernel[9].valid),
+            .udp_out_9_data          (udp_avst_from_kernel[9].data),
+            .udp_out_9_ready         (udp_avst_from_kernel[9].ready),
+            .udp_in_9_valid          (udp_avst_to_kernel[9].valid),
+            .udp_in_9_data           (udp_avst_to_kernel[9].data),
+            .udp_in_9_ready          (udp_avst_to_kernel[9].ready)
+        `endif //ASP_ENABLE_IOPIPE9
+        `ifdef ASP_ENABLE_IOPIPE10
+            ,.udp_out_10_valid        (udp_avst_from_kernel[10].valid),
+            .udp_out_10_data          (udp_avst_from_kernel[10].data),
+            .udp_out_10_ready         (udp_avst_from_kernel[10].ready),
+            .udp_in_10_valid          (udp_avst_to_kernel[10].valid),
+            .udp_in_10_data           (udp_avst_to_kernel[10].data),
+            .udp_in_10_ready          (udp_avst_to_kernel[10].ready)
+        `endif //ASP_ENABLE_IOPIPE10
+        `ifdef ASP_ENABLE_IOPIPE11
+            ,.udp_out_11_valid        (udp_avst_from_kernel[11].valid),
+            .udp_out_11_data          (udp_avst_from_kernel[11].data),
+            .udp_out_11_ready         (udp_avst_from_kernel[11].ready),
+            .udp_in_11_valid          (udp_avst_to_kernel[11].valid),
+            .udp_in_11_data           (udp_avst_to_kernel[11].data),
+            .udp_in_11_ready          (udp_avst_to_kernel[11].ready)
+        `endif //ASP_ENABLE_IOPIPE11
+        `ifdef ASP_ENABLE_IOPIPE12
+            ,.udp_out_12_valid        (udp_avst_from_kernel[12].valid),
+            .udp_out_12_data          (udp_avst_from_kernel[12].data),
+            .udp_out_12_ready         (udp_avst_from_kernel[12].ready),
+            .udp_in_12_valid          (udp_avst_to_kernel[12].valid),
+            .udp_in_12_data           (udp_avst_to_kernel[12].data),
+            .udp_in_12_ready          (udp_avst_to_kernel[12].ready)
+        `endif //ASP_ENABLE_IOPIPE12
+        `ifdef ASP_ENABLE_IOPIPE13
+            ,.udp_out_13_valid        (udp_avst_from_kernel[13].valid),
+            .udp_out_13_data          (udp_avst_from_kernel[13].data),
+            .udp_out_13_ready         (udp_avst_from_kernel[13].ready),
+            .udp_in_13_valid          (udp_avst_to_kernel[13].valid),
+            .udp_in_13_data           (udp_avst_to_kernel[13].data),
+            .udp_in_13_ready          (udp_avst_to_kernel[13].ready)
+        `endif //ASP_ENABLE_IOPIPE13
+        `ifdef ASP_ENABLE_IOPIPE14
+            ,.udp_out_14_valid        (udp_avst_from_kernel[14].valid),
+            .udp_out_14_data          (udp_avst_from_kernel[14].data),
+            .udp_out_14_ready         (udp_avst_from_kernel[14].ready),
+            .udp_in_14_valid          (udp_avst_to_kernel[14].valid),
+            .udp_in_14_data           (udp_avst_to_kernel[14].data),
+            .udp_in_14_ready          (udp_avst_to_kernel[14].ready)
+        `endif //ASP_ENABLE_IOPIPE14
+        `ifdef ASP_ENABLE_IOPIPE15
+            ,.udp_out_15_valid        (udp_avst_from_kernel[15].valid),
+            .udp_out_15_data          (udp_avst_from_kernel[15].data),
+            .udp_out_15_ready         (udp_avst_from_kernel[15].ready),
+            .udp_in_15_valid          (udp_avst_to_kernel[15].valid),
+            .udp_in_15_data           (udp_avst_to_kernel[15].data),
+            .udp_in_15_ready          (udp_avst_to_kernel[15].ready)
+        `endif //ASP_ENABLE_IOPIPE15
+    `endif
 );
 
 `ifdef INCLUDE_USM_SUPPORT
     `ifdef USM_DO_SINGLE_BURST_PARTIAL_WRITES
-        
-        typedef struct packed {
-            logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] burstcount;
-            logic valid;
-            logic read;
-            logic write;
-        } usm_avmm_burstcnt_t;
-        localparam USM_BCNT_DWIDTH = OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH + 1 + 1 + 1;
-        usm_avmm_burstcnt_t [1:0] usm_burstcnt;
-        usm_avmm_burstcnt_t usm_burstcnt_dout;
-        logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] current_bcnt;
-        logic [OPENCL_SVM_QSYS_ADDR_WIDTH-1:0] prev_address_plus1;
-        localparam USM_BCNT_WDOG_WIDTH = 10;
-        logic [USM_BCNT_WDOG_WIDTH-1:0] usm_burstcnt_wdog;
-        logic usm_burstcnt_buffer_full, usm_burstcnt_buffer_almfull, usm_burstcnt_buffer_empty;
-        logic [9:0] usm_burstcnt_buffer_usedw;
-        typedef enum {  ST_SET_BCNT,
-                        ST_DO_WR_BURST,
-                        XXX } usm_bcnt_st_e;
-        usm_bcnt_st_e usm_bcnt_cs, usm_bcnt_ns;
-        logic usm_bcnt_st_is_setbcnt, usm_bcnt_st_is_do_wr_burst;
-        logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] usm_avmm_fifo_rd_remaining;
-        logic usm_avmm_fifo_rd, usm_bcnt_fifo_rd;
-        logic [7:0] svm_addr_cnt;
-        
-        //Work around the PIM's partial-host-memory-write limitations
-        always_comb begin
-            usm_avmm_cmd_from_kernelsystem.address    = usm_avmm_cmd_from_kernelsystem.write ? svm_avmm_bridge_address + svm_addr_cnt : svm_avmm_bridge_address;
-            usm_avmm_cmd_from_kernelsystem.burstcount = usm_avmm_cmd_from_kernelsystem.write ? 'h1 : svm_avmm_bridge_burstcount;
-        end
-        
-        always_ff @(posedge clk or negedge reset_n) begin
-            if (!reset_n) begin
-                svm_addr_cnt <= 'h0;
-            end else begin
-                if (svm_addr_cnt == (svm_avmm_bridge_burstcount-'b1) ) begin
-                    if (usm_avmm_cmd_from_kernelsystem.write) begin
-                        svm_addr_cnt <= 'b0;
-                    end else begin
-                        svm_addr_cnt <= svm_addr_cnt;
-                    end
-                end else begin
-                    svm_addr_cnt <= svm_addr_cnt + usm_avmm_cmd_from_kernelsystem.write;
-                end
-            end
-        end
-        
-        //due to WRA I need to add a buffer here, using almost-full to generate waitrequest to kernel.
-        logic usm_avmm_buffer_full, usm_avmm_buffer_almfull, usm_avmm_buffer_empty;
-        logic [9:0] usm_avmm_buffer_usedw;
-        scfifo
-        #(
-            .lpm_numwords(USM_AVMM_BUFFER_DEPTH),
-            .lpm_showahead("ON"),
-            .lpm_type("scfifo"),
-            .lpm_width(USM_AVMM_BUFFER_WIDTH),
-            .lpm_widthu($clog2(USM_AVMM_BUFFER_DEPTH)),
-            .almost_full_value(USM_AVMM_BUFFER_ALMFULL_VALUE),
-            .overflow_checking("OFF"),
-            .underflow_checking("OFF"),
-            .use_eab("ON"),
-            .add_ram_output_register("ON")
-            )
-        usm_avmm_buffer
+        avmm_single_burst_partial_writes avmm_single_burst_partial_writes_inst
         (
-            .clock(clk),
-            .sclr(!reset_n),
-    
-            .data(usm_avmm_cmd_from_kernelsystem),
-            .wrreq(usm_avmm_cmd_from_kernelsystem.write | usm_avmm_cmd_from_kernelsystem.read),
-            .full(usm_avmm_buffer_full),
-            .almost_full(usm_avmm_buffer_almfull),
-    
-            .rdreq(usm_avmm_fifo_rd),
-            .q(usm_avmm_cmd_buf_out),
-            .empty(usm_avmm_buffer_empty),
-            .almost_empty(),
-    
-            .aclr(),
-            .usedw(usm_avmm_buffer_usedw),
-            .eccstatus()
+            .clk      ,
+            .reset_n  ,
+            .to_avmm_source (svm_avmm_kernelsystem),
+            .to_avmm_sink   (svm_avmm_bridge)
         );
-        
-        always_comb begin
-            kernel_system_svm_write = usm_avmm_fifo_rd & usm_avmm_cmd_buf_out.write;
-            kernel_system_svm_read  = usm_avmm_fifo_rd & usm_avmm_cmd_buf_out.read;
-            
-            svm_avmm_bridge.address    = usm_avmm_cmd_buf_out.address;
-            svm_avmm_bridge.writedata  = usm_avmm_cmd_buf_out.writedata;
-            svm_avmm_bridge.burstcount = usm_avmm_cmd_buf_out.write ? usm_avmm_fifo_rd_remaining : usm_avmm_cmd_buf_out.burstcount;
-            svm_avmm_bridge.byteenable = usm_avmm_cmd_buf_out.byteenable;
-        end
-        
-        //re-create the burst-count data based on byteenable, address, and original burst-count
-        //Every partial-write (where byteenable is not all 1's) must result in be a burst-count of '1'.
-        //Other writes should be grouped together into maximal-sized bursts.
-        //
-        //
-        
-        always_ff @(posedge clk) begin
-            if (!reset_n) begin
-                usm_burstcnt <= 'h0;
-                current_bcnt <= 'h1;
-                prev_address_plus1 <= 'b0;
-                usm_burstcnt_wdog <= 'b0;
-            end else begin
-                //when tracking a write-burst, we might need to flush it out because we don't know when the
-                //write from the kernel-system is actually complete.
-                usm_burstcnt_wdog <= current_bcnt > 'h1 ? {usm_burstcnt_wdog[0 +: (USM_BCNT_WDOG_WIDTH-1)], 1'b1} : '0;
-                //push in a 0 to create a pulse for a follow-up partial write burstcount of 1
-                //it will be over-written later in the block if/when necessary.
-                usm_burstcnt[1] <= usm_burstcnt[0];
-                usm_burstcnt[0].valid <= 1'b0;
-                //if it is a read req from the kernel-system, just use that burstcount value
-                if (usm_avmm_cmd_from_kernelsystem.read) begin
-                    usm_burstcnt_wdog <= 'h0;
-                    //if we were tracking a write-burst and a read comes in, send both the write and read in order
-                    if (current_bcnt > 'h1) begin
-                        usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
-                        usm_burstcnt[1].valid <= 1'b1;
-                        usm_burstcnt[1].write <= 1'b1;
-                        usm_burstcnt[1].read <= 1'b0;
-                    end
-                    usm_burstcnt[0].burstcount <= svm_avmm_bridge_burstcount;
-                    usm_burstcnt[0].valid <= 1'b1;
-                    usm_burstcnt[0].write <= 1'b0;
-                    usm_burstcnt[0].read <= 1'b1;
-                    current_bcnt <= 'h1;
-                //if it is a write req from kernel-system, need to figure out the maximal burst
-                end else if (usm_avmm_cmd_from_kernelsystem.write) begin
-                    usm_burstcnt_wdog <= 'h0;
-                    //if original burst-cnt is 1, leave it as 1
-                    if (svm_avmm_bridge_burstcount == 'h1) begin
-                        //if need to send the previous burst, too.
-                        if (current_bcnt > 'h1) begin
-                            usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
-                            usm_burstcnt[1].valid <= 1'b1;
-                            usm_burstcnt[1].write <= 1'b1;
-                            usm_burstcnt[1].read <= 1'b0;
-                        end
-                        usm_burstcnt[0].burstcount <= 'h1;
-                        usm_burstcnt[0].valid <= 1'b1;
-                        usm_burstcnt[0].write <= 1'b1;
-                        usm_burstcnt[0].read  <= 1'b0;
-                        current_bcnt <= 'h1;
-                    //original burst-cnt is not 1; this is the first word of the burst
-                    end else if (current_bcnt == 'h1) begin
-                        if ( !(&usm_avmm_cmd_from_kernelsystem.byteenable) ) begin
-                            usm_burstcnt[0].burstcount <= 'h1;
-                            usm_burstcnt[0].valid <= 1'b1;
-                            usm_burstcnt[0].write <= 1'b1;
-                            usm_burstcnt[0].read <= 1'b0;
-                        end else begin
-                            prev_address_plus1 <= usm_avmm_cmd_from_kernelsystem.address + 'h1;
-                            current_bcnt <= 'h2;
-                        end
-                    //if continuous address
-                    end else if (prev_address_plus1 == usm_avmm_cmd_from_kernelsystem.address) begin
-                        //if partial write, send burst and singleton
-                        if ( !(&usm_avmm_cmd_from_kernelsystem.byteenable) ) begin
-                            usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
-                            usm_burstcnt[1].valid <= 1'b1;
-                            usm_burstcnt[1].write <= 1'b1;
-                            usm_burstcnt[1].read <= 1'b0;
-                            usm_burstcnt[0].burstcount <= 'h1;
-                            usm_burstcnt[0].valid <= 1'b1;
-                            usm_burstcnt[0].write <= 1'b1;
-                            usm_burstcnt[0].read <= 1'b0;
-                            current_bcnt <= 'h1;
-                        //not a partial write and not a full burst, so keep adding to burstcount
-                        end else if (current_bcnt < OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_MAX) begin
-                            current_bcnt <= current_bcnt + 'h1;
-                        //full burst, so send burst and start again
-                        end else begin
-                            usm_burstcnt[0].burstcount <= current_bcnt;
-                            usm_burstcnt[0].valid <= 1'b1;
-                            usm_burstcnt[0].write <= 1'b1;
-                            usm_burstcnt[0].read <= 1'b0;
-                            current_bcnt <= 'h1;
-                        end
-                        prev_address_plus1 <= usm_avmm_cmd_from_kernelsystem.address + 'h1;
-                    //not a continuous address, send the previous burst and start tracking the new one
-                    end else begin
-                        //if partial write, send burst and singleton
-                        if ( !(&usm_avmm_cmd_from_kernelsystem.byteenable) ) begin
-                            usm_burstcnt[1].burstcount <= current_bcnt - 'b1;
-                            usm_burstcnt[1].valid <= 1'b1;
-                            usm_burstcnt[1].write <= 1'b1;
-                            usm_burstcnt[1].read <= 1'b0;
-                            usm_burstcnt[0].burstcount <= 'h1;
-                            usm_burstcnt[0].valid <= 1'b1;
-                            usm_burstcnt[0].write <= 1'b1;
-                            usm_burstcnt[0].read <= 1'b0;
-                            current_bcnt <= 'h1;
-                        //not partial burst, so send previous burst and continue tracking the new one
-                        end else begin
-                            usm_burstcnt[0].burstcount <= current_bcnt - 'b1;
-                            usm_burstcnt[0].valid <= 1'b1;
-                            usm_burstcnt[0].write <= 1'b1;
-                            usm_burstcnt[0].read <= 1'b0;
-                            current_bcnt <= 'h1;
-                            prev_address_plus1 <= usm_avmm_cmd_from_kernelsystem.address + 'h1;
-                        end
-                    end
-                //watchdog to flush out any final write request. 
-                end else if (&usm_burstcnt_wdog) begin
-                    usm_burstcnt[0].burstcount <= current_bcnt - 'b1;
-                    usm_burstcnt[0].valid <= 1'b1;
-                    usm_burstcnt[0].write <= 1'b1;
-                    usm_burstcnt[0].read <= 1'b0;
-                    current_bcnt <= 'h1;
-                    usm_burstcnt_wdog <= 'b0;
-                end
-            end
-        end
-        
-        //push the burst-count info into a scFIFO
-        scfifo
-        #(
-            .lpm_numwords(USM_AVMM_BUFFER_DEPTH),
-            .lpm_showahead("ON"),
-            .lpm_type("scfifo"),
-            .lpm_width(USM_BCNT_DWIDTH),
-            .lpm_widthu($clog2(USM_AVMM_BUFFER_DEPTH)),
-            .almost_full_value(USM_AVMM_BUFFER_ALMFULL_VALUE),
-            .overflow_checking("OFF"),
-            .underflow_checking("OFF"),
-            .use_eab("ON"),
-            .add_ram_output_register("ON")
-            )
-        usm_burstcnt_buffer
-        (
-            .clock(clk),
-            .sclr(!reset_n),
-    
-            .data(usm_burstcnt[1]),
-            .wrreq(usm_burstcnt[1].valid),
-            .full(usm_burstcnt_buffer_full),
-            .almost_full(usm_burstcnt_buffer_almfull),
-    
-            .rdreq(usm_bcnt_fifo_rd),
-            .q(usm_burstcnt_dout),
-            .empty(usm_burstcnt_buffer_empty),
-            .almost_empty(),
-    
-            .aclr(),
-            .usedw(usm_burstcnt_buffer_usedw),
-            .eccstatus()
-        );
-        
-        
-        //will require some state machine to track coordination of popping from the 2 FIFOs
-        // can't pop from the main FIFO until something exists in the bcnt FIFO.
-        // for each entry in the bcnt FIFO, pop that number of elements from the main FIFO.
-        // the main FIFO is populated prior to the bcnt FIFO having data, so we are guaranteed
-        //   the main FIFO will always have enough data in it to satisfy the bcnt size.
-        always_ff @(posedge clk)
-            if (!reset_n)
-                usm_bcnt_cs <= ST_SET_BCNT;
-            else
-                usm_bcnt_cs <= usm_bcnt_ns;
-        
-        always_comb begin
-            usm_bcnt_ns = XXX;
-            case (usm_bcnt_cs)
-                ST_SET_BCNT:    if (!usm_burstcnt_buffer_empty && !svm_avmm_bridge.waitrequest) begin
-                                    //if read or (bcnt == 1) stay here so we're ready 
-                                    // for the next one on the next cycle
-                                    if (usm_burstcnt_dout.read == 'b1 || 
-                                        usm_burstcnt_dout.burstcount == 'h1) begin
-                                        usm_bcnt_ns = ST_SET_BCNT;
-                                    end else begin
-                                        usm_bcnt_ns = ST_DO_WR_BURST;
-                                    end
-                                end else begin
-                                    usm_bcnt_ns = ST_SET_BCNT;
-                                end
-                                //if final word of this burst and not waitreq
-                ST_DO_WR_BURST: if (usm_avmm_fifo_rd_remaining == 'h1 && !svm_avmm_bridge.waitrequest) begin
-                                    //if there is another burst waiting to go, stay here and start new burst
-                                    if (!usm_burstcnt_buffer_empty && usm_burstcnt_dout.write == 'b1 && usm_burstcnt_dout.burstcount != 'h1) begin
-                                        usm_bcnt_ns = ST_DO_WR_BURST;
-                                    end else begin
-                                        usm_bcnt_ns = ST_SET_BCNT;
-                                    end
-                                end else begin
-                                    usm_bcnt_ns = ST_DO_WR_BURST;
-                                end
-            endcase
-        end
-        
-        assign usm_bcnt_st_is_setbcnt = usm_bcnt_cs == ST_SET_BCNT;
-        assign usm_bcnt_st_is_do_wr_burst = usm_bcnt_cs == ST_DO_WR_BURST;
-        
-        //use a counter to manage popping from the usm_avmm FIFO.
-        always_ff @(posedge clk)
-            if (!reset_n)
-                usm_avmm_fifo_rd_remaining <= 'b0;
-            else begin
-                //if burstcount fifo isn't empty and !waitreq
-                if (!usm_burstcnt_buffer_empty && !svm_avmm_bridge.waitrequest && (usm_bcnt_st_is_setbcnt || 
-                   (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) ) ) begin
-                    usm_avmm_fifo_rd_remaining <= usm_burstcnt_dout.read ? 'h1 : usm_burstcnt_dout.burstcount;
-                //pop from usm_avmm FIFO as long as the counter is non-zero and !waitreq
-                end else if (usm_avmm_fifo_rd)
-                    usm_avmm_fifo_rd_remaining <= usm_avmm_fifo_rd_remaining - 'h1;
-                else 
-                    usm_avmm_fifo_rd_remaining <= usm_avmm_fifo_rd_remaining;
-            end
-
-        //we know there is sufficient data in the usm_avmm FIFO because the bcnt FIFO isn't written-to until the 
-        // original burst has been pushed into the usm_avmm FIFO.
-        assign usm_avmm_fifo_rd = usm_avmm_fifo_rd_remaining && !svm_avmm_bridge.waitrequest;
-        //pop the next usm_bcnt value when? When it is first popped, so that the next value is already 
-        // waiting on the FIFO output when we are done with the current burst.
-        assign usm_bcnt_fifo_rd =   !usm_burstcnt_buffer_empty && !svm_avmm_bridge.waitrequest && (usm_bcnt_st_is_setbcnt || 
-                                    (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) );
-        
     `else
+        //if not requiring partial-writes splitting, just pass the signals through
         always_comb begin
-            svm_avmm_bridge.address    = svm_avmm_bridge_address;
-            svm_avmm_bridge.burstcount = svm_avmm_bridge_burstcount;
+            svm_avmm_kernelsystem.waitrequest    = svm_avmm_bridge.waitrequest;
+            svm_avmm_kernelsystem.readdata       = svm_avmm_bridge.readdata;
+            svm_avmm_kernelsystem.readdatavalid  = svm_avmm_bridge.readdatavalid;
+            
+            svm_avmm_bridge.burstcount     = svm_avmm_kernelsystem.burstcount;
+            svm_avmm_bridge.writedata      = svm_avmm_kernelsystem.writedata ;
+            svm_avmm_bridge.address        = svm_avmm_kernelsystem.address   ;
+            svm_avmm_bridge.byteenable     = svm_avmm_kernelsystem.byteenable;
+            svm_avmm_bridge.write          = svm_avmm_kernelsystem.write     ;
+            svm_avmm_bridge.read           = svm_avmm_kernelsystem.read      ;
+            // Higher-level interfaces don't like 'X' during simulation. Drive 0's when not 
+            // driven by the kernel-system.
+            //drive with the modified version during simulation
+            // synthesis translate off
+                svm_avmm_bridge.write = svm_avmm_kernelsystem.write === 'X ? 'b0 : svm_avmm_kernelsystem.write;
+                svm_avmm_bridge.read  = svm_avmm_kernelsystem.read  === 'X ? 'b0 : svm_avmm_kernelsystem.read;
+            // synthesis translate on
         end
     `endif
-    
-    // Higher-level interfaces don't like 'X' during simulation. Drive 0's when not 
-    // driven by the kernel-system.
-    always_comb begin
-        //drive with the value from the kernel-system by default
-        svm_avmm_bridge.write = kernel_system_svm_write;
-        svm_avmm_bridge.read  = kernel_system_svm_read;
-        //drive with the modified version during simulation
-    // synthesis translate off
-        svm_avmm_bridge.write = kernel_system_svm_write === 'X ? 'b0 : kernel_system_svm_write;
-        svm_avmm_bridge.read  = kernel_system_svm_read  === 'X ? 'b0 : kernel_system_svm_read;
-    // synthesis translate on
-    end
 `endif
 
 endmodule : kernel_wrapper

--- a/d5005/hardware/ofs_d5005_usm/quartus.ini
+++ b/d5005/hardware/ofs_d5005_usm/quartus.ini
@@ -1,8 +1,0 @@
-#from BBS build for DC
-pgm_allow_mt25q=on
-
-# Workaround that uses hssi_device.json in project's directory to display transceiver tile in Chip Planner
-acvq_use_project_path_hssi_json = on
-
-# Workaround to reduce timing errors introduced by crosstalk between static and PR regions
-route_xtalk_high_criticality=0.9

--- a/n6001/hardware/ofs_n6001/build/bsp_design_files.tcl
+++ b/n6001/hardware/ofs_n6001/build/bsp_design_files.tcl
@@ -32,6 +32,7 @@ set_global_assignment -name SYSTEMVERILOG_FILE "rtl/bsp_host_mem_if_mux.sv"
 set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_wr_ack_gen.sv"
 set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_wr_ack_burst_to_word.sv"
 set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_wr_ack_tracker.sv"
+set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_single_burst_partial_writes.sv"
 
 #--------------------
 # Search paths (for headers, etc)

--- a/n6001/hardware/ofs_n6001/build/rtl/avmm_single_burst_partial_writes.v
+++ b/n6001/hardware/ofs_n6001/build/rtl/avmm_single_burst_partial_writes.v
@@ -1,0 +1,375 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: MIT
+//
+
+`include "platform_if.vh"
+`include "fpga_defines.vh"
+`include "opencl_bsp.vh"
+
+// avmm_single_burst_partial_writes
+// Split an AVMM interface's partial writes into a single partial-write and 
+//  a re-grouped burst. Handles partial writes on either/or end of the burst
+//  (start and/or end), as well as initial bursts of 1.
+
+module avmm_single_burst_partial_writes  
+import dc_bsp_pkg::*;
+(
+    input       clk,
+    input       reset_n,
+
+    ofs_plat_avalon_mem_if.to_source to_avmm_source,
+    ofs_plat_avalon_mem_if.to_sink to_avmm_sink
+);
+
+localparam AVMM_BUFFER_WIDTH =  OPENCL_SVM_QSYS_ADDR_WIDTH +
+                                OPENCL_BSP_KERNEL_SVM_DATA_WIDTH +
+                                OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH +
+                                1 + //write req
+                                1 + //read req
+                                (OPENCL_BSP_KERNEL_SVM_DATA_WIDTH/8); //byteenable size
+localparam AVMM_BUFFER_DEPTH = 1024;
+localparam AVMM_BUFFER_SKID_SPACE = 64;
+localparam AVMM_BUFFER_ALMFULL_VALUE = AVMM_BUFFER_DEPTH - AVMM_BUFFER_SKID_SPACE;
+
+typedef struct packed {
+    logic read, write;
+    logic [OPENCL_SVM_QSYS_ADDR_WIDTH-1:0] address;
+    logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] burstcount;
+    logic [(OPENCL_BSP_KERNEL_SVM_DATA_WIDTH/8)-1:0] byteenable;
+    logic [OPENCL_BSP_KERNEL_SVM_DATA_WIDTH-1:0] writedata;
+} avmm_cmd_t;
+avmm_cmd_t avmm_cmd_buf_in, avmm_cmd_buf_out;
+
+typedef struct packed {
+    logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] burstcount;
+    logic valid;
+    logic read;
+    logic write;
+} avmm_burstcnt_t;
+localparam USM_BCNT_DWIDTH = OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH + 1 + 1 + 1;
+avmm_burstcnt_t [1:0] burstcnt_data;
+avmm_burstcnt_t usm_burstcnt_dout;
+logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] current_bcnt;
+logic [OPENCL_SVM_QSYS_ADDR_WIDTH-1:0] prev_address_plus1;
+localparam BCNT_WDOG_WIDTH = 10;
+logic [BCNT_WDOG_WIDTH-1:0] burstcnt_wdog;
+logic burstcnt_buffer_full, burstcnt_buffer_almfull, burstcnt_buffer_empty;
+logic [9:0] usm_burstcnt_buffer_usedw;
+typedef enum {  ST_SET_BCNT,
+                ST_DO_WR_BURST,
+                XXX } usm_bcnt_st_e;
+usm_bcnt_st_e usm_bcnt_cs, usm_bcnt_ns;
+logic usm_bcnt_st_is_setbcnt, usm_bcnt_st_is_do_wr_burst;
+logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] usm_avmm_fifo_rd_remaining;
+logic usm_avmm_fifo_rd, usm_bcnt_fifo_rd;
+logic [7:0] svm_addr_cnt;
+
+//the readdata-path is just passed-through
+always_comb begin
+    to_avmm_source.readdata = to_avmm_sink.readdata;
+    to_avmm_source.readdatavalid = to_avmm_sink.readdatavalid;
+end
+
+always_comb begin
+    avmm_cmd_buf_in.address    = to_avmm_source.write ? to_avmm_source.address + svm_addr_cnt : to_avmm_source.address;
+    avmm_cmd_buf_in.burstcount = to_avmm_source.write ? 'h1 : to_avmm_source.burstcount;
+    avmm_cmd_buf_in.write      = to_avmm_source.write;
+    avmm_cmd_buf_in.writedata  = to_avmm_source.writedata;
+    avmm_cmd_buf_in.read       = to_avmm_source.read;
+    avmm_cmd_buf_in.byteenable = to_avmm_source.byteenable;
+end
+
+always_ff @(posedge clk or negedge reset_n) begin
+    if (!reset_n) begin
+        svm_addr_cnt <= 'h0;
+    end else begin
+        if (svm_addr_cnt == (to_avmm_source.burstcount-'b1) ) begin
+            if (avmm_cmd_buf_in.write) begin
+                svm_addr_cnt <= 'b0;
+            end else begin
+                svm_addr_cnt <= svm_addr_cnt;
+            end
+        end else begin
+            svm_addr_cnt <= svm_addr_cnt + avmm_cmd_buf_in.write;
+        end
+    end
+end
+
+//due to WRA I need to add a buffer here, using almost-full to generate waitrequest to kernel.
+logic avmm_buffer_full, avmm_buffer_empty;
+logic [9:0] usm_avmm_buffer_usedw;
+scfifo
+#(
+    .lpm_numwords(AVMM_BUFFER_DEPTH),
+    .lpm_showahead("ON"),
+    .lpm_type("scfifo"),
+    .lpm_width(AVMM_BUFFER_WIDTH),
+    .lpm_widthu($clog2(AVMM_BUFFER_DEPTH)),
+    .almost_full_value(AVMM_BUFFER_ALMFULL_VALUE),
+    .overflow_checking("OFF"),
+    .underflow_checking("OFF"),
+    .use_eab("ON"),
+    .add_ram_output_register("ON")
+    )
+usm_avmm_buffer
+(
+    .clock(clk),
+    .sclr(!reset_n),
+
+    .data(avmm_cmd_buf_in),
+    .wrreq(avmm_cmd_buf_in.write | avmm_cmd_buf_in.read),
+    .full(avmm_buffer_full),
+    .almost_full(to_avmm_source.waitrequest),
+
+    .rdreq(usm_avmm_fifo_rd),
+    .q(avmm_cmd_buf_out),
+    .empty(avmm_buffer_empty),
+    .almost_empty(),
+
+    .aclr(),
+    .usedw(usm_avmm_buffer_usedw),
+    .eccstatus()
+);
+
+always_comb begin
+    to_avmm_sink.write = usm_avmm_fifo_rd & avmm_cmd_buf_out.write;
+    to_avmm_sink.read  = usm_avmm_fifo_rd & avmm_cmd_buf_out.read;
+    //higher-level interfaces don't like 'X' during simulation. Drive 0's when not driven
+    // by the kernel-system.
+    // synthesis translate off
+        to_avmm_sink.write = (usm_avmm_fifo_rd & avmm_cmd_buf_out.write) === 'X ? 'b0 : (usm_avmm_fifo_rd & avmm_cmd_buf_out.write);
+        to_avmm_sink.read  = (usm_avmm_fifo_rd & avmm_cmd_buf_out.read)  === 'X ? 'b0 : (usm_avmm_fifo_rd & avmm_cmd_buf_out.read);
+    // synthesis translate on
+    
+    to_avmm_sink.address    = avmm_cmd_buf_out.address;
+    to_avmm_sink.writedata  = avmm_cmd_buf_out.writedata;
+    to_avmm_sink.burstcount = avmm_cmd_buf_out.write ? usm_avmm_fifo_rd_remaining : avmm_cmd_buf_out.burstcount;
+    to_avmm_sink.byteenable = avmm_cmd_buf_out.byteenable;
+end
+
+//re-create the burst-count data based on byteenable, address, and original burst-count
+//Every partial-write (where byteenable is not all 1's) must result in be a burst-count of '1'.
+//Other writes should be grouped together into maximal-sized bursts.
+//
+//
+
+always_ff @(posedge clk) begin
+    if (!reset_n) begin
+        burstcnt_data <= 'h0;
+        current_bcnt <= 'h1;
+        prev_address_plus1 <= 'b0;
+        burstcnt_wdog <= 'b0;
+    end else begin
+        //when tracking a write-burst, we might need to flush it out because we don't know when the
+        //write from the kernel-system is actually complete.
+        burstcnt_wdog <= current_bcnt > 'h1 ? {burstcnt_wdog[0 +: (BCNT_WDOG_WIDTH-1)], 1'b1} : '0;
+        //push in a 0 to create a pulse for a follow-up partial write burstcount of 1
+        //it will be over-written later in the block if/when necessary.
+        burstcnt_data[1] <= burstcnt_data[0];
+        burstcnt_data[0].valid <= 1'b0;
+        //if it is a read req from the kernel-system, just use that burstcount value
+        if (avmm_cmd_buf_in.read) begin
+            burstcnt_wdog <= 'h0;
+            //if we were tracking a write-burst and a read comes in, send both the write and read in order
+            if (current_bcnt > 'h1) begin
+                burstcnt_data[1].burstcount <= current_bcnt - 'b1;
+                burstcnt_data[1].valid <= 1'b1;
+                burstcnt_data[1].write <= 1'b1;
+                burstcnt_data[1].read <= 1'b0;
+            end
+            burstcnt_data[0].burstcount <= to_avmm_source.burstcount;
+            burstcnt_data[0].valid <= 1'b1;
+            burstcnt_data[0].write <= 1'b0;
+            burstcnt_data[0].read <= 1'b1;
+            current_bcnt <= 'h1;
+        //if it is a write req from kernel-system, need to figure out the maximal burst
+        end else if (avmm_cmd_buf_in.write) begin
+            burstcnt_wdog <= 'h0;
+            //if original burst-cnt is 1, leave it as 1
+            if (to_avmm_source.burstcount == 'h1) begin
+                //if need to send the previous burst, too.
+                if (current_bcnt > 'h1) begin
+                    burstcnt_data[1].burstcount <= current_bcnt - 'b1;
+                    burstcnt_data[1].valid <= 1'b1;
+                    burstcnt_data[1].write <= 1'b1;
+                    burstcnt_data[1].read <= 1'b0;
+                end
+                burstcnt_data[0].burstcount <= 'h1;
+                burstcnt_data[0].valid <= 1'b1;
+                burstcnt_data[0].write <= 1'b1;
+                burstcnt_data[0].read  <= 1'b0;
+                current_bcnt <= 'h1;
+            //original burst-cnt is not 1; this is the first word of the burst
+            end else if (current_bcnt == 'h1) begin
+                if ( !(&avmm_cmd_buf_in.byteenable) ) begin
+                    burstcnt_data[0].burstcount <= 'h1;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                end else begin
+                    prev_address_plus1 <= avmm_cmd_buf_in.address + 'h1;
+                    current_bcnt <= 'h2;
+                end
+            //if continuous address
+            end else if (prev_address_plus1 == avmm_cmd_buf_in.address) begin
+                //if partial write, send burst and singleton
+                if ( !(&avmm_cmd_buf_in.byteenable) ) begin
+                    burstcnt_data[1].burstcount <= current_bcnt - 'b1;
+                    burstcnt_data[1].valid <= 1'b1;
+                    burstcnt_data[1].write <= 1'b1;
+                    burstcnt_data[1].read <= 1'b0;
+                    burstcnt_data[0].burstcount <= 'h1;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                //not a partial write and not a full burst, so keep adding to burstcount
+                end else if (current_bcnt < OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_MAX) begin
+                    current_bcnt <= current_bcnt + 'h1;
+                //full burst, so send burst and start again
+                end else begin
+                    burstcnt_data[0].burstcount <= current_bcnt;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                end
+                prev_address_plus1 <= avmm_cmd_buf_in.address + 'h1;
+            //not a continuous address, send the previous burst and start tracking the new one
+            end else begin
+                //if partial write, send burst and singleton
+                if ( !(&avmm_cmd_buf_in.byteenable) ) begin
+                    burstcnt_data[1].burstcount <= current_bcnt - 'b1;
+                    burstcnt_data[1].valid <= 1'b1;
+                    burstcnt_data[1].write <= 1'b1;
+                    burstcnt_data[1].read <= 1'b0;
+                    burstcnt_data[0].burstcount <= 'h1;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                //not partial burst, so send previous burst and continue tracking the new one
+                end else begin
+                    burstcnt_data[0].burstcount <= current_bcnt - 'b1;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                    prev_address_plus1 <= avmm_cmd_buf_in.address + 'h1;
+                end
+            end
+        //watchdog to flush out any final write request. 
+        end else if (&burstcnt_wdog) begin
+            burstcnt_data[0].burstcount <= current_bcnt - 'b1;
+            burstcnt_data[0].valid <= 1'b1;
+            burstcnt_data[0].write <= 1'b1;
+            burstcnt_data[0].read <= 1'b0;
+            current_bcnt <= 'h1;
+            burstcnt_wdog <= 'b0;
+        end
+    end
+end
+
+//push the burst-count info into a scFIFO
+scfifo
+#(
+    .lpm_numwords(AVMM_BUFFER_DEPTH),
+    .lpm_showahead("ON"),
+    .lpm_type("scfifo"),
+    .lpm_width(USM_BCNT_DWIDTH),
+    .lpm_widthu($clog2(AVMM_BUFFER_DEPTH)),
+    .almost_full_value(AVMM_BUFFER_ALMFULL_VALUE),
+    .overflow_checking("OFF"),
+    .underflow_checking("OFF"),
+    .use_eab("ON"),
+    .add_ram_output_register("ON")
+    )
+burstcnt_buffer
+(
+    .clock(clk),
+    .sclr(!reset_n),
+
+    .data(burstcnt_data[1]),
+    .wrreq(burstcnt_data[1].valid),
+    .full(burstcnt_buffer_full),
+    .almost_full(burstcnt_buffer_almfull),
+
+    .rdreq(usm_bcnt_fifo_rd),
+    .q(usm_burstcnt_dout),
+    .empty(burstcnt_buffer_empty),
+    .almost_empty(),
+
+    .aclr(),
+    .usedw(usm_burstcnt_buffer_usedw),
+    .eccstatus()
+);
+
+
+//will require some state machine to track coordination of popping from the 2 FIFOs
+// can't pop from the main FIFO until something exists in the bcnt FIFO.
+// for each entry in the bcnt FIFO, pop that number of elements from the main FIFO.
+// the main FIFO is populated prior to the bcnt FIFO having data, so we are guaranteed
+//   the main FIFO will always have enough data in it to satisfy the bcnt size.
+always_ff @(posedge clk)
+    if (!reset_n)
+        usm_bcnt_cs <= ST_SET_BCNT;
+    else
+        usm_bcnt_cs <= usm_bcnt_ns;
+
+always_comb begin
+    usm_bcnt_ns = XXX;
+    case (usm_bcnt_cs)
+        ST_SET_BCNT:    if (!burstcnt_buffer_empty && !to_avmm_sink.waitrequest) begin
+                            //if read or (bcnt == 1) stay here so we're ready 
+                            // for the next one on the next cycle
+                            if (usm_burstcnt_dout.read == 'b1 || 
+                                usm_burstcnt_dout.burstcount == 'h1) begin
+                                usm_bcnt_ns = ST_SET_BCNT;
+                            end else begin
+                                usm_bcnt_ns = ST_DO_WR_BURST;
+                            end
+                        end else begin
+                            usm_bcnt_ns = ST_SET_BCNT;
+                        end
+                        //if final word of this burst and not waitreq
+        ST_DO_WR_BURST: if (usm_avmm_fifo_rd_remaining == 'h1 && !to_avmm_sink.waitrequest) begin
+                            //if there is another burst waiting to go, stay here and start new burst
+                            if (!burstcnt_buffer_empty && usm_burstcnt_dout.write == 'b1 && usm_burstcnt_dout.burstcount != 'h1) begin
+                                usm_bcnt_ns = ST_DO_WR_BURST;
+                            end else begin
+                                usm_bcnt_ns = ST_SET_BCNT;
+                            end
+                        end else begin
+                            usm_bcnt_ns = ST_DO_WR_BURST;
+                        end
+    endcase
+end
+
+assign usm_bcnt_st_is_setbcnt = usm_bcnt_cs == ST_SET_BCNT;
+assign usm_bcnt_st_is_do_wr_burst = usm_bcnt_cs == ST_DO_WR_BURST;
+
+//use a counter to manage popping from the usm_avmm FIFO.
+always_ff @(posedge clk)
+    if (!reset_n)
+        usm_avmm_fifo_rd_remaining <= 'b0;
+    else begin
+        //if burstcount fifo isn't empty and !waitreq
+        if (!burstcnt_buffer_empty && !to_avmm_sink.waitrequest && (usm_bcnt_st_is_setbcnt || 
+           (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) ) ) begin
+            usm_avmm_fifo_rd_remaining <= usm_burstcnt_dout.read ? 'h1 : usm_burstcnt_dout.burstcount;
+        //pop from usm_avmm FIFO as long as the counter is non-zero and !waitreq
+        end else if (usm_avmm_fifo_rd)
+            usm_avmm_fifo_rd_remaining <= usm_avmm_fifo_rd_remaining - 'h1;
+        else 
+            usm_avmm_fifo_rd_remaining <= usm_avmm_fifo_rd_remaining;
+    end
+
+//we know there is sufficient data in the usm_avmm FIFO because the bcnt FIFO isn't written-to until the 
+// original burst has been pushed into the usm_avmm FIFO.
+assign usm_avmm_fifo_rd = usm_avmm_fifo_rd_remaining && !to_avmm_sink.waitrequest;
+//pop the next usm_bcnt value when? When it is first popped, so that the next value is already 
+// waiting on the FIFO output when we are done with the current burst.
+assign usm_bcnt_fifo_rd =   !burstcnt_buffer_empty && !to_avmm_sink.waitrequest && (usm_bcnt_st_is_setbcnt || 
+                            (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) );
+
+endmodule : avmm_single_burst_partial_writes

--- a/n6001/hardware/ofs_n6001/quartus.ini
+++ b/n6001/hardware/ofs_n6001/quartus.ini
@@ -1,8 +1,0 @@
-#from BBS build for DC
-pgm_allow_mt25q=on
-
-# Workaround that uses hssi_device.json in project's directory to display transceiver tile in Chip Planner
-acvq_use_project_path_hssi_json = on
-
-# Workaround to reduce timing errors introduced by crosstalk between static and PR regions
-route_xtalk_high_criticality=0.9

--- a/n6001/hardware/ofs_n6001_iopipes/build/bsp_design_files.tcl
+++ b/n6001/hardware/ofs_n6001_iopipes/build/bsp_design_files.tcl
@@ -37,6 +37,7 @@ set_global_assignment -name SYSTEMVERILOG_FILE "rtl/bsp_host_mem_if_mux.sv"
 set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_wr_ack_gen.sv"
 set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_wr_ack_burst_to_word.sv"
 set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_wr_ack_tracker.sv"
+set_global_assignment -name SYSTEMVERILOG_FILE "rtl/avmm_single_burst_partial_writes.sv"
 
 #--------------------
 # Search paths (for headers, etc)

--- a/n6001/hardware/ofs_n6001_iopipes/build/rtl/avmm_single_burst_partial_writes.v
+++ b/n6001/hardware/ofs_n6001_iopipes/build/rtl/avmm_single_burst_partial_writes.v
@@ -1,0 +1,375 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: MIT
+//
+
+`include "platform_if.vh"
+`include "fpga_defines.vh"
+`include "opencl_bsp.vh"
+
+// avmm_single_burst_partial_writes
+// Split an AVMM interface's partial writes into a single partial-write and 
+//  a re-grouped burst. Handles partial writes on either/or end of the burst
+//  (start and/or end), as well as initial bursts of 1.
+
+module avmm_single_burst_partial_writes  
+import dc_bsp_pkg::*;
+(
+    input       clk,
+    input       reset_n,
+
+    ofs_plat_avalon_mem_if.to_source to_avmm_source,
+    ofs_plat_avalon_mem_if.to_sink to_avmm_sink
+);
+
+localparam AVMM_BUFFER_WIDTH =  OPENCL_SVM_QSYS_ADDR_WIDTH +
+                                OPENCL_BSP_KERNEL_SVM_DATA_WIDTH +
+                                OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH +
+                                1 + //write req
+                                1 + //read req
+                                (OPENCL_BSP_KERNEL_SVM_DATA_WIDTH/8); //byteenable size
+localparam AVMM_BUFFER_DEPTH = 1024;
+localparam AVMM_BUFFER_SKID_SPACE = 64;
+localparam AVMM_BUFFER_ALMFULL_VALUE = AVMM_BUFFER_DEPTH - AVMM_BUFFER_SKID_SPACE;
+
+typedef struct packed {
+    logic read, write;
+    logic [OPENCL_SVM_QSYS_ADDR_WIDTH-1:0] address;
+    logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] burstcount;
+    logic [(OPENCL_BSP_KERNEL_SVM_DATA_WIDTH/8)-1:0] byteenable;
+    logic [OPENCL_BSP_KERNEL_SVM_DATA_WIDTH-1:0] writedata;
+} avmm_cmd_t;
+avmm_cmd_t avmm_cmd_buf_in, avmm_cmd_buf_out;
+
+typedef struct packed {
+    logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] burstcount;
+    logic valid;
+    logic read;
+    logic write;
+} avmm_burstcnt_t;
+localparam USM_BCNT_DWIDTH = OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH + 1 + 1 + 1;
+avmm_burstcnt_t [1:0] burstcnt_data;
+avmm_burstcnt_t usm_burstcnt_dout;
+logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] current_bcnt;
+logic [OPENCL_SVM_QSYS_ADDR_WIDTH-1:0] prev_address_plus1;
+localparam BCNT_WDOG_WIDTH = 10;
+logic [BCNT_WDOG_WIDTH-1:0] burstcnt_wdog;
+logic burstcnt_buffer_full, burstcnt_buffer_almfull, burstcnt_buffer_empty;
+logic [9:0] usm_burstcnt_buffer_usedw;
+typedef enum {  ST_SET_BCNT,
+                ST_DO_WR_BURST,
+                XXX } usm_bcnt_st_e;
+usm_bcnt_st_e usm_bcnt_cs, usm_bcnt_ns;
+logic usm_bcnt_st_is_setbcnt, usm_bcnt_st_is_do_wr_burst;
+logic [OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_WIDTH-1:0] usm_avmm_fifo_rd_remaining;
+logic usm_avmm_fifo_rd, usm_bcnt_fifo_rd;
+logic [7:0] svm_addr_cnt;
+
+//the readdata-path is just passed-through
+always_comb begin
+    to_avmm_source.readdata = to_avmm_sink.readdata;
+    to_avmm_source.readdatavalid = to_avmm_sink.readdatavalid;
+end
+
+always_comb begin
+    avmm_cmd_buf_in.address    = to_avmm_source.write ? to_avmm_source.address + svm_addr_cnt : to_avmm_source.address;
+    avmm_cmd_buf_in.burstcount = to_avmm_source.write ? 'h1 : to_avmm_source.burstcount;
+    avmm_cmd_buf_in.write      = to_avmm_source.write;
+    avmm_cmd_buf_in.writedata  = to_avmm_source.writedata;
+    avmm_cmd_buf_in.read       = to_avmm_source.read;
+    avmm_cmd_buf_in.byteenable = to_avmm_source.byteenable;
+end
+
+always_ff @(posedge clk or negedge reset_n) begin
+    if (!reset_n) begin
+        svm_addr_cnt <= 'h0;
+    end else begin
+        if (svm_addr_cnt == (to_avmm_source.burstcount-'b1) ) begin
+            if (avmm_cmd_buf_in.write) begin
+                svm_addr_cnt <= 'b0;
+            end else begin
+                svm_addr_cnt <= svm_addr_cnt;
+            end
+        end else begin
+            svm_addr_cnt <= svm_addr_cnt + avmm_cmd_buf_in.write;
+        end
+    end
+end
+
+//due to WRA I need to add a buffer here, using almost-full to generate waitrequest to kernel.
+logic avmm_buffer_full, avmm_buffer_empty;
+logic [9:0] usm_avmm_buffer_usedw;
+scfifo
+#(
+    .lpm_numwords(AVMM_BUFFER_DEPTH),
+    .lpm_showahead("ON"),
+    .lpm_type("scfifo"),
+    .lpm_width(AVMM_BUFFER_WIDTH),
+    .lpm_widthu($clog2(AVMM_BUFFER_DEPTH)),
+    .almost_full_value(AVMM_BUFFER_ALMFULL_VALUE),
+    .overflow_checking("OFF"),
+    .underflow_checking("OFF"),
+    .use_eab("ON"),
+    .add_ram_output_register("ON")
+    )
+usm_avmm_buffer
+(
+    .clock(clk),
+    .sclr(!reset_n),
+
+    .data(avmm_cmd_buf_in),
+    .wrreq(avmm_cmd_buf_in.write | avmm_cmd_buf_in.read),
+    .full(avmm_buffer_full),
+    .almost_full(to_avmm_source.waitrequest),
+
+    .rdreq(usm_avmm_fifo_rd),
+    .q(avmm_cmd_buf_out),
+    .empty(avmm_buffer_empty),
+    .almost_empty(),
+
+    .aclr(),
+    .usedw(usm_avmm_buffer_usedw),
+    .eccstatus()
+);
+
+always_comb begin
+    to_avmm_sink.write = usm_avmm_fifo_rd & avmm_cmd_buf_out.write;
+    to_avmm_sink.read  = usm_avmm_fifo_rd & avmm_cmd_buf_out.read;
+    //higher-level interfaces don't like 'X' during simulation. Drive 0's when not driven
+    // by the kernel-system.
+    // synthesis translate off
+        to_avmm_sink.write = (usm_avmm_fifo_rd & avmm_cmd_buf_out.write) === 'X ? 'b0 : (usm_avmm_fifo_rd & avmm_cmd_buf_out.write);
+        to_avmm_sink.read  = (usm_avmm_fifo_rd & avmm_cmd_buf_out.read)  === 'X ? 'b0 : (usm_avmm_fifo_rd & avmm_cmd_buf_out.read);
+    // synthesis translate on
+    
+    to_avmm_sink.address    = avmm_cmd_buf_out.address;
+    to_avmm_sink.writedata  = avmm_cmd_buf_out.writedata;
+    to_avmm_sink.burstcount = avmm_cmd_buf_out.write ? usm_avmm_fifo_rd_remaining : avmm_cmd_buf_out.burstcount;
+    to_avmm_sink.byteenable = avmm_cmd_buf_out.byteenable;
+end
+
+//re-create the burst-count data based on byteenable, address, and original burst-count
+//Every partial-write (where byteenable is not all 1's) must result in be a burst-count of '1'.
+//Other writes should be grouped together into maximal-sized bursts.
+//
+//
+
+always_ff @(posedge clk) begin
+    if (!reset_n) begin
+        burstcnt_data <= 'h0;
+        current_bcnt <= 'h1;
+        prev_address_plus1 <= 'b0;
+        burstcnt_wdog <= 'b0;
+    end else begin
+        //when tracking a write-burst, we might need to flush it out because we don't know when the
+        //write from the kernel-system is actually complete.
+        burstcnt_wdog <= current_bcnt > 'h1 ? {burstcnt_wdog[0 +: (BCNT_WDOG_WIDTH-1)], 1'b1} : '0;
+        //push in a 0 to create a pulse for a follow-up partial write burstcount of 1
+        //it will be over-written later in the block if/when necessary.
+        burstcnt_data[1] <= burstcnt_data[0];
+        burstcnt_data[0].valid <= 1'b0;
+        //if it is a read req from the kernel-system, just use that burstcount value
+        if (avmm_cmd_buf_in.read) begin
+            burstcnt_wdog <= 'h0;
+            //if we were tracking a write-burst and a read comes in, send both the write and read in order
+            if (current_bcnt > 'h1) begin
+                burstcnt_data[1].burstcount <= current_bcnt - 'b1;
+                burstcnt_data[1].valid <= 1'b1;
+                burstcnt_data[1].write <= 1'b1;
+                burstcnt_data[1].read <= 1'b0;
+            end
+            burstcnt_data[0].burstcount <= to_avmm_source.burstcount;
+            burstcnt_data[0].valid <= 1'b1;
+            burstcnt_data[0].write <= 1'b0;
+            burstcnt_data[0].read <= 1'b1;
+            current_bcnt <= 'h1;
+        //if it is a write req from kernel-system, need to figure out the maximal burst
+        end else if (avmm_cmd_buf_in.write) begin
+            burstcnt_wdog <= 'h0;
+            //if original burst-cnt is 1, leave it as 1
+            if (to_avmm_source.burstcount == 'h1) begin
+                //if need to send the previous burst, too.
+                if (current_bcnt > 'h1) begin
+                    burstcnt_data[1].burstcount <= current_bcnt - 'b1;
+                    burstcnt_data[1].valid <= 1'b1;
+                    burstcnt_data[1].write <= 1'b1;
+                    burstcnt_data[1].read <= 1'b0;
+                end
+                burstcnt_data[0].burstcount <= 'h1;
+                burstcnt_data[0].valid <= 1'b1;
+                burstcnt_data[0].write <= 1'b1;
+                burstcnt_data[0].read  <= 1'b0;
+                current_bcnt <= 'h1;
+            //original burst-cnt is not 1; this is the first word of the burst
+            end else if (current_bcnt == 'h1) begin
+                if ( !(&avmm_cmd_buf_in.byteenable) ) begin
+                    burstcnt_data[0].burstcount <= 'h1;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                end else begin
+                    prev_address_plus1 <= avmm_cmd_buf_in.address + 'h1;
+                    current_bcnt <= 'h2;
+                end
+            //if continuous address
+            end else if (prev_address_plus1 == avmm_cmd_buf_in.address) begin
+                //if partial write, send burst and singleton
+                if ( !(&avmm_cmd_buf_in.byteenable) ) begin
+                    burstcnt_data[1].burstcount <= current_bcnt - 'b1;
+                    burstcnt_data[1].valid <= 1'b1;
+                    burstcnt_data[1].write <= 1'b1;
+                    burstcnt_data[1].read <= 1'b0;
+                    burstcnt_data[0].burstcount <= 'h1;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                //not a partial write and not a full burst, so keep adding to burstcount
+                end else if (current_bcnt < OPENCL_BSP_KERNEL_SVM_BURSTCOUNT_MAX) begin
+                    current_bcnt <= current_bcnt + 'h1;
+                //full burst, so send burst and start again
+                end else begin
+                    burstcnt_data[0].burstcount <= current_bcnt;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                end
+                prev_address_plus1 <= avmm_cmd_buf_in.address + 'h1;
+            //not a continuous address, send the previous burst and start tracking the new one
+            end else begin
+                //if partial write, send burst and singleton
+                if ( !(&avmm_cmd_buf_in.byteenable) ) begin
+                    burstcnt_data[1].burstcount <= current_bcnt - 'b1;
+                    burstcnt_data[1].valid <= 1'b1;
+                    burstcnt_data[1].write <= 1'b1;
+                    burstcnt_data[1].read <= 1'b0;
+                    burstcnt_data[0].burstcount <= 'h1;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                //not partial burst, so send previous burst and continue tracking the new one
+                end else begin
+                    burstcnt_data[0].burstcount <= current_bcnt - 'b1;
+                    burstcnt_data[0].valid <= 1'b1;
+                    burstcnt_data[0].write <= 1'b1;
+                    burstcnt_data[0].read <= 1'b0;
+                    current_bcnt <= 'h1;
+                    prev_address_plus1 <= avmm_cmd_buf_in.address + 'h1;
+                end
+            end
+        //watchdog to flush out any final write request. 
+        end else if (&burstcnt_wdog) begin
+            burstcnt_data[0].burstcount <= current_bcnt - 'b1;
+            burstcnt_data[0].valid <= 1'b1;
+            burstcnt_data[0].write <= 1'b1;
+            burstcnt_data[0].read <= 1'b0;
+            current_bcnt <= 'h1;
+            burstcnt_wdog <= 'b0;
+        end
+    end
+end
+
+//push the burst-count info into a scFIFO
+scfifo
+#(
+    .lpm_numwords(AVMM_BUFFER_DEPTH),
+    .lpm_showahead("ON"),
+    .lpm_type("scfifo"),
+    .lpm_width(USM_BCNT_DWIDTH),
+    .lpm_widthu($clog2(AVMM_BUFFER_DEPTH)),
+    .almost_full_value(AVMM_BUFFER_ALMFULL_VALUE),
+    .overflow_checking("OFF"),
+    .underflow_checking("OFF"),
+    .use_eab("ON"),
+    .add_ram_output_register("ON")
+    )
+burstcnt_buffer
+(
+    .clock(clk),
+    .sclr(!reset_n),
+
+    .data(burstcnt_data[1]),
+    .wrreq(burstcnt_data[1].valid),
+    .full(burstcnt_buffer_full),
+    .almost_full(burstcnt_buffer_almfull),
+
+    .rdreq(usm_bcnt_fifo_rd),
+    .q(usm_burstcnt_dout),
+    .empty(burstcnt_buffer_empty),
+    .almost_empty(),
+
+    .aclr(),
+    .usedw(usm_burstcnt_buffer_usedw),
+    .eccstatus()
+);
+
+
+//will require some state machine to track coordination of popping from the 2 FIFOs
+// can't pop from the main FIFO until something exists in the bcnt FIFO.
+// for each entry in the bcnt FIFO, pop that number of elements from the main FIFO.
+// the main FIFO is populated prior to the bcnt FIFO having data, so we are guaranteed
+//   the main FIFO will always have enough data in it to satisfy the bcnt size.
+always_ff @(posedge clk)
+    if (!reset_n)
+        usm_bcnt_cs <= ST_SET_BCNT;
+    else
+        usm_bcnt_cs <= usm_bcnt_ns;
+
+always_comb begin
+    usm_bcnt_ns = XXX;
+    case (usm_bcnt_cs)
+        ST_SET_BCNT:    if (!burstcnt_buffer_empty && !to_avmm_sink.waitrequest) begin
+                            //if read or (bcnt == 1) stay here so we're ready 
+                            // for the next one on the next cycle
+                            if (usm_burstcnt_dout.read == 'b1 || 
+                                usm_burstcnt_dout.burstcount == 'h1) begin
+                                usm_bcnt_ns = ST_SET_BCNT;
+                            end else begin
+                                usm_bcnt_ns = ST_DO_WR_BURST;
+                            end
+                        end else begin
+                            usm_bcnt_ns = ST_SET_BCNT;
+                        end
+                        //if final word of this burst and not waitreq
+        ST_DO_WR_BURST: if (usm_avmm_fifo_rd_remaining == 'h1 && !to_avmm_sink.waitrequest) begin
+                            //if there is another burst waiting to go, stay here and start new burst
+                            if (!burstcnt_buffer_empty && usm_burstcnt_dout.write == 'b1 && usm_burstcnt_dout.burstcount != 'h1) begin
+                                usm_bcnt_ns = ST_DO_WR_BURST;
+                            end else begin
+                                usm_bcnt_ns = ST_SET_BCNT;
+                            end
+                        end else begin
+                            usm_bcnt_ns = ST_DO_WR_BURST;
+                        end
+    endcase
+end
+
+assign usm_bcnt_st_is_setbcnt = usm_bcnt_cs == ST_SET_BCNT;
+assign usm_bcnt_st_is_do_wr_burst = usm_bcnt_cs == ST_DO_WR_BURST;
+
+//use a counter to manage popping from the usm_avmm FIFO.
+always_ff @(posedge clk)
+    if (!reset_n)
+        usm_avmm_fifo_rd_remaining <= 'b0;
+    else begin
+        //if burstcount fifo isn't empty and !waitreq
+        if (!burstcnt_buffer_empty && !to_avmm_sink.waitrequest && (usm_bcnt_st_is_setbcnt || 
+           (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) ) ) begin
+            usm_avmm_fifo_rd_remaining <= usm_burstcnt_dout.read ? 'h1 : usm_burstcnt_dout.burstcount;
+        //pop from usm_avmm FIFO as long as the counter is non-zero and !waitreq
+        end else if (usm_avmm_fifo_rd)
+            usm_avmm_fifo_rd_remaining <= usm_avmm_fifo_rd_remaining - 'h1;
+        else 
+            usm_avmm_fifo_rd_remaining <= usm_avmm_fifo_rd_remaining;
+    end
+
+//we know there is sufficient data in the usm_avmm FIFO because the bcnt FIFO isn't written-to until the 
+// original burst has been pushed into the usm_avmm FIFO.
+assign usm_avmm_fifo_rd = usm_avmm_fifo_rd_remaining && !to_avmm_sink.waitrequest;
+//pop the next usm_bcnt value when? When it is first popped, so that the next value is already 
+// waiting on the FIFO output when we are done with the current burst.
+assign usm_bcnt_fifo_rd =   !burstcnt_buffer_empty && !to_avmm_sink.waitrequest && (usm_bcnt_st_is_setbcnt || 
+                            (usm_bcnt_st_is_do_wr_burst && usm_avmm_fifo_rd_remaining == 'h1) );
+
+endmodule : avmm_single_burst_partial_writes

--- a/n6001/hardware/ofs_n6001_iopipes/quartus.ini
+++ b/n6001/hardware/ofs_n6001_iopipes/quartus.ini
@@ -4,5 +4,5 @@ pgm_allow_mt25q=on
 # Workaround that uses hssi_device.json in project's directory to display transceiver tile in Chip Planner
 acvq_use_project_path_hssi_json = on
 
-# Workaround to reduce timing erorrs introduced by crosstalk between Static and PR regions
+# Workaround to reduce timing errors introduced by crosstalk between static and PR regions
 route_xtalk_high_criticality=0.9

--- a/n6001/hardware/ofs_n6001_iopipes/quartus.ini
+++ b/n6001/hardware/ofs_n6001_iopipes/quartus.ini
@@ -1,8 +1,0 @@
-#from BBS build for DC
-pgm_allow_mt25q=on
-
-# Workaround that uses hssi_device.json in project's directory to display transceiver tile in Chip Planner
-acvq_use_project_path_hssi_json = on
-
-# Workaround to reduce timing errors introduced by crosstalk between static and PR regions
-route_xtalk_high_criticality=0.9

--- a/n6001/hardware/ofs_n6001_usm/build/rtl/kernel_wrapper.v
+++ b/n6001/hardware/ofs_n6001_usm/build/rtl/kernel_wrapper.v
@@ -182,7 +182,9 @@ kernel_system kernel_system_inst (
         .kernel_ddr4a_write           (mem_avmm_bridge[0].write        ),
         .kernel_ddr4a_read            (mem_avmm_bridge[0].read         ),
         .kernel_ddr4a_byteenable      (mem_avmm_bridge[0].byteenable   ),
-        .kernel_ddr4a_writeack        (mem_avmm_bridge[0].writeack     ),
+	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+	    .kernel_ddr4a_writeack        (mem_avmm_bridge[0].writeack     ),
+	`endif
     `endif
     `ifdef PAC_BSP_ENABLE_DDR4_BANK2
         .kernel_ddr4b_waitrequest     (mem_avmm_bridge[1].waitrequest  ),
@@ -194,7 +196,9 @@ kernel_system kernel_system_inst (
         .kernel_ddr4b_write           (mem_avmm_bridge[1].write        ),
         .kernel_ddr4b_read            (mem_avmm_bridge[1].read         ),
         .kernel_ddr4b_byteenable      (mem_avmm_bridge[1].byteenable   ),
-        .kernel_ddr4b_writeack        (mem_avmm_bridge[1].writeack     ),
+    	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+	    .kernel_ddr4b_writeack        (mem_avmm_bridge[1].writeack     ),
+	`endif
     `endif
     `ifdef PAC_BSP_ENABLE_DDR4_BANK3
         .kernel_ddr4c_waitrequest     (mem_avmm_bridge[2].waitrequest  ),
@@ -206,7 +210,9 @@ kernel_system kernel_system_inst (
         .kernel_ddr4c_write           (mem_avmm_bridge[2].write        ),
         .kernel_ddr4c_read            (mem_avmm_bridge[2].read         ),
         .kernel_ddr4c_byteenable      (mem_avmm_bridge[2].byteenable   ),
-        .kernel_ddr4c_writeack        (mem_avmm_bridge[2].writeack     ),
+	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+            .kernel_ddr4c_writeack        (mem_avmm_bridge[2].writeack     ),
+	`endif
     `endif
     `ifdef PAC_BSP_ENABLE_DDR4_BANK4
         .kernel_ddr4d_waitrequest     (mem_avmm_bridge[3].waitrequest  ),
@@ -218,7 +224,9 @@ kernel_system kernel_system_inst (
         .kernel_ddr4d_write           (mem_avmm_bridge[3].write        ),
         .kernel_ddr4d_read            (mem_avmm_bridge[3].read         ),
         .kernel_ddr4d_byteenable      (mem_avmm_bridge[3].byteenable   ),
-        .kernel_ddr4d_writeack        (mem_avmm_bridge[3].writeack     ),
+	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+	    .kernel_ddr4d_writeack        (mem_avmm_bridge[3].writeack     ),
+    	`endif
     `endif
 
     .kernel_irq_irq                 (kernel_cra_avmm_bridge.kernel_irq),
@@ -276,6 +284,102 @@ kernel_system kernel_system_inst (
             .udp_in_3_data           (udp_avst_to_kernel[3].data),
             .udp_in_3_ready          (udp_avst_to_kernel[3].ready)
         `endif //ASP_ENABLE_IOPIPE3
+        `ifdef ASP_ENABLE_IOPIPE4
+            ,.udp_out_4_valid        (udp_avst_from_kernel[4].valid),
+            .udp_out_4_data          (udp_avst_from_kernel[4].data),
+            .udp_out_4_ready         (udp_avst_from_kernel[4].ready),
+            .udp_in_4_valid          (udp_avst_to_kernel[4].valid),
+            .udp_in_4_data           (udp_avst_to_kernel[4].data),
+            .udp_in_4_ready          (udp_avst_to_kernel[4].ready)
+        `endif //ASP_ENABLE_IOPIPE4
+        `ifdef ASP_ENABLE_IOPIPE5
+            ,.udp_out_5_valid        (udp_avst_from_kernel[5].valid),
+            .udp_out_5_data          (udp_avst_from_kernel[5].data),
+            .udp_out_5_ready         (udp_avst_from_kernel[5].ready),
+            .udp_in_5_valid          (udp_avst_to_kernel[5].valid),
+            .udp_in_5_data           (udp_avst_to_kernel[5].data),
+            .udp_in_5_ready          (udp_avst_to_kernel[5].ready)
+        `endif //ASP_ENABLE_IOPIPE5
+        `ifdef ASP_ENABLE_IOPIPE6
+            ,.udp_out_6_valid        (udp_avst_from_kernel[6].valid),
+            .udp_out_6_data          (udp_avst_from_kernel[6].data),
+            .udp_out_6_ready         (udp_avst_from_kernel[6].ready),
+            .udp_in_6_valid          (udp_avst_to_kernel[6].valid),
+            .udp_in_6_data           (udp_avst_to_kernel[6].data),
+            .udp_in_6_ready          (udp_avst_to_kernel[6].ready)
+        `endif //ASP_ENABLE_IOPIPE6
+        `ifdef ASP_ENABLE_IOPIPE7
+            ,.udp_out_7_valid        (udp_avst_from_kernel[7].valid),
+            .udp_out_7_data          (udp_avst_from_kernel[7].data),
+            .udp_out_7_ready         (udp_avst_from_kernel[7].ready),
+            .udp_in_7_valid          (udp_avst_to_kernel[7].valid),
+            .udp_in_7_data           (udp_avst_to_kernel[7].data),
+            .udp_in_7_ready          (udp_avst_to_kernel[7].ready)
+        `endif //ASP_ENABLE_IOPIPE7
+        `ifdef ASP_ENABLE_IOPIPE8
+            ,.udp_out_8_valid        (udp_avst_from_kernel[8].valid),
+            .udp_out_8_data          (udp_avst_from_kernel[8].data),
+            .udp_out_8_ready         (udp_avst_from_kernel[8].ready),
+            .udp_in_8_valid          (udp_avst_to_kernel[8].valid),
+            .udp_in_8_data           (udp_avst_to_kernel[8].data),
+            .udp_in_8_ready          (udp_avst_to_kernel[8].ready)
+        `endif //ASP_ENABLE_IOPIPE8
+        `ifdef ASP_ENABLE_IOPIPE9
+            ,.udp_out_9_valid        (udp_avst_from_kernel[9].valid),
+            .udp_out_9_data          (udp_avst_from_kernel[9].data),
+            .udp_out_9_ready         (udp_avst_from_kernel[9].ready),
+            .udp_in_9_valid          (udp_avst_to_kernel[9].valid),
+            .udp_in_9_data           (udp_avst_to_kernel[9].data),
+            .udp_in_9_ready          (udp_avst_to_kernel[9].ready)
+        `endif //ASP_ENABLE_IOPIPE9
+        `ifdef ASP_ENABLE_IOPIPE10
+            ,.udp_out_10_valid        (udp_avst_from_kernel[10].valid),
+            .udp_out_10_data          (udp_avst_from_kernel[10].data),
+            .udp_out_10_ready         (udp_avst_from_kernel[10].ready),
+            .udp_in_10_valid          (udp_avst_to_kernel[10].valid),
+            .udp_in_10_data           (udp_avst_to_kernel[10].data),
+            .udp_in_10_ready          (udp_avst_to_kernel[10].ready)
+        `endif //ASP_ENABLE_IOPIPE10
+        `ifdef ASP_ENABLE_IOPIPE11
+            ,.udp_out_11_valid        (udp_avst_from_kernel[11].valid),
+            .udp_out_11_data          (udp_avst_from_kernel[11].data),
+            .udp_out_11_ready         (udp_avst_from_kernel[11].ready),
+            .udp_in_11_valid          (udp_avst_to_kernel[11].valid),
+            .udp_in_11_data           (udp_avst_to_kernel[11].data),
+            .udp_in_11_ready          (udp_avst_to_kernel[11].ready)
+        `endif //ASP_ENABLE_IOPIPE11
+        `ifdef ASP_ENABLE_IOPIPE12
+            ,.udp_out_12_valid        (udp_avst_from_kernel[12].valid),
+            .udp_out_12_data          (udp_avst_from_kernel[12].data),
+            .udp_out_12_ready         (udp_avst_from_kernel[12].ready),
+            .udp_in_12_valid          (udp_avst_to_kernel[12].valid),
+            .udp_in_12_data           (udp_avst_to_kernel[12].data),
+            .udp_in_12_ready          (udp_avst_to_kernel[12].ready)
+        `endif //ASP_ENABLE_IOPIPE12
+        `ifdef ASP_ENABLE_IOPIPE13
+            ,.udp_out_13_valid        (udp_avst_from_kernel[13].valid),
+            .udp_out_13_data          (udp_avst_from_kernel[13].data),
+            .udp_out_13_ready         (udp_avst_from_kernel[13].ready),
+            .udp_in_13_valid          (udp_avst_to_kernel[13].valid),
+            .udp_in_13_data           (udp_avst_to_kernel[13].data),
+            .udp_in_13_ready          (udp_avst_to_kernel[13].ready)
+        `endif //ASP_ENABLE_IOPIPE13
+        `ifdef ASP_ENABLE_IOPIPE14
+            ,.udp_out_14_valid        (udp_avst_from_kernel[14].valid),
+            .udp_out_14_data          (udp_avst_from_kernel[14].data),
+            .udp_out_14_ready         (udp_avst_from_kernel[14].ready),
+            .udp_in_14_valid          (udp_avst_to_kernel[14].valid),
+            .udp_in_14_data           (udp_avst_to_kernel[14].data),
+            .udp_in_14_ready          (udp_avst_to_kernel[14].ready)
+        `endif //ASP_ENABLE_IOPIPE14
+        `ifdef ASP_ENABLE_IOPIPE15
+            ,.udp_out_15_valid        (udp_avst_from_kernel[15].valid),
+            .udp_out_15_data          (udp_avst_from_kernel[15].data),
+            .udp_out_15_ready         (udp_avst_from_kernel[15].ready),
+            .udp_in_15_valid          (udp_avst_to_kernel[15].valid),
+            .udp_in_15_data           (udp_avst_to_kernel[15].data),
+            .udp_in_15_ready          (udp_avst_to_kernel[15].ready)
+        `endif //ASP_ENABLE_IOPIPE15
     `endif
 );
 

--- a/n6001/hardware/ofs_n6001_usm/quartus.ini
+++ b/n6001/hardware/ofs_n6001_usm/quartus.ini
@@ -1,8 +1,0 @@
-#from BBS build for DC
-pgm_allow_mt25q=on
-
-# Workaround that uses hssi_device.json in project's directory to display transceiver tile in Chip Planner
-acvq_use_project_path_hssi_json = on
-
-# Workaround to reduce timing errors introduced by crosstalk between static and PR regions
-route_xtalk_high_criticality=0.9

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/kernel_wrapper.v
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/kernel_wrapper.v
@@ -182,7 +182,9 @@ kernel_system kernel_system_inst (
         .kernel_ddr4a_write           (mem_avmm_bridge[0].write        ),
         .kernel_ddr4a_read            (mem_avmm_bridge[0].read         ),
         .kernel_ddr4a_byteenable      (mem_avmm_bridge[0].byteenable   ),
-        .kernel_ddr4a_writeack        (mem_avmm_bridge[0].writeack     ),
+	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+	    .kernel_ddr4a_writeack        (mem_avmm_bridge[0].writeack     ),
+	`endif
     `endif
     `ifdef PAC_BSP_ENABLE_DDR4_BANK2
         .kernel_ddr4b_waitrequest     (mem_avmm_bridge[1].waitrequest  ),
@@ -194,7 +196,9 @@ kernel_system kernel_system_inst (
         .kernel_ddr4b_write           (mem_avmm_bridge[1].write        ),
         .kernel_ddr4b_read            (mem_avmm_bridge[1].read         ),
         .kernel_ddr4b_byteenable      (mem_avmm_bridge[1].byteenable   ),
-        .kernel_ddr4b_writeack        (mem_avmm_bridge[1].writeack     ),
+    	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+	    .kernel_ddr4b_writeack        (mem_avmm_bridge[1].writeack     ),
+	`endif
     `endif
     `ifdef PAC_BSP_ENABLE_DDR4_BANK3
         .kernel_ddr4c_waitrequest     (mem_avmm_bridge[2].waitrequest  ),
@@ -206,7 +210,9 @@ kernel_system kernel_system_inst (
         .kernel_ddr4c_write           (mem_avmm_bridge[2].write        ),
         .kernel_ddr4c_read            (mem_avmm_bridge[2].read         ),
         .kernel_ddr4c_byteenable      (mem_avmm_bridge[2].byteenable   ),
-        .kernel_ddr4c_writeack        (mem_avmm_bridge[2].writeack     ),
+	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+            .kernel_ddr4c_writeack        (mem_avmm_bridge[2].writeack     ),
+	`endif
     `endif
     `ifdef PAC_BSP_ENABLE_DDR4_BANK4
         .kernel_ddr4d_waitrequest     (mem_avmm_bridge[3].waitrequest  ),
@@ -218,7 +224,9 @@ kernel_system kernel_system_inst (
         .kernel_ddr4d_write           (mem_avmm_bridge[3].write        ),
         .kernel_ddr4d_read            (mem_avmm_bridge[3].read         ),
         .kernel_ddr4d_byteenable      (mem_avmm_bridge[3].byteenable   ),
-        .kernel_ddr4d_writeack        (mem_avmm_bridge[3].writeack     ),
+	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+	    .kernel_ddr4d_writeack        (mem_avmm_bridge[3].writeack     ),
+    	`endif
     `endif
 
     .kernel_irq_irq                 (kernel_cra_avmm_bridge.kernel_irq),

--- a/n6001/hardware/ofs_n6001_usm_iopipes/quartus.ini
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/quartus.ini
@@ -4,5 +4,5 @@ pgm_allow_mt25q=on
 # Workaround that uses hssi_device.json in project's directory to display transceiver tile in Chip Planner
 acvq_use_project_path_hssi_json = on
 
-# Workaround to reduce timing erorrs introduced by crosstalk between Static and PR regions
+# Workaround to reduce timing errors introduced by crosstalk between static and PR regions
 route_xtalk_high_criticality=0.9

--- a/n6001/hardware/ofs_n6001_usm_iopipes/quartus.ini
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/quartus.ini
@@ -1,8 +1,0 @@
-#from BBS build for DC
-pgm_allow_mt25q=on
-
-# Workaround that uses hssi_device.json in project's directory to display transceiver tile in Chip Planner
-acvq_use_project_path_hssi_json = on
-
-# Workaround to reduce timing errors introduced by crosstalk between static and PR regions
-route_xtalk_high_criticality=0.9


### PR DESCRIPTION
### Description
Previously all kernel_wrapper.v files for all ASPs (D5005 and N6001) as well as the board variants (ofs_d5005, ofs_d5005_usm...) were different. This change commonizes all board variant's kernel_wrapper.v files.
Additionally all quartus.ini files were removed as they are obsolete now.

### Collateral (docs, reports, design examples, case IDs):
none

### Tests added:
none

### Tests run:
- compiled and ran board_test and simple_host_streaming on D5005 (targeting ofs_d5005 and ofs_d5005_usm respectively) -> passed
- compiled and ran board_test and simple_host_streaming on N6001 using slimFIM (targeting ofs_n6001 and ofs_n6001_usm respectively) -> passed
- compiled and ran the following designs on N6001 using base FIM (all passed):

anr
board_test
cholesky
cholesky_inversion
db
decompress
double_buffering
mvdr_beamforming
qri

simple_host_streaming
buffered_host_streaming
explicit_data_movement
zero_copy_data_transfer

