### PR TITLE
[Update] commonizing kernel interface and MBD IP for D5005 and N6001

### DIFF
--- a/d5005/hardware/ofs_d5005/build/board.qsys
+++ b/d5005/hardware/ofs_d5005/build/board.qsys
@@ -253,7 +253,7 @@ https://fpgasoftware.intel.com/eula.-->
          type = "int";
       }
    }
-   element kernel_interface_s10_0
+   element kernel_interface
    {
       datum _sortIndex
       {
@@ -261,7 +261,7 @@ https://fpgasoftware.intel.com/eula.-->
          type = "int";
       }
    }
-   element kernel_interface_s10_0.ctrl
+   element kernel_interface.ctrl
    {
       datum baseAddress
       {
@@ -371,7 +371,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='board_afu_id_avmm_slave_0.afu_cfg_slave' start='0x0' end='0x40' datawidth='64' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Read_Slave' start='0x100' end='0x104' datawidth='32' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Mask_Slave' start='0x108' end='0x10C' datawidth='32' /&amp;gt;&amp;lt;slave name='kernel_interface_s10_0.ctrl' start='0x4000' end='0x8000' datawidth='32' /&amp;gt;&amp;lt;slave name='pipe_stage_dma_csr.s0' start='0x20000' end='0x20800' datawidth='64' /&amp;gt;&amp;lt;slave name='ddr_board.null_dfh_id' start='0x20800' end='0x20840' datawidth='64' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='board_afu_id_avmm_slave_0.afu_cfg_slave' start='0x0' end='0x40' datawidth='64' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Read_Slave' start='0x100' end='0x104' datawidth='32' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Mask_Slave' start='0x108' end='0x10C' datawidth='32' /&amp;gt;&amp;lt;slave name='kernel_interface.ctrl' start='0x4000' end='0x8000' datawidth='32' /&amp;gt;&amp;lt;slave name='pipe_stage_dma_csr.s0' start='0x20000' end='0x20800' datawidth='64' /&amp;gt;&amp;lt;slave name='ddr_board.null_dfh_id' start='0x20800' end='0x20840' datawidth='64' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
@@ -11047,7 +11047,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:module altera:enabled="true" altera:auto_export="false">
         <altera:entity_info>
           <ipxact:vendor>Altera Corporation</ipxact:vendor>
-          <ipxact:library>kernel_interface_s10_0</ipxact:library>
+          <ipxact:library>kernel_interface</ipxact:library>
           <ipxact:name>altera_generic_component</ipxact:name>
           <ipxact:version>1.0</ipxact:version>
         </altera:entity_info>
@@ -11769,7 +11769,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;bridgesToReceiver&lt;/key&gt;
-                            &lt;value&gt;kernel_interface_s10_0.kernel_irq_from_kernel&lt;/value&gt;
+                            &lt;value&gt;kernel_interface.kernel_irq_from_kernel&lt;/value&gt;
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;irqScheme&lt;/key&gt;
@@ -11924,9 +11924,9 @@ https://fpgasoftware.intel.com/eula.-->
         &lt;/interfaces&gt;
     &lt;/boundary&gt;
     &lt;originalModuleInfo&gt;
-        &lt;className&gt;kernel_interface_s10&lt;/className&gt;
-        &lt;version&gt;17.1&lt;/version&gt;
-        &lt;displayName&gt;OpenCL Kernel Interface for S10&lt;/displayName&gt;
+        &lt;className&gt;kernel_interface&lt;/className&gt;
+        &lt;version&gt;23.2&lt;/version&gt;
+        &lt;displayName&gt;oneAPI Kernel Interface&lt;/displayName&gt;
     &lt;/originalModuleInfo&gt;
     &lt;systemInfoParameterDescriptors&gt;
         &lt;descriptors&gt;
@@ -12667,7 +12667,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;bridgesToReceiver&lt;/key&gt;
-                        &lt;value&gt;kernel_interface_s10_0.kernel_irq_from_kernel&lt;/value&gt;
+                        &lt;value&gt;kernel_interface.kernel_irq_from_kernel&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;irqScheme&lt;/key&gt;
@@ -12822,35 +12822,35 @@ https://fpgasoftware.intel.com/eula.-->
               <ipxact:name>generationInfoDefinition</ipxact:name>
               <ipxact:displayName>Generation Behavior</ipxact:displayName>
               <ipxact:value>&lt;generationInfoDefinition&gt;
-    &lt;hdlLibraryName&gt;board_kernel_interface_s10_0&lt;/hdlLibraryName&gt;
+    &lt;hdlLibraryName&gt;board_kernel_interface&lt;/hdlLibraryName&gt;
     &lt;fileSets&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_s10_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_s10_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;QUARTUS_SYNTH&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_s10_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_s10_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VERILOG&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_s10_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_s10_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_s10_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_s10_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_s10_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_s10_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;CDC_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
@@ -12871,7 +12871,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:parameter parameterId="logicalView" type="string">
               <ipxact:name>logicalView</ipxact:name>
               <ipxact:displayName>Logical view</ipxact:displayName>
-              <ipxact:value>ip/board/board_kernel_interface_s10_0.ip</ipxact:value>
+              <ipxact:value>ip/board/board_kernel_interface.ip</ipxact:value>
             </ipxact:parameter>
             <ipxact:parameter parameterId="moduleAssignmentDefinition" type="string">
               <ipxact:name>moduleAssignmentDefinition</ipxact:name>
@@ -15646,7 +15646,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:module>
     </altera:modules>
     <altera:connections>
-      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="kernel_interface_s10_0.kernel_cra" altera:end="board_kernel_cra_pipe.s0">
+      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="kernel_interface.kernel_cra" altera:end="board_kernel_cra_pipe.s0">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15726,7 +15726,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="OPTIMIZED_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="pipe_stage_host_ctrl.m0" altera:end="kernel_interface_s10_0.ctrl">
+      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="pipe_stage_host_ctrl.m0" altera:end="kernel_interface.ctrl">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x4000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15791,7 +15791,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="clk_200.out_clk" altera:end="pipe_stage_host_ctrl.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk_in.out_clk" altera:end="board_kernel_cra_reset.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk_in.out_clk" altera:end="board_kernel_cra_pipe.clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="22.3" altera:start="clk_200.out_clk" altera:end="kernel_interface_s10_0.clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="22.3" altera:start="clk_200.out_clk" altera:end="kernel_interface.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="clk_200.out_clk" altera:end="pipe_stage_dma_csr.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk_in.out_clk" altera:end="kernel_clk_export.clk_in"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="clk_200.out_clk" altera:end="board_afu_id_avmm_slave_0.clock"></altera:connection>
@@ -15801,28 +15801,28 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="emif_ddr4d_clk.out_clk" altera:end="ddr_board.ddr_clk_d"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="clk_200.out_clk" altera:end="ddr_board.host_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk_in.out_clk" altera:end="ddr_board.kernel_clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk_in.out_clk" altera:end="kernel_interface_s10_0.kernel_clk"></altera:connection>
-      <altera:connection altera:kind="conduit" altera:version="22.3" altera:start="kernel_interface_s10_0.acl_bsp_memorg_host0x018" altera:end="ddr_board.acl_bsp_memorg_host">
+      <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk_in.out_clk" altera:end="kernel_interface.kernel_clk"></altera:connection>
+      <altera:connection altera:kind="conduit" altera:version="22.3" altera:start="kernel_interface.acl_bsp_memorg_host0x018" altera:end="ddr_board.acl_bsp_memorg_host">
         <altera:connection_parameter altera:parameter_name="endPort" altera:parameter_value=""></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="endPortLSB" altera:parameter_value="0"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="startPort" altera:parameter_value=""></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="startPortLSB" altera:parameter_value="0"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="width" altera:parameter_value="0"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="interrupt" altera:version="22.3" altera:start="board_irq_ctrl_0.interrupt_receiver" altera:end="kernel_interface_s10_0.kernel_irq_to_host">
+      <altera:connection altera:kind="interrupt" altera:version="22.3" altera:start="board_irq_ctrl_0.interrupt_receiver" altera:end="kernel_interface.kernel_irq_to_host">
         <altera:connection_parameter altera:parameter_name="irqNumber" altera:parameter_value="0"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="kernel_interface_s10_0.kernel_reset" altera:end="kernel_clk_export.clk_in_reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="kernel_interface_s10_0.kernel_reset" altera:end="ddr_board.kernel_reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="kernel_interface.kernel_reset" altera:end="kernel_clk_export.clk_in_reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="kernel_interface.kernel_reset" altera:end="ddr_board.kernel_reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="board_irq_ctrl_0.Resetn"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="ddr_board.global_reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="board_kernel_cra_reset.in_reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="board_afu_id_avmm_slave_0.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="pipe_stage_host_ctrl.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="board_kernel_cra_reset.out_reset" altera:end="board_kernel_cra_pipe.reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="kernel_interface_s10_0.reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="kernel_interface.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="pipe_stage_dma_csr.reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="kernel_interface_s10_0.sw_reset_in"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="kernel_interface.sw_reset_in"></altera:connection>
     </altera:connections>
     <altera:interconnect_requirements></altera:interconnect_requirements>
     <altera:wire_level_connections></altera:wire_level_connections>
@@ -15853,7 +15853,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:interface_mapping altera:name="kernel_ddr4b" altera:internal="ddr_board.kernel_ddr4b" altera:type="avalon" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="kernel_ddr4c" altera:internal="ddr_board.kernel_ddr4c" altera:type="avalon" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="kernel_ddr4d" altera:internal="ddr_board.kernel_ddr4d" altera:type="avalon" altera:dir="end"></altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_irq" altera:internal="kernel_interface_s10_0.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start"></altera:interface_mapping>
+      <altera:interface_mapping altera:name="kernel_irq" altera:internal="kernel_interface.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start"></altera:interface_mapping>
       <altera:interface_mapping altera:name="kernel_reset" altera:internal="kernel_clk_export.clk_reset" altera:type="reset" altera:dir="start"></altera:interface_mapping>
     </altera:altera_interface_boundary>
     <ipxact:components>
@@ -15873,10 +15873,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>kernel_interface_s10_0.kernel_cra</ipxact:name>
+            <ipxact:name>kernel_interface.kernel_cra</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="kernel_interface_s10_0.kernel_cra">
+              <ipxact:addressSpaceRef addressSpaceRef="kernel_interface.kernel_cra">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -15899,7 +15899,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>kernel_interface_s10_0.ctrl</ipxact:name>
+            <ipxact:name>kernel_interface.ctrl</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -15942,7 +15942,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:busInterfaces>
         <ipxact:addressSpaces>
           <ipxact:addressSpace>
-            <ipxact:name>kernel_interface_s10_0.kernel_cra</ipxact:name>
+            <ipxact:name>kernel_interface.kernel_cra</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>board_kernel_cra_pipe.s0</ipxact:name>
@@ -15970,7 +15970,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:range>0x0000_0040</ipxact:range>
               </ipxact:segment>
               <ipxact:segment>
-                <ipxact:name>kernel_interface_s10_0.ctrl</ipxact:name>
+                <ipxact:name>kernel_interface.ctrl</ipxact:name>
                 <ipxact:addressOffset>0x0000_4000</ipxact:addressOffset>
                 <ipxact:range>0x0000_4000</ipxact:range>
               </ipxact:segment>

--- a/d5005/hardware/ofs_d5005/build/ddr_board.qsys
+++ b/d5005/hardware/ofs_d5005/build/ddr_board.qsys
@@ -40,7 +40,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:displayName>bonusData</ipxact:displayName>
           <ipxact:value>bonusData 
 {
-   element acl_memory_bank_divider_0
+   element memory_bank_divider
    {
       datum _sortIndex
       {
@@ -410,7 +410,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='acl_memory_bank_divider_0.s' start='0x0' end='0x800000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='memory_bank_divider.s' start='0x0' end='0x800000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
@@ -431,7 +431,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='acl_memory_bank_divider_0.s' start='0x0' end='0x800000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='memory_bank_divider.s' start='0x0' end='0x800000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
@@ -690,7 +690,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:module altera:enabled="true" altera:auto_export="false">
         <altera:entity_info>
           <ipxact:vendor>Altera Corporation</ipxact:vendor>
-          <ipxact:library>acl_memory_bank_divider_0</ipxact:library>
+          <ipxact:library>memory_bank_divider</ipxact:library>
           <ipxact:name>altera_generic_component</ipxact:name>
           <ipxact:version>1.0</ipxact:version>
         </altera:entity_info>
@@ -2214,9 +2214,9 @@ https://fpgasoftware.intel.com/eula.-->
         &lt;/interfaces&gt;
     &lt;/boundary&gt;
     &lt;originalModuleInfo&gt;
-        &lt;className&gt;acl_memory_bank_divider&lt;/className&gt;
-        &lt;version&gt;21.3&lt;/version&gt;
-        &lt;displayName&gt;OpenCL Memory Bank Divider&lt;/displayName&gt;
+        &lt;className&gt;memory_bank_divider&lt;/className&gt;
+        &lt;version&gt;23.2&lt;/version&gt;
+        &lt;displayName&gt;oneAPI Memory Bank Divider&lt;/displayName&gt;
     &lt;/originalModuleInfo&gt;
     &lt;systemInfoParameterDescriptors&gt;
         &lt;descriptors&gt;
@@ -3788,35 +3788,35 @@ https://fpgasoftware.intel.com/eula.-->
               <ipxact:name>generationInfoDefinition</ipxact:name>
               <ipxact:displayName>Generation Behavior</ipxact:displayName>
               <ipxact:value>&lt;generationInfoDefinition&gt;
-    &lt;hdlLibraryName&gt;ddr_board_acl_memory_bank_divider_1&lt;/hdlLibraryName&gt;
+    &lt;hdlLibraryName&gt;ddr_board_memory_bank_divider&lt;/hdlLibraryName&gt;
     &lt;fileSets&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;QUARTUS_SYNTH&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VERILOG&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;CDC_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
@@ -3837,7 +3837,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:parameter parameterId="logicalView" type="string">
               <ipxact:name>logicalView</ipxact:name>
               <ipxact:displayName>Logical view</ipxact:displayName>
-              <ipxact:value>ip/ddr_board/ddr_board_acl_memory_bank_divider_1.ip</ipxact:value>
+              <ipxact:value>ip/ddr_board/ddr_board_memory_bank_divider.ip</ipxact:value>
             </ipxact:parameter>
             <ipxact:parameter parameterId="moduleAssignmentDefinition" type="string">
               <ipxact:name>moduleAssignmentDefinition</ipxact:name>
@@ -15169,7 +15169,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:module>
     </altera:modules>
     <altera:connections>
-      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="acl_memory_bank_divider_0.bank1" altera:end="ddr_channel_a.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="memory_bank_divider.bank1" altera:end="ddr_channel_a.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15189,7 +15189,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="OPTIMIZED_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="acl_memory_bank_divider_0.bank2" altera:end="ddr_channel_b.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="memory_bank_divider.bank2" altera:end="ddr_channel_b.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15209,7 +15209,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="OPTIMIZED_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="acl_memory_bank_divider_0.bank3" altera:end="ddr_channel_c.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="memory_bank_divider.bank3" altera:end="ddr_channel_c.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15229,7 +15229,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="OPTIMIZED_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="acl_memory_bank_divider_0.bank4" altera:end="ddr_channel_d.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="memory_bank_divider.bank4" altera:end="ddr_channel_d.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15249,7 +15249,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="OPTIMIZED_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="dma_localmem_wr_pipe.m0" altera:end="acl_memory_bank_divider_0.s">
+      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="dma_localmem_wr_pipe.m0" altera:end="memory_bank_divider.s">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15269,7 +15269,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="OPTIMIZED_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="dma_localmem_rd_pipe.m0" altera:end="acl_memory_bank_divider_0.s">
+      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="dma_localmem_rd_pipe.m0" altera:end="memory_bank_divider.s">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15291,7 +15291,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk.out_clk" altera:end="kernel_reset.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="host_clk.out_clk" altera:end="global_reset.clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="22.3" altera:start="host_clk.out_clk" altera:end="acl_memory_bank_divider_0.clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="22.3" altera:start="host_clk.out_clk" altera:end="memory_bank_divider.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="host_clk.out_clk" altera:end="dma_localmem_rd_pipe.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="host_clk.out_clk" altera:end="dma_localmem_wr_pipe.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="host_clk.out_clk" altera:end="null_dfh_inst.clock"></altera:connection>
@@ -15303,13 +15303,13 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="host_clk.out_clk" altera:end="ddr_channel_b.host_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="host_clk.out_clk" altera:end="ddr_channel_c.host_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="host_clk.out_clk" altera:end="ddr_channel_d.host_clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk.out_clk" altera:end="acl_memory_bank_divider_0.kernel_clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk.out_clk" altera:end="memory_bank_divider.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_a.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_b.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_c.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_d.kernel_clk"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="kernel_reset.out_reset" altera:end="acl_memory_bank_divider_0.kernel_reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset.out_reset" altera:end="acl_memory_bank_divider_0.reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="kernel_reset.out_reset" altera:end="memory_bank_divider.kernel_reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset.out_reset" altera:end="memory_bank_divider.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset.out_reset" altera:end="null_dfh_inst.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset.out_reset" altera:end="dma_localmem_wr_pipe.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset.out_reset" altera:end="dma_localmem_rd_pipe.reset"></altera:connection>
@@ -15324,8 +15324,8 @@ https://fpgasoftware.intel.com/eula.-->
     <altera:hdl_parameter_mappings></altera:hdl_parameter_mappings>
     <altera:preserved_ports_for_debug></altera:preserved_ports_for_debug>
     <altera:altera_interface_boundary>
-      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="acl_memory_bank_divider_0.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end"></altera:interface_mapping>
-      <altera:interface_mapping altera:name="acl_bsp_snoop" altera:internal="acl_memory_bank_divider_0.acl_bsp_snoop" altera:type="avalon_streaming" altera:dir="start"></altera:interface_mapping>
+      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="memory_bank_divider.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end"></altera:interface_mapping>
+      <altera:interface_mapping altera:name="acl_bsp_snoop" altera:internal="memory_bank_divider.acl_bsp_snoop" altera:type="avalon_streaming" altera:dir="start"></altera:interface_mapping>
       <altera:interface_mapping altera:name="ddr_clk_a" altera:internal="ddr_clk_a.in_clk" altera:type="clock" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="ddr_clk_b" altera:internal="ddr_clk_b.in_clk" altera:type="clock" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="ddr_clk_c" altera:internal="ddr_clk_c.in_clk" altera:type="clock" altera:dir="end"></altera:interface_mapping>
@@ -15358,10 +15358,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank1</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank1</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank1">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank1">
                 <ipxact:baseAddress>0x0000_0000_0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -15371,10 +15371,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank2</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank2</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank2">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank2">
                 <ipxact:baseAddress>0x0000_0000_0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -15384,10 +15384,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank3</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank3</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank3">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank3">
                 <ipxact:baseAddress>0x0000_0000_0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -15397,16 +15397,16 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank4</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank4</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank4">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank4">
                 <ipxact:baseAddress>0x0000_0000_0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+            <ipxact:name>memory_bank_divider.s</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -15419,7 +15419,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:master>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+            <ipxact:name>memory_bank_divider.s</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -15454,7 +15454,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:busInterfaces>
         <ipxact:addressSpaces>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank1</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank1</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_a.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -15464,7 +15464,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank2</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank2</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_b.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -15474,7 +15474,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank3</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank3</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_c.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -15484,7 +15484,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank4</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank4</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_d.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -15497,7 +15497,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:name>dma_localmem_rd_pipe.m0</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
-                <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+                <ipxact:name>memory_bank_divider.s</ipxact:name>
                 <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
                 <ipxact:range>0x0000_0008_0000_0000</ipxact:range>
               </ipxact:segment>
@@ -15507,7 +15507,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:name>dma_localmem_wr_pipe.m0</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
-                <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+                <ipxact:name>memory_bank_divider.s</ipxact:name>
                 <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
                 <ipxact:range>0x0000_0008_0000_0000</ipxact:range>
               </ipxact:segment>

--- a/d5005/hardware/ofs_d5005/build/hw_iface.iipx
+++ b/d5005/hardware/ofs_d5005/build/hw_iface.iipx
@@ -194,94 +194,6 @@
   <tag2 key="TCL_PACKAGE_VERSION" value="10.0" />
  </component>
  <component
-   name="acl_kernel_clk"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/iface/acl_kernel_clk.qsys"
-   displayName="OpenCL Kernel Clock Generator"
-   version="1.0"
-   description="Generates the kernel clocks for ACL"
-   tags="INTERNAL_COMPONENT=false"
-   categories="OpenCL BSP Components"
-   factory="QsysFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPONENT_HIDE_FROM_QUARTUS" value="true" />
- </component>
- <component
-   name="acl_kernel_clk_a10"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_clk_a10_hw.tcl"
-   displayName="OpenCL A10 Kernel Clock Generator"
-   version="16.1"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="comp" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="16.1" />
- </component>
- <component
-   name="acl_kernel_clk_noreconfig"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/iface/acl_kernel_clk_noreconfig.qsys"
-   displayName="OpenCL Kernel Clock Generator - no Dynamic Reconfig"
-   version="1.0"
-   description="Generates the kernel clocks for ACL"
-   tags="INTERNAL_COMPONENT=false"
-   categories="OpenCL BSP Components"
-   factory="QsysFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPONENT_HIDE_FROM_QUARTUS" value="true" />
- </component>
- <component
-   name="acl_kernel_clk_s10"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_clk_s10_hw.tcl"
-   displayName="OpenCL S10 Kernel Clock Generator"
-   version="17.0"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="comp" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="16.1" />
- </component>
- <component
-   name="acl_kernel_clk_s10_reconfig"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_clk_s10_reconfig_hw.tcl"
-   displayName="OpenCL S10 reconfigurable kernel clock generator"
-   version="17.0"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="comp" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="16.1" />
- </component>
- <component
-   name="acl_kernel_interface_soc"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/iface/acl_kernel_interface_soc.qsys"
-   displayName="acl_kernel_interface_soc"
-   version="1.0"
-   description="ACL Kernel Interface"
-   tags=""
-   categories="ACL BSP Components"
-   factory="QsysFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPONENT_HIDE_FROM_QUARTUS" value="true" />
- </component>
- <component
-   name="acl_memory_bank_divider"
-   file="./ip/acl_memory_bank_divider_hw.tcl"
-   displayName="OpenCL Memory Bank Divider"
-   version="21.3"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="compose" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="17.0" />
- </component>
- <component
    name="acl_snoop_adapter"
    file="${INTELFPGAOCLSDKROOT}/ip/board/export/snoop_adapter_hw.tcl"
    displayName="Avalon Snoop Adapter"
@@ -709,36 +621,6 @@
   <tag2 key="OPAQUE_ADDRESS_MAP" value="true" />
   <tag2 key="SUPPORTED_FILE_SETS" value="QUARTUS_SYNTH,SIM_VERILOG" />
   <tag2 key="TCL_PACKAGE_VERSION" value="12.1" />
- </component>
- <component
-   name="kernel_interface"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_interface_hw.tcl"
-   displayName="OpenCL Kernel Interface"
-   version="15.1"
-   description="Connects the OpenCL host to the FPGA kernel"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="compose" />
-  <tag2 key="OPAQUE_ADDRESS_MAP" value="false" />
-  <tag2 key="PARAMETER_UPGRADE_CALLBACK" value="ip_upgrade" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="13.1" />
- </component>
- <component
-   name="kernel_interface_s10"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_interface_s10_hw.tcl"
-   displayName="OpenCL Kernel Interface for S10"
-   version="17.1"
-   description="Connects the OpenCL host to the FPGA kernel"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="compose" />
-  <tag2 key="OPAQUE_ADDRESS_MAP" value="false" />
-  <tag2 key="PARAMETER_UPGRADE_CALLBACK" value="ip_upgrade" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="17.0" />
  </component>
  <component
    name="mem_org_mode"

--- a/d5005/hardware/ofs_d5005/build/ip/board/board_kernel_interface.ip
+++ b/d5005/hardware/ofs_d5005/build/ip/board/board_kernel_interface.ip
@@ -14,16 +14,16 @@ refer to the applicable agreement for further details, at
 https://fpgasoftware.intel.com/eula.-->
 <ipxact:component xmlns:altera="http://www.altera.com/XMLSchema/IPXact2014/extensions" xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2014">
   <ipxact:vendor>author</ipxact:vendor>
-  <ipxact:library>board_kernel_interface_agilex_0</ipxact:library>
-  <ipxact:name>kernel_interface_agilex_0</ipxact:name>
-  <ipxact:version>17.1</ipxact:version>
+  <ipxact:library>board_kernel_interface</ipxact:library>
+  <ipxact:name>kernel_interface</ipxact:name>
+  <ipxact:version>23.2</ipxact:version>
   <ipxact:busInterfaces>
     <ipxact:busInterface>
       <ipxact:name>kernel_cra</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -284,10 +284,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>ctrl</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -605,10 +605,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>acl_bsp_memorg_host0x018</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="conduit" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="conduit" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="conduit" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="conduit" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -642,10 +642,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -689,10 +689,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -731,10 +731,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_irq_from_kernel</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -778,10 +778,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_irq_to_host</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -819,7 +819,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="bridgesToReceiver" type="string">
           <ipxact:name>bridgesToReceiver</ipxact:name>
           <ipxact:displayName>Bridges to receiver</ipxact:displayName>
-          <ipxact:value>board_kernel_interface_agilex_0.kernel_irq_from_kernel</ipxact:value>
+          <ipxact:value>board_kernel_interface.kernel_irq_from_kernel</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="irqScheme" type="string">
           <ipxact:name>irqScheme</ipxact:name>
@@ -830,10 +830,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>sw_reset_in</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -862,10 +862,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -899,10 +899,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -941,10 +941,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>sw_reset_export</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -993,10 +993,11 @@ https://fpgasoftware.intel.com/eula.-->
     <ipxact:instantiations>
       <ipxact:componentInstantiation>
         <ipxact:name>QUARTUS_SYNTH</ipxact:name>
-        <ipxact:moduleName>kernel_interface_agilex</ipxact:moduleName>
+        <ipxact:moduleName>kernel_interface</ipxact:moduleName>
         <ipxact:fileSetRef>
           <ipxact:localName>QUARTUS_SYNTH</ipxact:localName>
         </ipxact:fileSetRef>
+        <ipxact:parameters></ipxact:parameters>
       </ipxact:componentInstantiation>
     </ipxact:instantiations>
     <ipxact:ports>
@@ -1004,6 +1005,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_waitrequest</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1034,6 +1036,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_readdatavalid</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1046,6 +1049,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_burstcount</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC_VECTOR</ipxact:typeName>
@@ -1094,6 +1098,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_write</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1106,6 +1111,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_read</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1136,6 +1142,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_debugaccess</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1148,6 +1155,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_waitrequest</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1178,6 +1186,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_readdatavalid</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1190,6 +1199,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_burstcount</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC_VECTOR</ipxact:typeName>
@@ -1238,6 +1248,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_write</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1250,6 +1261,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_read</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1280,6 +1292,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_debugaccess</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1310,6 +1323,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>clk_clk</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1322,6 +1336,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>reset_reset_n</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1334,6 +1349,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_irq_from_kernel_irq</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC_VECTOR</ipxact:typeName>
@@ -1346,6 +1362,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_irq_to_host_irq</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1358,6 +1375,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>sw_reset_in_reset</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1370,6 +1388,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_clk_clk</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1382,6 +1401,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_reset_reset_n</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1394,6 +1414,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>sw_reset_export_reset_n</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1407,9 +1428,9 @@ https://fpgasoftware.intel.com/eula.-->
   <ipxact:vendorExtensions>
     <altera:entity_info>
       <ipxact:vendor>author</ipxact:vendor>
-      <ipxact:library>board_kernel_interface_agilex_0</ipxact:library>
-      <ipxact:name>kernel_interface_agilex</ipxact:name>
-      <ipxact:version>17.1</ipxact:version>
+      <ipxact:library>board_kernel_interface</ipxact:library>
+      <ipxact:name>kernel_interface</ipxact:name>
+      <ipxact:version>23.2</ipxact:version>
     </altera:entity_info>
     <altera:altera_module_parameters>
       <ipxact:parameters>
@@ -1426,12 +1447,12 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="AUTO_DEVICE_FAMILY" type="string">
           <ipxact:name>AUTO_DEVICE_FAMILY</ipxact:name>
           <ipxact:displayName>Auto DEVICE_FAMILY</ipxact:displayName>
-          <ipxact:value>Agilex</ipxact:value>
+          <ipxact:value>Stratix 10</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE" type="string">
           <ipxact:name>AUTO_DEVICE</ipxact:name>
           <ipxact:displayName>Auto DEVICE</ipxact:displayName>
-          <ipxact:value>AGFB014R24A2E2V</ipxact:value>
+          <ipxact:value>1SX280HN2F43E2VG</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE_SPEEDGRADE" type="string">
           <ipxact:name>AUTO_DEVICE_SPEEDGRADE</ipxact:name>
@@ -1445,17 +1466,17 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="board" type="string">
           <ipxact:name>board</ipxact:name>
           <ipxact:displayName>Board</ipxact:displayName>
-          <ipxact:value>Unknown</ipxact:value>
+          <ipxact:value>default</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="device" type="string">
           <ipxact:name>device</ipxact:name>
           <ipxact:displayName>Device</ipxact:displayName>
-          <ipxact:value>AGFB014R24A2E2V</ipxact:value>
+          <ipxact:value>1SX280HN2F43E2VG</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="deviceFamily" type="string">
           <ipxact:name>deviceFamily</ipxact:name>
           <ipxact:displayName>Device family</ipxact:displayName>
-          <ipxact:value>Agilex</ipxact:value>
+          <ipxact:value>Stratix 10</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="deviceSpeedGrade" type="string">
           <ipxact:name>deviceSpeedGrade</ipxact:name>
@@ -1472,6 +1493,17 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:displayName>bonusData</ipxact:displayName>
           <ipxact:value>bonusData 
 {
+   element $system
+   {
+      datum _originalDeviceFamily
+      {
+         value = "Stratix 10";
+         type = "String";
+      }
+   }
+   element kernel_interface
+   {
+   }
 }
 </ipxact:value>
         </ipxact:parameter>
@@ -2195,7 +2227,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;bridgesToReceiver&lt;/key&gt;
-                        &lt;value&gt;board_kernel_interface_agilex_0.kernel_irq_from_kernel&lt;/value&gt;
+                        &lt;value&gt;board_kernel_interface.kernel_irq_from_kernel&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;irqScheme&lt;/key&gt;
@@ -2379,16 +2411,21 @@ https://fpgasoftware.intel.com/eula.-->
     &lt;/connPtSystemInfos&gt;
 &lt;/systemInfosDefinition&gt;</ipxact:value>
         </ipxact:parameter>
+        <ipxact:parameter parameterId="pinAssignmentListDefinition" type="string">
+          <ipxact:name>pinAssignmentListDefinition</ipxact:name>
+          <ipxact:displayName>pinAssignmentListDefinition</ipxact:displayName>
+          <ipxact:value>&lt;pinAssignmentListDefinition/&gt;</ipxact:value>
+        </ipxact:parameter>
       </ipxact:parameters>
     </altera:altera_system_parameters>
     <altera:altera_interface_boundary>
-      <altera:interface_mapping altera:name="acl_bsp_memorg_host0x018" altera:internal="kernel_interface_agilex_0.acl_bsp_memorg_host0x018" altera:type="conduit" altera:dir="end">
+      <altera:interface_mapping altera:name="acl_bsp_memorg_host0x018" altera:internal="kernel_interface.acl_bsp_memorg_host0x018" altera:type="conduit" altera:dir="end">
         <altera:port_mapping altera:name="acl_bsp_memorg_host0x018_mode" altera:internal="acl_bsp_memorg_host0x018_mode"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="clk" altera:internal="kernel_interface_agilex_0.clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="clk" altera:internal="kernel_interface.clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="clk_clk" altera:internal="clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="ctrl" altera:internal="kernel_interface_agilex_0.ctrl" altera:type="avalon" altera:dir="end">
+      <altera:interface_mapping altera:name="ctrl" altera:internal="kernel_interface.ctrl" altera:type="avalon" altera:dir="end">
         <altera:port_mapping altera:name="ctrl_address" altera:internal="ctrl_address"></altera:port_mapping>
         <altera:port_mapping altera:name="ctrl_burstcount" altera:internal="ctrl_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="ctrl_byteenable" altera:internal="ctrl_byteenable"></altera:port_mapping>
@@ -2400,10 +2437,10 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="ctrl_write" altera:internal="ctrl_write"></altera:port_mapping>
         <altera:port_mapping altera:name="ctrl_writedata" altera:internal="ctrl_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_clk" altera:internal="kernel_interface_agilex_0.kernel_clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_clk" altera:internal="kernel_interface.kernel_clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="kernel_clk_clk" altera:internal="kernel_clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_cra" altera:internal="kernel_interface_agilex_0.kernel_cra" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="kernel_cra" altera:internal="kernel_interface.kernel_cra" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="kernel_cra_address" altera:internal="kernel_cra_address"></altera:port_mapping>
         <altera:port_mapping altera:name="kernel_cra_burstcount" altera:internal="kernel_cra_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="kernel_cra_byteenable" altera:internal="kernel_cra_byteenable"></altera:port_mapping>
@@ -2415,22 +2452,22 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="kernel_cra_write" altera:internal="kernel_cra_write"></altera:port_mapping>
         <altera:port_mapping altera:name="kernel_cra_writedata" altera:internal="kernel_cra_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_irq_from_kernel" altera:internal="kernel_interface_agilex_0.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start">
+      <altera:interface_mapping altera:name="kernel_irq_from_kernel" altera:internal="kernel_interface.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start">
         <altera:port_mapping altera:name="kernel_irq_from_kernel_irq" altera:internal="kernel_irq_from_kernel_irq"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_irq_to_host" altera:internal="kernel_interface_agilex_0.kernel_irq_to_host" altera:type="interrupt" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_irq_to_host" altera:internal="kernel_interface.kernel_irq_to_host" altera:type="interrupt" altera:dir="end">
         <altera:port_mapping altera:name="kernel_irq_to_host_irq" altera:internal="kernel_irq_to_host_irq"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_reset" altera:internal="kernel_interface_agilex_0.kernel_reset" altera:type="reset" altera:dir="start">
+      <altera:interface_mapping altera:name="kernel_reset" altera:internal="kernel_interface.kernel_reset" altera:type="reset" altera:dir="start">
         <altera:port_mapping altera:name="kernel_reset_reset_n" altera:internal="kernel_reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="reset" altera:internal="kernel_interface_agilex_0.reset" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="reset" altera:internal="kernel_interface.reset" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="reset_reset_n" altera:internal="reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="sw_reset_export" altera:internal="kernel_interface_agilex_0.sw_reset_export" altera:type="reset" altera:dir="start">
+      <altera:interface_mapping altera:name="sw_reset_export" altera:internal="kernel_interface.sw_reset_export" altera:type="reset" altera:dir="start">
         <altera:port_mapping altera:name="sw_reset_export_reset_n" altera:internal="sw_reset_export_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="sw_reset_in" altera:internal="kernel_interface_agilex_0.sw_reset_in" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="sw_reset_in" altera:internal="kernel_interface.sw_reset_in" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="sw_reset_in_reset" altera:internal="sw_reset_in_reset"></altera:port_mapping>
       </altera:interface_mapping>
     </altera:altera_interface_boundary>
@@ -2443,52 +2480,52 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:busInterfaces>
           <ipxact:busInterface>
             <ipxact:name>kernel_cra.s0</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>clock_crosser.slave</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>address_span_extender_0.windowed_slave</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>address_span_extender_0.cntl</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>sw_reset.s</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>ctrl.s0</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>mem_org_mode0.s</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>version_id_0.s</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>kernel_cra.m0</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master></ipxact:master>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>clock_crosser.master</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master>
               <ipxact:addressSpaceRef addressSpaceRef="clock_crosser.master">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
@@ -2497,7 +2534,7 @@ https://fpgasoftware.intel.com/eula.-->
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>address_span_extender_0.expanded_master</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master>
               <ipxact:addressSpaceRef addressSpaceRef="address_span_extender_0.expanded_master">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
@@ -2506,7 +2543,7 @@ https://fpgasoftware.intel.com/eula.-->
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>ctrl.m0</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master>
               <ipxact:addressSpaceRef addressSpaceRef="ctrl.m0">
                 <ipxact:baseAddress>0x1000</ipxact:baseAddress>

--- a/d5005/hardware/ofs_d5005/build/ip/ddr_board/ddr_board_memory_bank_divider.ip
+++ b/d5005/hardware/ofs_d5005/build/ip/ddr_board/ddr_board_memory_bank_divider.ip
@@ -14,16 +14,16 @@ refer to the applicable agreement for further details, at
 https://fpgasoftware.intel.com/eula.-->
 <ipxact:component xmlns:altera="http://www.altera.com/XMLSchema/IPXact2014/extensions" xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2014">
   <ipxact:vendor>author</ipxact:vendor>
-  <ipxact:library>ddr_board_acl_memory_bank_divider_1</ipxact:library>
-  <ipxact:name>acl_memory_bank_divider_1</ipxact:name>
-  <ipxact:version>21.3</ipxact:version>
+  <ipxact:library>ddr_board_memory_bank_divider</ipxact:library>
+  <ipxact:name>memory_bank_divider</ipxact:name>
+  <ipxact:version>23.2</ipxact:version>
   <ipxact:busInterfaces>
     <ipxact:busInterface>
       <ipxact:name>clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -67,10 +67,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -109,10 +109,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>acl_bsp_snoop</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon_streaming" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon_streaming" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon_streaming" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon_streaming" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -161,7 +161,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="dataBitsPerSymbol" type="int">
           <ipxact:name>dataBitsPerSymbol</ipxact:name>
           <ipxact:displayName>Data bits per symbol</ipxact:displayName>
-          <ipxact:value>36</ipxact:value>
+          <ipxact:value>37</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="emptyWithinPacket" type="bit">
           <ipxact:name>emptyWithinPacket</ipxact:name>
@@ -217,10 +217,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -264,10 +264,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -306,10 +306,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>s</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -401,7 +401,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="addressSpan" type="string">
           <ipxact:name>addressSpan</ipxact:name>
           <ipxact:displayName>Address span</ipxact:displayName>
-          <ipxact:value>17179869184</ipxact:value>
+          <ipxact:value>34359738368</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="addressUnits" type="string">
           <ipxact:name>addressUnits</ipxact:name>
@@ -619,10 +619,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>acl_bsp_memorg_host</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="conduit" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="conduit" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="conduit" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="conduit" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -656,10 +656,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>bank1</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -920,10 +920,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>bank2</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -1184,10 +1184,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>bank3</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -1448,10 +1448,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>bank4</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -1722,7 +1722,7 @@ https://fpgasoftware.intel.com/eula.-->
     <ipxact:instantiations>
       <ipxact:componentInstantiation>
         <ipxact:name>QUARTUS_SYNTH</ipxact:name>
-        <ipxact:moduleName>acl_memory_bank_divider</ipxact:moduleName>
+        <ipxact:moduleName>memory_bank_divider</ipxact:moduleName>
         <ipxact:fileSetRef>
           <ipxact:localName>QUARTUS_SYNTH</ipxact:localName>
         </ipxact:fileSetRef>
@@ -1763,7 +1763,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>35</ipxact:right>
+              <ipxact:right>36</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -1957,7 +1957,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>27</ipxact:right>
+              <ipxact:right>28</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2073,7 +2073,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>31</ipxact:right>
+              <ipxact:right>32</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2228,7 +2228,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>31</ipxact:right>
+              <ipxact:right>32</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2383,7 +2383,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>31</ipxact:right>
+              <ipxact:right>32</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2538,7 +2538,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>31</ipxact:right>
+              <ipxact:right>32</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2611,9 +2611,9 @@ https://fpgasoftware.intel.com/eula.-->
   <ipxact:vendorExtensions>
     <altera:entity_info>
       <ipxact:vendor>author</ipxact:vendor>
-      <ipxact:library>ddr_board_acl_memory_bank_divider_1</ipxact:library>
-      <ipxact:name>acl_memory_bank_divider</ipxact:name>
-      <ipxact:version>21.3</ipxact:version>
+      <ipxact:library>ddr_board_memory_bank_divider</ipxact:library>
+      <ipxact:name>memory_bank_divider</ipxact:name>
+      <ipxact:version>23.2</ipxact:version>
     </altera:entity_info>
     <altera:altera_module_parameters>
       <ipxact:parameters>
@@ -2645,7 +2645,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="ADDRESS_WIDTH" type="int">
           <ipxact:name>ADDRESS_WIDTH</ipxact:name>
           <ipxact:displayName>Address Width (total addressable)</ipxact:displayName>
-          <ipxact:value>34</ipxact:value>
+          <ipxact:value>35</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="BURST_SIZE" type="int">
           <ipxact:name>BURST_SIZE</ipxact:name>
@@ -2665,17 +2665,17 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="SYNCHRONIZE_RESET" type="int">
           <ipxact:name>SYNCHRONIZE_RESET</ipxact:name>
           <ipxact:displayName>SYNCHRONIZE_RESET</ipxact:displayName>
-          <ipxact:value>1</ipxact:value>
+          <ipxact:value>0</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE_FAMILY" type="string">
           <ipxact:name>AUTO_DEVICE_FAMILY</ipxact:name>
           <ipxact:displayName>Auto DEVICE_FAMILY</ipxact:displayName>
-          <ipxact:value>Agilex</ipxact:value>
+          <ipxact:value>Stratix 10</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE" type="string">
           <ipxact:name>AUTO_DEVICE</ipxact:name>
           <ipxact:displayName>Auto DEVICE</ipxact:displayName>
-          <ipxact:value>AGFB014R24A2E2V</ipxact:value>
+          <ipxact:value>1SX280HN2F43E2VG</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE_SPEEDGRADE" type="string">
           <ipxact:name>AUTO_DEVICE_SPEEDGRADE</ipxact:name>
@@ -2686,15 +2686,20 @@ https://fpgasoftware.intel.com/eula.-->
     </altera:altera_module_parameters>
     <altera:altera_system_parameters>
       <ipxact:parameters>
+        <ipxact:parameter parameterId="board" type="string">
+          <ipxact:name>board</ipxact:name>
+          <ipxact:displayName>Board</ipxact:displayName>
+          <ipxact:value>default</ipxact:value>
+        </ipxact:parameter>
         <ipxact:parameter parameterId="device" type="string">
           <ipxact:name>device</ipxact:name>
           <ipxact:displayName>Device</ipxact:displayName>
-          <ipxact:value>AGFB014R24A2E2V</ipxact:value>
+          <ipxact:value>1SX280HN2F43E2VG</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="deviceFamily" type="string">
           <ipxact:name>deviceFamily</ipxact:name>
           <ipxact:displayName>Device family</ipxact:displayName>
-          <ipxact:value>Agilex</ipxact:value>
+          <ipxact:value>Stratix 10</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="deviceSpeedGrade" type="string">
           <ipxact:name>deviceSpeedGrade</ipxact:name>
@@ -2715,17 +2720,12 @@ https://fpgasoftware.intel.com/eula.-->
    {
       datum _originalDeviceFamily
       {
-         value = "Agilex";
+         value = "Stratix 10";
          type = "String";
       }
    }
-   element acl_memory_bank_divider_1
+   element memory_bank_divider
    {
-      datum _originalVersion
-      {
-         value = "1.0";
-         type = "String";
-      }
    }
 }
 </ipxact:value>
@@ -2824,7 +2824,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;acl_bsp_snoop_data&lt;/name&gt;
                     &lt;role&gt;data&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;36&lt;/width&gt;
+                    &lt;width&gt;37&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -2867,7 +2867,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;dataBitsPerSymbol&lt;/key&gt;
-                        &lt;value&gt;36&lt;/value&gt;
+                        &lt;value&gt;37&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;emptyWithinPacket&lt;/key&gt;
@@ -3066,7 +3066,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;s_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Input&lt;/direction&gt;
-                    &lt;width&gt;28&lt;/width&gt;
+                    &lt;width&gt;29&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -3104,7 +3104,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;addressSpan&lt;/key&gt;
-                        &lt;value&gt;17179869184&lt;/value&gt;
+                        &lt;value&gt;34359738368&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;addressUnits&lt;/key&gt;
@@ -3347,7 +3347,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;bank1_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;32&lt;/width&gt;
+                    &lt;width&gt;33&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -3586,7 +3586,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;bank2_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;32&lt;/width&gt;
+                    &lt;width&gt;33&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -3825,7 +3825,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;bank3_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;32&lt;/width&gt;
+                    &lt;width&gt;33&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -4064,7 +4064,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;bank4_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;32&lt;/width&gt;
+                    &lt;width&gt;33&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -4265,11 +4265,11 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='s' start='0x0' end='0x800000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
-                        &lt;value&gt;34&lt;/value&gt;
+                        &lt;value&gt;35&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;MAX_SLAVE_DATA_WIDTH&lt;/key&gt;
@@ -4281,18 +4281,23 @@ https://fpgasoftware.intel.com/eula.-->
     &lt;/connPtSystemInfos&gt;
 &lt;/systemInfosDefinition&gt;</ipxact:value>
         </ipxact:parameter>
+        <ipxact:parameter parameterId="pinAssignmentListDefinition" type="string">
+          <ipxact:name>pinAssignmentListDefinition</ipxact:name>
+          <ipxact:displayName>pinAssignmentListDefinition</ipxact:displayName>
+          <ipxact:value>&lt;pinAssignmentListDefinition/&gt;</ipxact:value>
+        </ipxact:parameter>
       </ipxact:parameters>
     </altera:altera_system_parameters>
     <altera:altera_interface_boundary>
-      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="acl_memory_bank_divider_1.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end">
+      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="memory_bank_divider.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end">
         <altera:port_mapping altera:name="acl_bsp_memorg_host_mode" altera:internal="acl_bsp_memorg_host_mode"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="acl_bsp_snoop" altera:internal="acl_memory_bank_divider_1.acl_bsp_snoop" altera:type="avalon_streaming" altera:dir="start">
+      <altera:interface_mapping altera:name="acl_bsp_snoop" altera:internal="memory_bank_divider.acl_bsp_snoop" altera:type="avalon_streaming" altera:dir="start">
         <altera:port_mapping altera:name="acl_bsp_snoop_data" altera:internal="acl_bsp_snoop_data"></altera:port_mapping>
         <altera:port_mapping altera:name="acl_bsp_snoop_ready" altera:internal="acl_bsp_snoop_ready"></altera:port_mapping>
         <altera:port_mapping altera:name="acl_bsp_snoop_valid" altera:internal="acl_bsp_snoop_valid"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank1" altera:internal="acl_memory_bank_divider_1.bank1" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank1" altera:internal="memory_bank_divider.bank1" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank1_address" altera:internal="bank1_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank1_burstcount" altera:internal="bank1_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank1_byteenable" altera:internal="bank1_byteenable"></altera:port_mapping>
@@ -4304,7 +4309,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank1_write" altera:internal="bank1_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank1_writedata" altera:internal="bank1_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank2" altera:internal="acl_memory_bank_divider_1.bank2" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank2" altera:internal="memory_bank_divider.bank2" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank2_address" altera:internal="bank2_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank2_burstcount" altera:internal="bank2_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank2_byteenable" altera:internal="bank2_byteenable"></altera:port_mapping>
@@ -4316,7 +4321,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank2_write" altera:internal="bank2_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank2_writedata" altera:internal="bank2_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank3" altera:internal="acl_memory_bank_divider_1.bank3" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank3" altera:internal="memory_bank_divider.bank3" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank3_address" altera:internal="bank3_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank3_burstcount" altera:internal="bank3_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank3_byteenable" altera:internal="bank3_byteenable"></altera:port_mapping>
@@ -4328,7 +4333,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank3_write" altera:internal="bank3_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank3_writedata" altera:internal="bank3_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank4" altera:internal="acl_memory_bank_divider_1.bank4" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank4" altera:internal="memory_bank_divider.bank4" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank4_address" altera:internal="bank4_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank4_burstcount" altera:internal="bank4_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank4_byteenable" altera:internal="bank4_byteenable"></altera:port_mapping>
@@ -4340,19 +4345,19 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank4_write" altera:internal="bank4_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank4_writedata" altera:internal="bank4_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="clk" altera:internal="acl_memory_bank_divider_1.clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="clk" altera:internal="memory_bank_divider.clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="clk_clk" altera:internal="clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_clk" altera:internal="acl_memory_bank_divider_1.kernel_clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_clk" altera:internal="memory_bank_divider.kernel_clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="kernel_clk_clk" altera:internal="kernel_clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_reset" altera:internal="acl_memory_bank_divider_1.kernel_reset" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_reset" altera:internal="memory_bank_divider.kernel_reset" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="kernel_reset_reset_n" altera:internal="kernel_reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="reset" altera:internal="acl_memory_bank_divider_1.reset" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="reset" altera:internal="memory_bank_divider.reset" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="reset_reset_n" altera:internal="reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="s" altera:internal="acl_memory_bank_divider_1.s" altera:type="avalon" altera:dir="end">
+      <altera:interface_mapping altera:name="s" altera:internal="memory_bank_divider.s" altera:type="avalon" altera:dir="end">
         <altera:port_mapping altera:name="s_address" altera:internal="s_address"></altera:port_mapping>
         <altera:port_mapping altera:name="s_burstcount" altera:internal="s_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="s_byteenable" altera:internal="s_byteenable"></altera:port_mapping>

--- a/d5005/hardware/ofs_d5005/build/ip/kernel_interface_hw.tcl
+++ b/d5005/hardware/ofs_d5005/build/ip/kernel_interface_hw.tcl
@@ -17,14 +17,14 @@
 package require -exact qsys 17.0
 
 # module properties
-set_module_property NAME {kernel_interface_agilex}
-set_module_property DISPLAY_NAME {OpenCL Kernel Interface for Agilex}
+set_module_property NAME {kernel_interface}
+set_module_property DISPLAY_NAME {oneAPI Kernel Interface}
 
 # default module properties
-set_module_property VERSION {17.1}
-set_module_property GROUP {OpenCL BSP Components}
-set_module_property DESCRIPTION {Connects the OpenCL host to the FPGA kernel}
-set_module_property AUTHOR {author}
+set_module_property VERSION {23.2}
+set_module_property GROUP {oneAPI ASP Components}
+set_module_property DESCRIPTION {Connects the oneAPI host to the FPGA kernel}
+set_module_property AUTHOR {OFS}
 
 set_module_property COMPOSITION_CALLBACK compose
 set_module_property opaque_address_map false

--- a/d5005/hardware/ofs_d5005/build/ip/memory_bank_divider_hw.tcl
+++ b/d5005/hardware/ofs_d5005/build/ip/memory_bank_divider_hw.tcl
@@ -1,14 +1,14 @@
 package require -exact qsys 17.0
 
 # module properties
-set_module_property NAME {acl_memory_bank_divider}
-set_module_property DISPLAY_NAME {OpenCL Memory Bank Divider}
+set_module_property NAME {memory_bank_divider}
+set_module_property DISPLAY_NAME {oneAPI Memory Bank Divider}
 
 # default module properties
-set_module_property VERSION {21.3}
-set_module_property GROUP {OpenCL BSP Components}
-set_module_property DESCRIPTION {default description}
-set_module_property AUTHOR {author}
+set_module_property VERSION {23.2}
+set_module_property GROUP {oneAPI ASP Components}
+set_module_property DESCRIPTION {Handles multiple global memory banks}
+set_module_property AUTHOR {OFS}
 
 # Set the name of the procedure to manipulate parameters
 set_module_property COMPOSITION_CALLBACK compose

--- a/d5005/hardware/ofs_d5005_usm/build/board.qsys
+++ b/d5005/hardware/ofs_d5005_usm/build/board.qsys
@@ -253,7 +253,7 @@ https://fpgasoftware.intel.com/eula.-->
          type = "int";
       }
    }
-   element kernel_interface_s10_0
+   element kernel_interface
    {
       datum _sortIndex
       {
@@ -261,7 +261,7 @@ https://fpgasoftware.intel.com/eula.-->
          type = "int";
       }
    }
-   element kernel_interface_s10_0.ctrl
+   element kernel_interface.ctrl
    {
       datum baseAddress
       {
@@ -371,7 +371,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='board_afu_id_avmm_slave_0.afu_cfg_slave' start='0x0' end='0x40' datawidth='64' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Read_Slave' start='0x100' end='0x104' datawidth='32' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Mask_Slave' start='0x108' end='0x10C' datawidth='32' /&amp;gt;&amp;lt;slave name='kernel_interface_s10_0.ctrl' start='0x4000' end='0x8000' datawidth='32' /&amp;gt;&amp;lt;slave name='pipe_stage_dma_csr.s0' start='0x20000' end='0x20800' datawidth='64' /&amp;gt;&amp;lt;slave name='ddr_board.null_dfh_id' start='0x20800' end='0x20840' datawidth='64' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='board_afu_id_avmm_slave_0.afu_cfg_slave' start='0x0' end='0x40' datawidth='64' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Read_Slave' start='0x100' end='0x104' datawidth='32' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Mask_Slave' start='0x108' end='0x10C' datawidth='32' /&amp;gt;&amp;lt;slave name='kernel_interface.ctrl' start='0x4000' end='0x8000' datawidth='32' /&amp;gt;&amp;lt;slave name='pipe_stage_dma_csr.s0' start='0x20000' end='0x20800' datawidth='64' /&amp;gt;&amp;lt;slave name='ddr_board.null_dfh_id' start='0x20800' end='0x20840' datawidth='64' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
@@ -11047,7 +11047,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:module altera:enabled="true" altera:auto_export="false">
         <altera:entity_info>
           <ipxact:vendor>Altera Corporation</ipxact:vendor>
-          <ipxact:library>kernel_interface_s10_0</ipxact:library>
+          <ipxact:library>kernel_interface</ipxact:library>
           <ipxact:name>altera_generic_component</ipxact:name>
           <ipxact:version>1.0</ipxact:version>
         </altera:entity_info>
@@ -11769,7 +11769,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;bridgesToReceiver&lt;/key&gt;
-                            &lt;value&gt;kernel_interface_s10_0.kernel_irq_from_kernel&lt;/value&gt;
+                            &lt;value&gt;kernel_interface.kernel_irq_from_kernel&lt;/value&gt;
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;irqScheme&lt;/key&gt;
@@ -11924,9 +11924,9 @@ https://fpgasoftware.intel.com/eula.-->
         &lt;/interfaces&gt;
     &lt;/boundary&gt;
     &lt;originalModuleInfo&gt;
-        &lt;className&gt;kernel_interface_s10&lt;/className&gt;
-        &lt;version&gt;17.1&lt;/version&gt;
-        &lt;displayName&gt;OpenCL Kernel Interface for S10&lt;/displayName&gt;
+        &lt;className&gt;kernel_interface&lt;/className&gt;
+        &lt;version&gt;23.2&lt;/version&gt;
+        &lt;displayName&gt;oneAPI Kernel Interface&lt;/displayName&gt;
     &lt;/originalModuleInfo&gt;
     &lt;systemInfoParameterDescriptors&gt;
         &lt;descriptors&gt;
@@ -12667,7 +12667,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;bridgesToReceiver&lt;/key&gt;
-                        &lt;value&gt;kernel_interface_s10_0.kernel_irq_from_kernel&lt;/value&gt;
+                        &lt;value&gt;kernel_interface.kernel_irq_from_kernel&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;irqScheme&lt;/key&gt;
@@ -12822,35 +12822,35 @@ https://fpgasoftware.intel.com/eula.-->
               <ipxact:name>generationInfoDefinition</ipxact:name>
               <ipxact:displayName>Generation Behavior</ipxact:displayName>
               <ipxact:value>&lt;generationInfoDefinition&gt;
-    &lt;hdlLibraryName&gt;board_kernel_interface_s10_0&lt;/hdlLibraryName&gt;
+    &lt;hdlLibraryName&gt;board_kernel_interface&lt;/hdlLibraryName&gt;
     &lt;fileSets&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_s10_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_s10_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;QUARTUS_SYNTH&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_s10_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_s10_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VERILOG&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_s10_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_s10_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_s10_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_s10_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_s10_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_s10_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;CDC_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
@@ -12871,7 +12871,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:parameter parameterId="logicalView" type="string">
               <ipxact:name>logicalView</ipxact:name>
               <ipxact:displayName>Logical view</ipxact:displayName>
-              <ipxact:value>ip/board/board_kernel_interface_s10_0.ip</ipxact:value>
+              <ipxact:value>ip/board/board_kernel_interface.ip</ipxact:value>
             </ipxact:parameter>
             <ipxact:parameter parameterId="moduleAssignmentDefinition" type="string">
               <ipxact:name>moduleAssignmentDefinition</ipxact:name>
@@ -15646,7 +15646,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:module>
     </altera:modules>
     <altera:connections>
-      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="kernel_interface_s10_0.kernel_cra" altera:end="board_kernel_cra_pipe.s0">
+      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="kernel_interface.kernel_cra" altera:end="board_kernel_cra_pipe.s0">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15726,7 +15726,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="OPTIMIZED_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="pipe_stage_host_ctrl.m0" altera:end="kernel_interface_s10_0.ctrl">
+      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="pipe_stage_host_ctrl.m0" altera:end="kernel_interface.ctrl">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x4000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15791,7 +15791,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="clk_200.out_clk" altera:end="pipe_stage_host_ctrl.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk_in.out_clk" altera:end="board_kernel_cra_reset.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk_in.out_clk" altera:end="board_kernel_cra_pipe.clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="22.3" altera:start="clk_200.out_clk" altera:end="kernel_interface_s10_0.clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="22.3" altera:start="clk_200.out_clk" altera:end="kernel_interface.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="clk_200.out_clk" altera:end="pipe_stage_dma_csr.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk_in.out_clk" altera:end="kernel_clk_export.clk_in"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="clk_200.out_clk" altera:end="board_afu_id_avmm_slave_0.clock"></altera:connection>
@@ -15801,28 +15801,28 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="emif_ddr4d_clk.out_clk" altera:end="ddr_board.ddr_clk_d"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="clk_200.out_clk" altera:end="ddr_board.host_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk_in.out_clk" altera:end="ddr_board.kernel_clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk_in.out_clk" altera:end="kernel_interface_s10_0.kernel_clk"></altera:connection>
-      <altera:connection altera:kind="conduit" altera:version="22.3" altera:start="kernel_interface_s10_0.acl_bsp_memorg_host0x018" altera:end="ddr_board.acl_bsp_memorg_host">
+      <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk_in.out_clk" altera:end="kernel_interface.kernel_clk"></altera:connection>
+      <altera:connection altera:kind="conduit" altera:version="22.3" altera:start="kernel_interface.acl_bsp_memorg_host0x018" altera:end="ddr_board.acl_bsp_memorg_host">
         <altera:connection_parameter altera:parameter_name="endPort" altera:parameter_value=""></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="endPortLSB" altera:parameter_value="0"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="startPort" altera:parameter_value=""></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="startPortLSB" altera:parameter_value="0"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="width" altera:parameter_value="0"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="interrupt" altera:version="22.3" altera:start="board_irq_ctrl_0.interrupt_receiver" altera:end="kernel_interface_s10_0.kernel_irq_to_host">
+      <altera:connection altera:kind="interrupt" altera:version="22.3" altera:start="board_irq_ctrl_0.interrupt_receiver" altera:end="kernel_interface.kernel_irq_to_host">
         <altera:connection_parameter altera:parameter_name="irqNumber" altera:parameter_value="0"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="kernel_interface_s10_0.kernel_reset" altera:end="kernel_clk_export.clk_in_reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="kernel_interface_s10_0.kernel_reset" altera:end="ddr_board.kernel_reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="kernel_interface.kernel_reset" altera:end="kernel_clk_export.clk_in_reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="kernel_interface.kernel_reset" altera:end="ddr_board.kernel_reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="board_irq_ctrl_0.Resetn"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="ddr_board.global_reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="board_kernel_cra_reset.in_reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="board_afu_id_avmm_slave_0.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="pipe_stage_host_ctrl.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="board_kernel_cra_reset.out_reset" altera:end="board_kernel_cra_pipe.reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="kernel_interface_s10_0.reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="kernel_interface.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="pipe_stage_dma_csr.reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="kernel_interface_s10_0.sw_reset_in"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset_in.out_reset" altera:end="kernel_interface.sw_reset_in"></altera:connection>
     </altera:connections>
     <altera:interconnect_requirements></altera:interconnect_requirements>
     <altera:wire_level_connections></altera:wire_level_connections>
@@ -15853,7 +15853,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:interface_mapping altera:name="kernel_ddr4b" altera:internal="ddr_board.kernel_ddr4b" altera:type="avalon" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="kernel_ddr4c" altera:internal="ddr_board.kernel_ddr4c" altera:type="avalon" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="kernel_ddr4d" altera:internal="ddr_board.kernel_ddr4d" altera:type="avalon" altera:dir="end"></altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_irq" altera:internal="kernel_interface_s10_0.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start"></altera:interface_mapping>
+      <altera:interface_mapping altera:name="kernel_irq" altera:internal="kernel_interface.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start"></altera:interface_mapping>
       <altera:interface_mapping altera:name="kernel_reset" altera:internal="kernel_clk_export.clk_reset" altera:type="reset" altera:dir="start"></altera:interface_mapping>
     </altera:altera_interface_boundary>
     <ipxact:components>
@@ -15873,10 +15873,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>kernel_interface_s10_0.kernel_cra</ipxact:name>
+            <ipxact:name>kernel_interface.kernel_cra</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="kernel_interface_s10_0.kernel_cra">
+              <ipxact:addressSpaceRef addressSpaceRef="kernel_interface.kernel_cra">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -15899,7 +15899,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>kernel_interface_s10_0.ctrl</ipxact:name>
+            <ipxact:name>kernel_interface.ctrl</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -15942,7 +15942,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:busInterfaces>
         <ipxact:addressSpaces>
           <ipxact:addressSpace>
-            <ipxact:name>kernel_interface_s10_0.kernel_cra</ipxact:name>
+            <ipxact:name>kernel_interface.kernel_cra</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>board_kernel_cra_pipe.s0</ipxact:name>
@@ -15970,7 +15970,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:range>0x0000_0040</ipxact:range>
               </ipxact:segment>
               <ipxact:segment>
-                <ipxact:name>kernel_interface_s10_0.ctrl</ipxact:name>
+                <ipxact:name>kernel_interface.ctrl</ipxact:name>
                 <ipxact:addressOffset>0x0000_4000</ipxact:addressOffset>
                 <ipxact:range>0x0000_4000</ipxact:range>
               </ipxact:segment>

--- a/d5005/hardware/ofs_d5005_usm/build/ddr_board.qsys
+++ b/d5005/hardware/ofs_d5005_usm/build/ddr_board.qsys
@@ -40,7 +40,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:displayName>bonusData</ipxact:displayName>
           <ipxact:value>bonusData 
 {
-   element acl_memory_bank_divider_0
+   element memory_bank_divider
    {
       datum _sortIndex
       {
@@ -410,7 +410,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='acl_memory_bank_divider_0.s' start='0x0' end='0x800000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='memory_bank_divider.s' start='0x0' end='0x800000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
@@ -431,7 +431,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='acl_memory_bank_divider_0.s' start='0x0' end='0x800000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='memory_bank_divider.s' start='0x0' end='0x800000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
@@ -690,7 +690,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:module altera:enabled="true" altera:auto_export="false">
         <altera:entity_info>
           <ipxact:vendor>Altera Corporation</ipxact:vendor>
-          <ipxact:library>acl_memory_bank_divider_0</ipxact:library>
+          <ipxact:library>memory_bank_divider</ipxact:library>
           <ipxact:name>altera_generic_component</ipxact:name>
           <ipxact:version>1.0</ipxact:version>
         </altera:entity_info>
@@ -2214,9 +2214,9 @@ https://fpgasoftware.intel.com/eula.-->
         &lt;/interfaces&gt;
     &lt;/boundary&gt;
     &lt;originalModuleInfo&gt;
-        &lt;className&gt;acl_memory_bank_divider&lt;/className&gt;
-        &lt;version&gt;21.3&lt;/version&gt;
-        &lt;displayName&gt;OpenCL Memory Bank Divider&lt;/displayName&gt;
+        &lt;className&gt;memory_bank_divider&lt;/className&gt;
+        &lt;version&gt;23.2&lt;/version&gt;
+        &lt;displayName&gt;oneAPI Memory Bank Divider&lt;/displayName&gt;
     &lt;/originalModuleInfo&gt;
     &lt;systemInfoParameterDescriptors&gt;
         &lt;descriptors&gt;
@@ -3788,35 +3788,35 @@ https://fpgasoftware.intel.com/eula.-->
               <ipxact:name>generationInfoDefinition</ipxact:name>
               <ipxact:displayName>Generation Behavior</ipxact:displayName>
               <ipxact:value>&lt;generationInfoDefinition&gt;
-    &lt;hdlLibraryName&gt;ddr_board_acl_memory_bank_divider_1&lt;/hdlLibraryName&gt;
+    &lt;hdlLibraryName&gt;ddr_board_memory_bank_divider&lt;/hdlLibraryName&gt;
     &lt;fileSets&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;QUARTUS_SYNTH&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VERILOG&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;CDC_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
@@ -3837,7 +3837,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:parameter parameterId="logicalView" type="string">
               <ipxact:name>logicalView</ipxact:name>
               <ipxact:displayName>Logical view</ipxact:displayName>
-              <ipxact:value>ip/ddr_board/ddr_board_acl_memory_bank_divider_1.ip</ipxact:value>
+              <ipxact:value>ip/ddr_board/ddr_board_memory_bank_divider.ip</ipxact:value>
             </ipxact:parameter>
             <ipxact:parameter parameterId="moduleAssignmentDefinition" type="string">
               <ipxact:name>moduleAssignmentDefinition</ipxact:name>
@@ -15169,7 +15169,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:module>
     </altera:modules>
     <altera:connections>
-      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="acl_memory_bank_divider_0.bank1" altera:end="ddr_channel_a.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="memory_bank_divider.bank1" altera:end="ddr_channel_a.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15189,7 +15189,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="OPTIMIZED_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="acl_memory_bank_divider_0.bank2" altera:end="ddr_channel_b.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="memory_bank_divider.bank2" altera:end="ddr_channel_b.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15209,7 +15209,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="OPTIMIZED_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="acl_memory_bank_divider_0.bank3" altera:end="ddr_channel_c.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="memory_bank_divider.bank3" altera:end="ddr_channel_c.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15229,7 +15229,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="OPTIMIZED_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="acl_memory_bank_divider_0.bank4" altera:end="ddr_channel_d.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="memory_bank_divider.bank4" altera:end="ddr_channel_d.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15249,7 +15249,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="OPTIMIZED_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="dma_localmem_wr_pipe.m0" altera:end="acl_memory_bank_divider_0.s">
+      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="dma_localmem_wr_pipe.m0" altera:end="memory_bank_divider.s">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15269,7 +15269,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="OPTIMIZED_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="dma_localmem_rd_pipe.m0" altera:end="acl_memory_bank_divider_0.s">
+      <altera:connection altera:kind="avalon" altera:version="22.3" altera:start="dma_localmem_rd_pipe.m0" altera:end="memory_bank_divider.s">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15291,7 +15291,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk.out_clk" altera:end="kernel_reset.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="host_clk.out_clk" altera:end="global_reset.clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="22.3" altera:start="host_clk.out_clk" altera:end="acl_memory_bank_divider_0.clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="22.3" altera:start="host_clk.out_clk" altera:end="memory_bank_divider.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="host_clk.out_clk" altera:end="dma_localmem_rd_pipe.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="host_clk.out_clk" altera:end="dma_localmem_wr_pipe.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="host_clk.out_clk" altera:end="null_dfh_inst.clock"></altera:connection>
@@ -15303,13 +15303,13 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="host_clk.out_clk" altera:end="ddr_channel_b.host_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="host_clk.out_clk" altera:end="ddr_channel_c.host_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="host_clk.out_clk" altera:end="ddr_channel_d.host_clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk.out_clk" altera:end="acl_memory_bank_divider_0.kernel_clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk.out_clk" altera:end="memory_bank_divider.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_a.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_b.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_c.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="22.3" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_d.kernel_clk"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="kernel_reset.out_reset" altera:end="acl_memory_bank_divider_0.kernel_reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset.out_reset" altera:end="acl_memory_bank_divider_0.reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="kernel_reset.out_reset" altera:end="memory_bank_divider.kernel_reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset.out_reset" altera:end="memory_bank_divider.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset.out_reset" altera:end="null_dfh_inst.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset.out_reset" altera:end="dma_localmem_wr_pipe.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="22.3" altera:start="global_reset.out_reset" altera:end="dma_localmem_rd_pipe.reset"></altera:connection>
@@ -15324,8 +15324,8 @@ https://fpgasoftware.intel.com/eula.-->
     <altera:hdl_parameter_mappings></altera:hdl_parameter_mappings>
     <altera:preserved_ports_for_debug></altera:preserved_ports_for_debug>
     <altera:altera_interface_boundary>
-      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="acl_memory_bank_divider_0.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end"></altera:interface_mapping>
-      <altera:interface_mapping altera:name="acl_bsp_snoop" altera:internal="acl_memory_bank_divider_0.acl_bsp_snoop" altera:type="avalon_streaming" altera:dir="start"></altera:interface_mapping>
+      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="memory_bank_divider.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end"></altera:interface_mapping>
+      <altera:interface_mapping altera:name="acl_bsp_snoop" altera:internal="memory_bank_divider.acl_bsp_snoop" altera:type="avalon_streaming" altera:dir="start"></altera:interface_mapping>
       <altera:interface_mapping altera:name="ddr_clk_a" altera:internal="ddr_clk_a.in_clk" altera:type="clock" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="ddr_clk_b" altera:internal="ddr_clk_b.in_clk" altera:type="clock" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="ddr_clk_c" altera:internal="ddr_clk_c.in_clk" altera:type="clock" altera:dir="end"></altera:interface_mapping>
@@ -15358,10 +15358,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank1</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank1</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank1">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank1">
                 <ipxact:baseAddress>0x0000_0000_0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -15371,10 +15371,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank2</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank2</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank2">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank2">
                 <ipxact:baseAddress>0x0000_0000_0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -15384,10 +15384,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank3</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank3</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank3">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank3">
                 <ipxact:baseAddress>0x0000_0000_0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -15397,16 +15397,16 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank4</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank4</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank4">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank4">
                 <ipxact:baseAddress>0x0000_0000_0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+            <ipxact:name>memory_bank_divider.s</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -15419,7 +15419,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:master>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+            <ipxact:name>memory_bank_divider.s</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -15454,7 +15454,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:busInterfaces>
         <ipxact:addressSpaces>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank1</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank1</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_a.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -15464,7 +15464,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank2</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank2</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_b.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -15474,7 +15474,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank3</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank3</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_c.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -15484,7 +15484,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank4</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank4</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_d.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -15497,7 +15497,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:name>dma_localmem_rd_pipe.m0</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
-                <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+                <ipxact:name>memory_bank_divider.s</ipxact:name>
                 <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
                 <ipxact:range>0x0000_0008_0000_0000</ipxact:range>
               </ipxact:segment>
@@ -15507,7 +15507,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:name>dma_localmem_wr_pipe.m0</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
-                <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+                <ipxact:name>memory_bank_divider.s</ipxact:name>
                 <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
                 <ipxact:range>0x0000_0008_0000_0000</ipxact:range>
               </ipxact:segment>

--- a/d5005/hardware/ofs_d5005_usm/build/hw_iface.iipx
+++ b/d5005/hardware/ofs_d5005_usm/build/hw_iface.iipx
@@ -194,94 +194,6 @@
   <tag2 key="TCL_PACKAGE_VERSION" value="10.0" />
  </component>
  <component
-   name="acl_kernel_clk"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/iface/acl_kernel_clk.qsys"
-   displayName="OpenCL Kernel Clock Generator"
-   version="1.0"
-   description="Generates the kernel clocks for ACL"
-   tags="INTERNAL_COMPONENT=false"
-   categories="OpenCL BSP Components"
-   factory="QsysFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPONENT_HIDE_FROM_QUARTUS" value="true" />
- </component>
- <component
-   name="acl_kernel_clk_a10"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_clk_a10_hw.tcl"
-   displayName="OpenCL A10 Kernel Clock Generator"
-   version="16.1"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="comp" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="16.1" />
- </component>
- <component
-   name="acl_kernel_clk_noreconfig"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/iface/acl_kernel_clk_noreconfig.qsys"
-   displayName="OpenCL Kernel Clock Generator - no Dynamic Reconfig"
-   version="1.0"
-   description="Generates the kernel clocks for ACL"
-   tags="INTERNAL_COMPONENT=false"
-   categories="OpenCL BSP Components"
-   factory="QsysFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPONENT_HIDE_FROM_QUARTUS" value="true" />
- </component>
- <component
-   name="acl_kernel_clk_s10"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_clk_s10_hw.tcl"
-   displayName="OpenCL S10 Kernel Clock Generator"
-   version="17.0"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="comp" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="16.1" />
- </component>
- <component
-   name="acl_kernel_clk_s10_reconfig"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_clk_s10_reconfig_hw.tcl"
-   displayName="OpenCL S10 reconfigurable kernel clock generator"
-   version="17.0"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="comp" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="16.1" />
- </component>
- <component
-   name="acl_kernel_interface_soc"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/iface/acl_kernel_interface_soc.qsys"
-   displayName="acl_kernel_interface_soc"
-   version="1.0"
-   description="ACL Kernel Interface"
-   tags=""
-   categories="ACL BSP Components"
-   factory="QsysFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPONENT_HIDE_FROM_QUARTUS" value="true" />
- </component>
- <component
-   name="acl_memory_bank_divider"
-   file="./ip/acl_memory_bank_divider_hw.tcl"
-   displayName="OpenCL Memory Bank Divider"
-   version="21.3"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="compose" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="17.0" />
- </component>
- <component
    name="acl_snoop_adapter"
    file="${INTELFPGAOCLSDKROOT}/ip/board/export/snoop_adapter_hw.tcl"
    displayName="Avalon Snoop Adapter"
@@ -709,36 +621,6 @@
   <tag2 key="OPAQUE_ADDRESS_MAP" value="true" />
   <tag2 key="SUPPORTED_FILE_SETS" value="QUARTUS_SYNTH,SIM_VERILOG" />
   <tag2 key="TCL_PACKAGE_VERSION" value="12.1" />
- </component>
- <component
-   name="kernel_interface"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_interface_hw.tcl"
-   displayName="OpenCL Kernel Interface"
-   version="15.1"
-   description="Connects the OpenCL host to the FPGA kernel"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="compose" />
-  <tag2 key="OPAQUE_ADDRESS_MAP" value="false" />
-  <tag2 key="PARAMETER_UPGRADE_CALLBACK" value="ip_upgrade" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="13.1" />
- </component>
- <component
-   name="kernel_interface_s10"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_interface_s10_hw.tcl"
-   displayName="OpenCL Kernel Interface for S10"
-   version="17.1"
-   description="Connects the OpenCL host to the FPGA kernel"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="compose" />
-  <tag2 key="OPAQUE_ADDRESS_MAP" value="false" />
-  <tag2 key="PARAMETER_UPGRADE_CALLBACK" value="ip_upgrade" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="17.0" />
  </component>
  <component
    name="mem_org_mode"

--- a/d5005/hardware/ofs_d5005_usm/build/ip/board/board_kernel_interface.ip
+++ b/d5005/hardware/ofs_d5005_usm/build/ip/board/board_kernel_interface.ip
@@ -14,16 +14,16 @@ refer to the applicable agreement for further details, at
 https://fpgasoftware.intel.com/eula.-->
 <ipxact:component xmlns:altera="http://www.altera.com/XMLSchema/IPXact2014/extensions" xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2014">
   <ipxact:vendor>author</ipxact:vendor>
-  <ipxact:library>board_kernel_interface_agilex_0</ipxact:library>
-  <ipxact:name>kernel_interface_agilex_0</ipxact:name>
-  <ipxact:version>17.1</ipxact:version>
+  <ipxact:library>board_kernel_interface</ipxact:library>
+  <ipxact:name>kernel_interface</ipxact:name>
+  <ipxact:version>23.2</ipxact:version>
   <ipxact:busInterfaces>
     <ipxact:busInterface>
       <ipxact:name>kernel_cra</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -284,10 +284,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>ctrl</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -605,10 +605,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>acl_bsp_memorg_host0x018</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="conduit" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="conduit" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="conduit" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="conduit" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -642,10 +642,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -689,10 +689,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -731,10 +731,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_irq_from_kernel</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -778,10 +778,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_irq_to_host</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -819,7 +819,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="bridgesToReceiver" type="string">
           <ipxact:name>bridgesToReceiver</ipxact:name>
           <ipxact:displayName>Bridges to receiver</ipxact:displayName>
-          <ipxact:value>board_kernel_interface_agilex_0.kernel_irq_from_kernel</ipxact:value>
+          <ipxact:value>board_kernel_interface.kernel_irq_from_kernel</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="irqScheme" type="string">
           <ipxact:name>irqScheme</ipxact:name>
@@ -830,10 +830,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>sw_reset_in</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -862,10 +862,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -899,10 +899,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -941,10 +941,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>sw_reset_export</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -993,10 +993,11 @@ https://fpgasoftware.intel.com/eula.-->
     <ipxact:instantiations>
       <ipxact:componentInstantiation>
         <ipxact:name>QUARTUS_SYNTH</ipxact:name>
-        <ipxact:moduleName>kernel_interface_agilex</ipxact:moduleName>
+        <ipxact:moduleName>kernel_interface</ipxact:moduleName>
         <ipxact:fileSetRef>
           <ipxact:localName>QUARTUS_SYNTH</ipxact:localName>
         </ipxact:fileSetRef>
+        <ipxact:parameters></ipxact:parameters>
       </ipxact:componentInstantiation>
     </ipxact:instantiations>
     <ipxact:ports>
@@ -1004,6 +1005,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_waitrequest</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1034,6 +1036,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_readdatavalid</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1046,6 +1049,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_burstcount</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC_VECTOR</ipxact:typeName>
@@ -1094,6 +1098,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_write</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1106,6 +1111,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_read</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1136,6 +1142,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_debugaccess</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1148,6 +1155,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_waitrequest</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1178,6 +1186,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_readdatavalid</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1190,6 +1199,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_burstcount</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC_VECTOR</ipxact:typeName>
@@ -1238,6 +1248,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_write</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1250,6 +1261,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_read</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1280,6 +1292,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_debugaccess</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1310,6 +1323,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>clk_clk</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1322,6 +1336,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>reset_reset_n</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1334,6 +1349,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_irq_from_kernel_irq</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC_VECTOR</ipxact:typeName>
@@ -1346,6 +1362,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_irq_to_host_irq</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1358,6 +1375,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>sw_reset_in_reset</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1370,6 +1388,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_clk_clk</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1382,6 +1401,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_reset_reset_n</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1394,6 +1414,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>sw_reset_export_reset_n</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
+          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1407,9 +1428,9 @@ https://fpgasoftware.intel.com/eula.-->
   <ipxact:vendorExtensions>
     <altera:entity_info>
       <ipxact:vendor>author</ipxact:vendor>
-      <ipxact:library>board_kernel_interface_agilex_0</ipxact:library>
-      <ipxact:name>kernel_interface_agilex</ipxact:name>
-      <ipxact:version>17.1</ipxact:version>
+      <ipxact:library>board_kernel_interface</ipxact:library>
+      <ipxact:name>kernel_interface</ipxact:name>
+      <ipxact:version>23.2</ipxact:version>
     </altera:entity_info>
     <altera:altera_module_parameters>
       <ipxact:parameters>
@@ -1426,12 +1447,12 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="AUTO_DEVICE_FAMILY" type="string">
           <ipxact:name>AUTO_DEVICE_FAMILY</ipxact:name>
           <ipxact:displayName>Auto DEVICE_FAMILY</ipxact:displayName>
-          <ipxact:value>Agilex</ipxact:value>
+          <ipxact:value>Stratix 10</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE" type="string">
           <ipxact:name>AUTO_DEVICE</ipxact:name>
           <ipxact:displayName>Auto DEVICE</ipxact:displayName>
-          <ipxact:value>AGFB014R24A2E2V</ipxact:value>
+          <ipxact:value>1SX280HN2F43E2VG</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE_SPEEDGRADE" type="string">
           <ipxact:name>AUTO_DEVICE_SPEEDGRADE</ipxact:name>
@@ -1445,17 +1466,17 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="board" type="string">
           <ipxact:name>board</ipxact:name>
           <ipxact:displayName>Board</ipxact:displayName>
-          <ipxact:value>Unknown</ipxact:value>
+          <ipxact:value>default</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="device" type="string">
           <ipxact:name>device</ipxact:name>
           <ipxact:displayName>Device</ipxact:displayName>
-          <ipxact:value>AGFB014R24A2E2V</ipxact:value>
+          <ipxact:value>1SX280HN2F43E2VG</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="deviceFamily" type="string">
           <ipxact:name>deviceFamily</ipxact:name>
           <ipxact:displayName>Device family</ipxact:displayName>
-          <ipxact:value>Agilex</ipxact:value>
+          <ipxact:value>Stratix 10</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="deviceSpeedGrade" type="string">
           <ipxact:name>deviceSpeedGrade</ipxact:name>
@@ -1472,6 +1493,17 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:displayName>bonusData</ipxact:displayName>
           <ipxact:value>bonusData 
 {
+   element $system
+   {
+      datum _originalDeviceFamily
+      {
+         value = "Stratix 10";
+         type = "String";
+      }
+   }
+   element kernel_interface
+   {
+   }
 }
 </ipxact:value>
         </ipxact:parameter>
@@ -2195,7 +2227,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;bridgesToReceiver&lt;/key&gt;
-                        &lt;value&gt;board_kernel_interface_agilex_0.kernel_irq_from_kernel&lt;/value&gt;
+                        &lt;value&gt;board_kernel_interface.kernel_irq_from_kernel&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;irqScheme&lt;/key&gt;
@@ -2379,16 +2411,21 @@ https://fpgasoftware.intel.com/eula.-->
     &lt;/connPtSystemInfos&gt;
 &lt;/systemInfosDefinition&gt;</ipxact:value>
         </ipxact:parameter>
+        <ipxact:parameter parameterId="pinAssignmentListDefinition" type="string">
+          <ipxact:name>pinAssignmentListDefinition</ipxact:name>
+          <ipxact:displayName>pinAssignmentListDefinition</ipxact:displayName>
+          <ipxact:value>&lt;pinAssignmentListDefinition/&gt;</ipxact:value>
+        </ipxact:parameter>
       </ipxact:parameters>
     </altera:altera_system_parameters>
     <altera:altera_interface_boundary>
-      <altera:interface_mapping altera:name="acl_bsp_memorg_host0x018" altera:internal="kernel_interface_agilex_0.acl_bsp_memorg_host0x018" altera:type="conduit" altera:dir="end">
+      <altera:interface_mapping altera:name="acl_bsp_memorg_host0x018" altera:internal="kernel_interface.acl_bsp_memorg_host0x018" altera:type="conduit" altera:dir="end">
         <altera:port_mapping altera:name="acl_bsp_memorg_host0x018_mode" altera:internal="acl_bsp_memorg_host0x018_mode"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="clk" altera:internal="kernel_interface_agilex_0.clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="clk" altera:internal="kernel_interface.clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="clk_clk" altera:internal="clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="ctrl" altera:internal="kernel_interface_agilex_0.ctrl" altera:type="avalon" altera:dir="end">
+      <altera:interface_mapping altera:name="ctrl" altera:internal="kernel_interface.ctrl" altera:type="avalon" altera:dir="end">
         <altera:port_mapping altera:name="ctrl_address" altera:internal="ctrl_address"></altera:port_mapping>
         <altera:port_mapping altera:name="ctrl_burstcount" altera:internal="ctrl_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="ctrl_byteenable" altera:internal="ctrl_byteenable"></altera:port_mapping>
@@ -2400,10 +2437,10 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="ctrl_write" altera:internal="ctrl_write"></altera:port_mapping>
         <altera:port_mapping altera:name="ctrl_writedata" altera:internal="ctrl_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_clk" altera:internal="kernel_interface_agilex_0.kernel_clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_clk" altera:internal="kernel_interface.kernel_clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="kernel_clk_clk" altera:internal="kernel_clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_cra" altera:internal="kernel_interface_agilex_0.kernel_cra" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="kernel_cra" altera:internal="kernel_interface.kernel_cra" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="kernel_cra_address" altera:internal="kernel_cra_address"></altera:port_mapping>
         <altera:port_mapping altera:name="kernel_cra_burstcount" altera:internal="kernel_cra_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="kernel_cra_byteenable" altera:internal="kernel_cra_byteenable"></altera:port_mapping>
@@ -2415,22 +2452,22 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="kernel_cra_write" altera:internal="kernel_cra_write"></altera:port_mapping>
         <altera:port_mapping altera:name="kernel_cra_writedata" altera:internal="kernel_cra_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_irq_from_kernel" altera:internal="kernel_interface_agilex_0.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start">
+      <altera:interface_mapping altera:name="kernel_irq_from_kernel" altera:internal="kernel_interface.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start">
         <altera:port_mapping altera:name="kernel_irq_from_kernel_irq" altera:internal="kernel_irq_from_kernel_irq"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_irq_to_host" altera:internal="kernel_interface_agilex_0.kernel_irq_to_host" altera:type="interrupt" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_irq_to_host" altera:internal="kernel_interface.kernel_irq_to_host" altera:type="interrupt" altera:dir="end">
         <altera:port_mapping altera:name="kernel_irq_to_host_irq" altera:internal="kernel_irq_to_host_irq"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_reset" altera:internal="kernel_interface_agilex_0.kernel_reset" altera:type="reset" altera:dir="start">
+      <altera:interface_mapping altera:name="kernel_reset" altera:internal="kernel_interface.kernel_reset" altera:type="reset" altera:dir="start">
         <altera:port_mapping altera:name="kernel_reset_reset_n" altera:internal="kernel_reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="reset" altera:internal="kernel_interface_agilex_0.reset" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="reset" altera:internal="kernel_interface.reset" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="reset_reset_n" altera:internal="reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="sw_reset_export" altera:internal="kernel_interface_agilex_0.sw_reset_export" altera:type="reset" altera:dir="start">
+      <altera:interface_mapping altera:name="sw_reset_export" altera:internal="kernel_interface.sw_reset_export" altera:type="reset" altera:dir="start">
         <altera:port_mapping altera:name="sw_reset_export_reset_n" altera:internal="sw_reset_export_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="sw_reset_in" altera:internal="kernel_interface_agilex_0.sw_reset_in" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="sw_reset_in" altera:internal="kernel_interface.sw_reset_in" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="sw_reset_in_reset" altera:internal="sw_reset_in_reset"></altera:port_mapping>
       </altera:interface_mapping>
     </altera:altera_interface_boundary>
@@ -2443,52 +2480,52 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:busInterfaces>
           <ipxact:busInterface>
             <ipxact:name>kernel_cra.s0</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>clock_crosser.slave</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>address_span_extender_0.windowed_slave</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>address_span_extender_0.cntl</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>sw_reset.s</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>ctrl.s0</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>mem_org_mode0.s</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>version_id_0.s</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>kernel_cra.m0</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master></ipxact:master>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>clock_crosser.master</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master>
               <ipxact:addressSpaceRef addressSpaceRef="clock_crosser.master">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
@@ -2497,7 +2534,7 @@ https://fpgasoftware.intel.com/eula.-->
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>address_span_extender_0.expanded_master</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master>
               <ipxact:addressSpaceRef addressSpaceRef="address_span_extender_0.expanded_master">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
@@ -2506,7 +2543,7 @@ https://fpgasoftware.intel.com/eula.-->
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>ctrl.m0</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master>
               <ipxact:addressSpaceRef addressSpaceRef="ctrl.m0">
                 <ipxact:baseAddress>0x1000</ipxact:baseAddress>

--- a/d5005/hardware/ofs_d5005_usm/build/ip/ddr_board/ddr_board_memory_bank_divider.ip
+++ b/d5005/hardware/ofs_d5005_usm/build/ip/ddr_board/ddr_board_memory_bank_divider.ip
@@ -14,16 +14,16 @@ refer to the applicable agreement for further details, at
 https://fpgasoftware.intel.com/eula.-->
 <ipxact:component xmlns:altera="http://www.altera.com/XMLSchema/IPXact2014/extensions" xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2014">
   <ipxact:vendor>author</ipxact:vendor>
-  <ipxact:library>ddr_board_acl_memory_bank_divider_1</ipxact:library>
-  <ipxact:name>acl_memory_bank_divider_1</ipxact:name>
-  <ipxact:version>21.3</ipxact:version>
+  <ipxact:library>ddr_board_memory_bank_divider</ipxact:library>
+  <ipxact:name>memory_bank_divider</ipxact:name>
+  <ipxact:version>23.2</ipxact:version>
   <ipxact:busInterfaces>
     <ipxact:busInterface>
       <ipxact:name>clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -67,10 +67,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -109,10 +109,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>acl_bsp_snoop</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon_streaming" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon_streaming" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon_streaming" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon_streaming" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -161,7 +161,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="dataBitsPerSymbol" type="int">
           <ipxact:name>dataBitsPerSymbol</ipxact:name>
           <ipxact:displayName>Data bits per symbol</ipxact:displayName>
-          <ipxact:value>36</ipxact:value>
+          <ipxact:value>37</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="emptyWithinPacket" type="bit">
           <ipxact:name>emptyWithinPacket</ipxact:name>
@@ -217,10 +217,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -264,10 +264,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -306,10 +306,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>s</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -401,7 +401,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="addressSpan" type="string">
           <ipxact:name>addressSpan</ipxact:name>
           <ipxact:displayName>Address span</ipxact:displayName>
-          <ipxact:value>17179869184</ipxact:value>
+          <ipxact:value>34359738368</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="addressUnits" type="string">
           <ipxact:name>addressUnits</ipxact:name>
@@ -619,10 +619,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>acl_bsp_memorg_host</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="conduit" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="conduit" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="conduit" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="conduit" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -656,10 +656,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>bank1</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -920,10 +920,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>bank2</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -1184,10 +1184,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>bank3</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -1448,10 +1448,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>bank4</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -1722,7 +1722,7 @@ https://fpgasoftware.intel.com/eula.-->
     <ipxact:instantiations>
       <ipxact:componentInstantiation>
         <ipxact:name>QUARTUS_SYNTH</ipxact:name>
-        <ipxact:moduleName>acl_memory_bank_divider</ipxact:moduleName>
+        <ipxact:moduleName>memory_bank_divider</ipxact:moduleName>
         <ipxact:fileSetRef>
           <ipxact:localName>QUARTUS_SYNTH</ipxact:localName>
         </ipxact:fileSetRef>
@@ -1763,7 +1763,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>35</ipxact:right>
+              <ipxact:right>36</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -1957,7 +1957,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>27</ipxact:right>
+              <ipxact:right>28</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2073,7 +2073,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>31</ipxact:right>
+              <ipxact:right>32</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2228,7 +2228,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>31</ipxact:right>
+              <ipxact:right>32</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2383,7 +2383,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>31</ipxact:right>
+              <ipxact:right>32</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2538,7 +2538,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>31</ipxact:right>
+              <ipxact:right>32</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2611,9 +2611,9 @@ https://fpgasoftware.intel.com/eula.-->
   <ipxact:vendorExtensions>
     <altera:entity_info>
       <ipxact:vendor>author</ipxact:vendor>
-      <ipxact:library>ddr_board_acl_memory_bank_divider_1</ipxact:library>
-      <ipxact:name>acl_memory_bank_divider</ipxact:name>
-      <ipxact:version>21.3</ipxact:version>
+      <ipxact:library>ddr_board_memory_bank_divider</ipxact:library>
+      <ipxact:name>memory_bank_divider</ipxact:name>
+      <ipxact:version>23.2</ipxact:version>
     </altera:entity_info>
     <altera:altera_module_parameters>
       <ipxact:parameters>
@@ -2645,7 +2645,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="ADDRESS_WIDTH" type="int">
           <ipxact:name>ADDRESS_WIDTH</ipxact:name>
           <ipxact:displayName>Address Width (total addressable)</ipxact:displayName>
-          <ipxact:value>34</ipxact:value>
+          <ipxact:value>35</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="BURST_SIZE" type="int">
           <ipxact:name>BURST_SIZE</ipxact:name>
@@ -2665,17 +2665,17 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="SYNCHRONIZE_RESET" type="int">
           <ipxact:name>SYNCHRONIZE_RESET</ipxact:name>
           <ipxact:displayName>SYNCHRONIZE_RESET</ipxact:displayName>
-          <ipxact:value>1</ipxact:value>
+          <ipxact:value>0</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE_FAMILY" type="string">
           <ipxact:name>AUTO_DEVICE_FAMILY</ipxact:name>
           <ipxact:displayName>Auto DEVICE_FAMILY</ipxact:displayName>
-          <ipxact:value>Agilex</ipxact:value>
+          <ipxact:value>Stratix 10</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE" type="string">
           <ipxact:name>AUTO_DEVICE</ipxact:name>
           <ipxact:displayName>Auto DEVICE</ipxact:displayName>
-          <ipxact:value>AGFB014R24A2E2V</ipxact:value>
+          <ipxact:value>1SX280HN2F43E2VG</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE_SPEEDGRADE" type="string">
           <ipxact:name>AUTO_DEVICE_SPEEDGRADE</ipxact:name>
@@ -2686,15 +2686,20 @@ https://fpgasoftware.intel.com/eula.-->
     </altera:altera_module_parameters>
     <altera:altera_system_parameters>
       <ipxact:parameters>
+        <ipxact:parameter parameterId="board" type="string">
+          <ipxact:name>board</ipxact:name>
+          <ipxact:displayName>Board</ipxact:displayName>
+          <ipxact:value>default</ipxact:value>
+        </ipxact:parameter>
         <ipxact:parameter parameterId="device" type="string">
           <ipxact:name>device</ipxact:name>
           <ipxact:displayName>Device</ipxact:displayName>
-          <ipxact:value>AGFB014R24A2E2V</ipxact:value>
+          <ipxact:value>1SX280HN2F43E2VG</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="deviceFamily" type="string">
           <ipxact:name>deviceFamily</ipxact:name>
           <ipxact:displayName>Device family</ipxact:displayName>
-          <ipxact:value>Agilex</ipxact:value>
+          <ipxact:value>Stratix 10</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="deviceSpeedGrade" type="string">
           <ipxact:name>deviceSpeedGrade</ipxact:name>
@@ -2715,17 +2720,12 @@ https://fpgasoftware.intel.com/eula.-->
    {
       datum _originalDeviceFamily
       {
-         value = "Agilex";
+         value = "Stratix 10";
          type = "String";
       }
    }
-   element acl_memory_bank_divider_1
+   element memory_bank_divider
    {
-      datum _originalVersion
-      {
-         value = "1.0";
-         type = "String";
-      }
    }
 }
 </ipxact:value>
@@ -2824,7 +2824,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;acl_bsp_snoop_data&lt;/name&gt;
                     &lt;role&gt;data&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;36&lt;/width&gt;
+                    &lt;width&gt;37&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -2867,7 +2867,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;dataBitsPerSymbol&lt;/key&gt;
-                        &lt;value&gt;36&lt;/value&gt;
+                        &lt;value&gt;37&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;emptyWithinPacket&lt;/key&gt;
@@ -3066,7 +3066,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;s_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Input&lt;/direction&gt;
-                    &lt;width&gt;28&lt;/width&gt;
+                    &lt;width&gt;29&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -3104,7 +3104,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;addressSpan&lt;/key&gt;
-                        &lt;value&gt;17179869184&lt;/value&gt;
+                        &lt;value&gt;34359738368&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;addressUnits&lt;/key&gt;
@@ -3347,7 +3347,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;bank1_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;32&lt;/width&gt;
+                    &lt;width&gt;33&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -3586,7 +3586,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;bank2_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;32&lt;/width&gt;
+                    &lt;width&gt;33&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -3825,7 +3825,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;bank3_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;32&lt;/width&gt;
+                    &lt;width&gt;33&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -4064,7 +4064,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;bank4_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;32&lt;/width&gt;
+                    &lt;width&gt;33&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -4265,11 +4265,11 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='s' start='0x0' end='0x800000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
-                        &lt;value&gt;34&lt;/value&gt;
+                        &lt;value&gt;35&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;MAX_SLAVE_DATA_WIDTH&lt;/key&gt;
@@ -4281,18 +4281,23 @@ https://fpgasoftware.intel.com/eula.-->
     &lt;/connPtSystemInfos&gt;
 &lt;/systemInfosDefinition&gt;</ipxact:value>
         </ipxact:parameter>
+        <ipxact:parameter parameterId="pinAssignmentListDefinition" type="string">
+          <ipxact:name>pinAssignmentListDefinition</ipxact:name>
+          <ipxact:displayName>pinAssignmentListDefinition</ipxact:displayName>
+          <ipxact:value>&lt;pinAssignmentListDefinition/&gt;</ipxact:value>
+        </ipxact:parameter>
       </ipxact:parameters>
     </altera:altera_system_parameters>
     <altera:altera_interface_boundary>
-      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="acl_memory_bank_divider_1.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end">
+      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="memory_bank_divider.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end">
         <altera:port_mapping altera:name="acl_bsp_memorg_host_mode" altera:internal="acl_bsp_memorg_host_mode"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="acl_bsp_snoop" altera:internal="acl_memory_bank_divider_1.acl_bsp_snoop" altera:type="avalon_streaming" altera:dir="start">
+      <altera:interface_mapping altera:name="acl_bsp_snoop" altera:internal="memory_bank_divider.acl_bsp_snoop" altera:type="avalon_streaming" altera:dir="start">
         <altera:port_mapping altera:name="acl_bsp_snoop_data" altera:internal="acl_bsp_snoop_data"></altera:port_mapping>
         <altera:port_mapping altera:name="acl_bsp_snoop_ready" altera:internal="acl_bsp_snoop_ready"></altera:port_mapping>
         <altera:port_mapping altera:name="acl_bsp_snoop_valid" altera:internal="acl_bsp_snoop_valid"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank1" altera:internal="acl_memory_bank_divider_1.bank1" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank1" altera:internal="memory_bank_divider.bank1" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank1_address" altera:internal="bank1_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank1_burstcount" altera:internal="bank1_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank1_byteenable" altera:internal="bank1_byteenable"></altera:port_mapping>
@@ -4304,7 +4309,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank1_write" altera:internal="bank1_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank1_writedata" altera:internal="bank1_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank2" altera:internal="acl_memory_bank_divider_1.bank2" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank2" altera:internal="memory_bank_divider.bank2" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank2_address" altera:internal="bank2_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank2_burstcount" altera:internal="bank2_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank2_byteenable" altera:internal="bank2_byteenable"></altera:port_mapping>
@@ -4316,7 +4321,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank2_write" altera:internal="bank2_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank2_writedata" altera:internal="bank2_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank3" altera:internal="acl_memory_bank_divider_1.bank3" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank3" altera:internal="memory_bank_divider.bank3" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank3_address" altera:internal="bank3_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank3_burstcount" altera:internal="bank3_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank3_byteenable" altera:internal="bank3_byteenable"></altera:port_mapping>
@@ -4328,7 +4333,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank3_write" altera:internal="bank3_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank3_writedata" altera:internal="bank3_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank4" altera:internal="acl_memory_bank_divider_1.bank4" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank4" altera:internal="memory_bank_divider.bank4" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank4_address" altera:internal="bank4_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank4_burstcount" altera:internal="bank4_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank4_byteenable" altera:internal="bank4_byteenable"></altera:port_mapping>
@@ -4340,19 +4345,19 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank4_write" altera:internal="bank4_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank4_writedata" altera:internal="bank4_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="clk" altera:internal="acl_memory_bank_divider_1.clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="clk" altera:internal="memory_bank_divider.clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="clk_clk" altera:internal="clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_clk" altera:internal="acl_memory_bank_divider_1.kernel_clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_clk" altera:internal="memory_bank_divider.kernel_clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="kernel_clk_clk" altera:internal="kernel_clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_reset" altera:internal="acl_memory_bank_divider_1.kernel_reset" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_reset" altera:internal="memory_bank_divider.kernel_reset" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="kernel_reset_reset_n" altera:internal="kernel_reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="reset" altera:internal="acl_memory_bank_divider_1.reset" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="reset" altera:internal="memory_bank_divider.reset" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="reset_reset_n" altera:internal="reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="s" altera:internal="acl_memory_bank_divider_1.s" altera:type="avalon" altera:dir="end">
+      <altera:interface_mapping altera:name="s" altera:internal="memory_bank_divider.s" altera:type="avalon" altera:dir="end">
         <altera:port_mapping altera:name="s_address" altera:internal="s_address"></altera:port_mapping>
         <altera:port_mapping altera:name="s_burstcount" altera:internal="s_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="s_byteenable" altera:internal="s_byteenable"></altera:port_mapping>

--- a/d5005/hardware/ofs_d5005_usm/build/ip/kernel_interface_hw.tcl
+++ b/d5005/hardware/ofs_d5005_usm/build/ip/kernel_interface_hw.tcl
@@ -17,14 +17,14 @@
 package require -exact qsys 17.0
 
 # module properties
-set_module_property NAME {kernel_interface_agilex}
-set_module_property DISPLAY_NAME {OpenCL Kernel Interface for Agilex}
+set_module_property NAME {kernel_interface}
+set_module_property DISPLAY_NAME {oneAPI Kernel Interface}
 
 # default module properties
-set_module_property VERSION {17.1}
-set_module_property GROUP {OpenCL BSP Components}
-set_module_property DESCRIPTION {Connects the OpenCL host to the FPGA kernel}
-set_module_property AUTHOR {author}
+set_module_property VERSION {23.2}
+set_module_property GROUP {oneAPI ASP Components}
+set_module_property DESCRIPTION {Connects the oneAPI host to the FPGA kernel}
+set_module_property AUTHOR {OFS}
 
 set_module_property COMPOSITION_CALLBACK compose
 set_module_property opaque_address_map false

--- a/d5005/hardware/ofs_d5005_usm/build/ip/memory_bank_divider_hw.tcl
+++ b/d5005/hardware/ofs_d5005_usm/build/ip/memory_bank_divider_hw.tcl
@@ -1,14 +1,14 @@
 package require -exact qsys 17.0
 
 # module properties
-set_module_property NAME {acl_memory_bank_divider}
-set_module_property DISPLAY_NAME {OpenCL Memory Bank Divider}
+set_module_property NAME {memory_bank_divider}
+set_module_property DISPLAY_NAME {oneAPI Memory Bank Divider}
 
 # default module properties
-set_module_property VERSION {21.3}
-set_module_property GROUP {OpenCL BSP Components}
-set_module_property DESCRIPTION {default description}
-set_module_property AUTHOR {author}
+set_module_property VERSION {23.2}
+set_module_property GROUP {oneAPI ASP Components}
+set_module_property DESCRIPTION {Handles multiple global memory banks}
+set_module_property AUTHOR {OFS}
 
 # Set the name of the procedure to manipulate parameters
 set_module_property COMPOSITION_CALLBACK compose

--- a/n6001/hardware/ofs_n6001/build/board.qsys
+++ b/n6001/hardware/ofs_n6001/build/board.qsys
@@ -256,7 +256,7 @@ https://fpgasoftware.intel.com/eula.-->
          type = "int";
       }
    }
-   element kernel_interface_agilex_0
+   element kernel_interface
    {
       datum _sortIndex
       {
@@ -264,7 +264,7 @@ https://fpgasoftware.intel.com/eula.-->
          type = "int";
       }
    }
-   element kernel_interface_agilex_0.ctrl
+   element kernel_interface.ctrl
    {
       datum baseAddress
       {
@@ -369,7 +369,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='board_afu_id_avmm_slave_0.afu_cfg_slave' start='0x0' end='0x40' datawidth='64' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Read_Slave' start='0x100' end='0x104' datawidth='32' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Mask_Slave' start='0x108' end='0x10C' datawidth='32' /&amp;gt;&amp;lt;slave name='kernel_interface_agilex_0.ctrl' start='0x4000' end='0x8000' datawidth='32' /&amp;gt;&amp;lt;slave name='pipe_stage_dma_csr.s0' start='0x20000' end='0x20800' datawidth='64' /&amp;gt;&amp;lt;slave name='ddr_board.null_dfh_id' start='0x20800' end='0x20840' datawidth='64' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='board_afu_id_avmm_slave_0.afu_cfg_slave' start='0x0' end='0x40' datawidth='64' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Read_Slave' start='0x100' end='0x104' datawidth='32' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Mask_Slave' start='0x108' end='0x10C' datawidth='32' /&amp;gt;&amp;lt;slave name='kernel_interface.ctrl' start='0x4000' end='0x8000' datawidth='32' /&amp;gt;&amp;lt;slave name='pipe_stage_dma_csr.s0' start='0x20000' end='0x20800' datawidth='64' /&amp;gt;&amp;lt;slave name='ddr_board.null_dfh_id' start='0x20800' end='0x20840' datawidth='64' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
@@ -10861,7 +10861,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:module altera:enabled="true" altera:auto_export="false">
         <altera:entity_info>
           <ipxact:vendor>Altera Corporation</ipxact:vendor>
-          <ipxact:library>kernel_interface_agilex_0</ipxact:library>
+          <ipxact:library>kernel_interface</ipxact:library>
           <ipxact:name>altera_generic_component</ipxact:name>
           <ipxact:version>1.0</ipxact:version>
         </altera:entity_info>
@@ -11587,7 +11587,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;bridgesToReceiver&lt;/key&gt;
-                            &lt;value&gt;kernel_interface_agilex_0.kernel_irq_from_kernel&lt;/value&gt;
+                            &lt;value&gt;kernel_interface.kernel_irq_from_kernel&lt;/value&gt;
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;irqScheme&lt;/key&gt;
@@ -11742,9 +11742,9 @@ https://fpgasoftware.intel.com/eula.-->
         &lt;/interfaces&gt;
     &lt;/boundary&gt;
     &lt;originalModuleInfo&gt;
-        &lt;className&gt;kernel_interface_agilex&lt;/className&gt;
-        &lt;version&gt;17.1&lt;/version&gt;
-        &lt;displayName&gt;OpenCL Kernel Interface for Agilex&lt;/displayName&gt;
+        &lt;className&gt;kernel_interface&lt;/className&gt;
+        &lt;version&gt;23.2&lt;/version&gt;
+        &lt;displayName&gt;oneAPI Kernel Interface&lt;/displayName&gt;
     &lt;/originalModuleInfo&gt;
     &lt;systemInfoParameterDescriptors&gt;
         &lt;descriptors&gt;
@@ -12510,7 +12510,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;bridgesToReceiver&lt;/key&gt;
-                        &lt;value&gt;kernel_interface_agilex_0.kernel_irq_from_kernel&lt;/value&gt;
+                        &lt;value&gt;kernel_interface.kernel_irq_from_kernel&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;irqScheme&lt;/key&gt;
@@ -12669,29 +12669,29 @@ https://fpgasoftware.intel.com/eula.-->
               <ipxact:name>generationInfoDefinition</ipxact:name>
               <ipxact:displayName>Generation Behavior</ipxact:displayName>
               <ipxact:value>&lt;generationInfoDefinition&gt;
-    &lt;hdlLibraryName&gt;board_kernel_interface_agilex_0&lt;/hdlLibraryName&gt;
+    &lt;hdlLibraryName&gt;board_kernel_interface&lt;/hdlLibraryName&gt;
     &lt;fileSets&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_agilex_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_agilex_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;QUARTUS_SYNTH&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_agilex_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_agilex_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VERILOG&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_agilex_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_agilex_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_agilex_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_agilex_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
@@ -12711,7 +12711,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:parameter parameterId="logicalView" type="string">
               <ipxact:name>logicalView</ipxact:name>
               <ipxact:displayName>Logical view</ipxact:displayName>
-              <ipxact:value>ip/board/board_kernel_interface_agilex_0.ip</ipxact:value>
+              <ipxact:value>ip/board/board_kernel_interface.ip</ipxact:value>
             </ipxact:parameter>
             <ipxact:parameter parameterId="moduleAssignmentDefinition" type="string">
               <ipxact:name>moduleAssignmentDefinition</ipxact:name>
@@ -15480,7 +15480,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:module>
     </altera:modules>
     <altera:connections>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="kernel_interface_agilex_0.kernel_cra" altera:end="board_kernel_cra_pipe.s0">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="kernel_interface.kernel_cra" altera:end="board_kernel_cra_pipe.s0">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15564,7 +15564,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="pipe_stage_host_ctrl.m0" altera:end="kernel_interface_agilex_0.ctrl">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="pipe_stage_host_ctrl.m0" altera:end="kernel_interface.ctrl">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x4000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15633,7 +15633,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="board_kernel_cra_reset.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="board_kernel_cra_pipe.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="pipe_stage_dma_csr.clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="kernel_interface_agilex_0.clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="kernel_interface.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="kernel_clk_export.clk_in"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="board_afu_id_avmm_slave_0.clock"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="emif_ddr4a_clk.out_clk" altera:end="ddr_board.ddr_clk_a"></altera:connection>
@@ -15642,19 +15642,19 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="emif_ddr4d_clk.out_clk" altera:end="ddr_board.ddr_clk_d"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="ddr_board.host_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="ddr_board.kernel_clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="kernel_interface_agilex_0.kernel_clk"></altera:connection>
-      <altera:connection altera:kind="conduit" altera:version="23.1" altera:start="kernel_interface_agilex_0.acl_bsp_memorg_host0x018" altera:end="ddr_board.acl_bsp_memorg_host">
+      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="kernel_interface.kernel_clk"></altera:connection>
+      <altera:connection altera:kind="conduit" altera:version="23.1" altera:start="kernel_interface.acl_bsp_memorg_host0x018" altera:end="ddr_board.acl_bsp_memorg_host">
         <altera:connection_parameter altera:parameter_name="endPort" altera:parameter_value=""></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="endPortLSB" altera:parameter_value="0"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="startPort" altera:parameter_value=""></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="startPortLSB" altera:parameter_value="0"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="width" altera:parameter_value="0"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="interrupt" altera:version="23.1" altera:start="board_irq_ctrl_0.interrupt_receiver" altera:end="kernel_interface_agilex_0.kernel_irq_to_host">
+      <altera:connection altera:kind="interrupt" altera:version="23.1" altera:start="board_irq_ctrl_0.interrupt_receiver" altera:end="kernel_interface.kernel_irq_to_host">
         <altera:connection_parameter altera:parameter_name="irqNumber" altera:parameter_value="0"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_interface_agilex_0.kernel_reset" altera:end="kernel_clk_export.clk_in_reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_interface_agilex_0.kernel_reset" altera:end="ddr_board.kernel_reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_interface.kernel_reset" altera:end="kernel_clk_export.clk_in_reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_interface.kernel_reset" altera:end="ddr_board.kernel_reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="board_irq_ctrl_0.Resetn"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="ddr_board.global_reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="board_kernel_cra_reset.in_reset"></altera:connection>
@@ -15662,8 +15662,8 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="pipe_stage_host_ctrl.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="board_kernel_cra_reset.out_reset" altera:end="board_kernel_cra_pipe.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="pipe_stage_dma_csr.reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="kernel_interface_agilex_0.reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="kernel_interface_agilex_0.sw_reset_in"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="kernel_interface.reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="kernel_interface.sw_reset_in"></altera:connection>
     </altera:connections>
     <altera:interconnect_requirements></altera:interconnect_requirements>
     <altera:wire_level_connections></altera:wire_level_connections>
@@ -15693,7 +15693,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:interface_mapping altera:name="kernel_ddr4b" altera:internal="ddr_board.kernel_ddr4b" altera:type="avalon" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="kernel_ddr4c" altera:internal="ddr_board.kernel_ddr4c" altera:type="avalon" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="kernel_ddr4d" altera:internal="ddr_board.kernel_ddr4d" altera:type="avalon" altera:dir="end"></altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_irq" altera:internal="kernel_interface_agilex_0.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start"></altera:interface_mapping>
+      <altera:interface_mapping altera:name="kernel_irq" altera:internal="kernel_interface.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start"></altera:interface_mapping>
       <altera:interface_mapping altera:name="kernel_reset" altera:internal="kernel_clk_export.clk_reset" altera:type="reset" altera:dir="start"></altera:interface_mapping>
     </altera:altera_interface_boundary>
     <ipxact:components>
@@ -15713,10 +15713,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>kernel_interface_agilex_0.kernel_cra</ipxact:name>
+            <ipxact:name>kernel_interface.kernel_cra</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="kernel_interface_agilex_0.kernel_cra">
+              <ipxact:addressSpaceRef addressSpaceRef="kernel_interface.kernel_cra">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -15739,7 +15739,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>kernel_interface_agilex_0.ctrl</ipxact:name>
+            <ipxact:name>kernel_interface.ctrl</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -15782,7 +15782,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:busInterfaces>
         <ipxact:addressSpaces>
           <ipxact:addressSpace>
-            <ipxact:name>kernel_interface_agilex_0.kernel_cra</ipxact:name>
+            <ipxact:name>kernel_interface.kernel_cra</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>board_kernel_cra_pipe.s0</ipxact:name>
@@ -15810,7 +15810,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:range>0x0000_0040</ipxact:range>
               </ipxact:segment>
               <ipxact:segment>
-                <ipxact:name>kernel_interface_agilex_0.ctrl</ipxact:name>
+                <ipxact:name>kernel_interface.ctrl</ipxact:name>
                 <ipxact:addressOffset>0x0000_4000</ipxact:addressOffset>
                 <ipxact:range>0x0000_4000</ipxact:range>
               </ipxact:segment>

--- a/n6001/hardware/ofs_n6001/build/ddr_board.qsys
+++ b/n6001/hardware/ofs_n6001/build/ddr_board.qsys
@@ -51,7 +51,7 @@ https://fpgasoftware.intel.com/eula.-->
          type = "int";
       }
    }
-   element acl_memory_bank_divider_0
+   element memory_bank_divider
    {
       datum _sortIndex
       {
@@ -416,7 +416,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='acl_memory_bank_divider_0.s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='memory_bank_divider.s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
@@ -437,7 +437,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='acl_memory_bank_divider_0.s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='memory_bank_divider.s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
@@ -2092,7 +2092,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:module altera:enabled="true" altera:auto_export="false">
         <altera:entity_info>
           <ipxact:vendor>Altera Corporation</ipxact:vendor>
-          <ipxact:library>acl_memory_bank_divider_0</ipxact:library>
+          <ipxact:library>memory_bank_divider</ipxact:library>
           <ipxact:name>altera_generic_component</ipxact:name>
           <ipxact:version>1.0</ipxact:version>
         </altera:entity_info>
@@ -3632,9 +3632,9 @@ https://fpgasoftware.intel.com/eula.-->
         &lt;/interfaces&gt;
     &lt;/boundary&gt;
     &lt;originalModuleInfo&gt;
-        &lt;className&gt;acl_memory_bank_divider&lt;/className&gt;
-        &lt;version&gt;21.3&lt;/version&gt;
-        &lt;displayName&gt;OpenCL Memory Bank Divider&lt;/displayName&gt;
+        &lt;className&gt;memory_bank_divider&lt;/className&gt;
+        &lt;version&gt;23.2&lt;/version&gt;
+        &lt;displayName&gt;oneAPI Memory Bank Divider&lt;/displayName&gt;
     &lt;/originalModuleInfo&gt;
     &lt;systemInfoParameterDescriptors&gt;
         &lt;descriptors&gt;
@@ -5206,29 +5206,29 @@ https://fpgasoftware.intel.com/eula.-->
               <ipxact:name>generationInfoDefinition</ipxact:name>
               <ipxact:displayName>Generation Behavior</ipxact:displayName>
               <ipxact:value>&lt;generationInfoDefinition&gt;
-    &lt;hdlLibraryName&gt;ddr_board_acl_memory_bank_divider_1&lt;/hdlLibraryName&gt;
+    &lt;hdlLibraryName&gt;ddr_board_memory_bank_divider&lt;/hdlLibraryName&gt;
     &lt;fileSets&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;QUARTUS_SYNTH&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VERILOG&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
@@ -5248,7 +5248,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:parameter parameterId="logicalView" type="string">
               <ipxact:name>logicalView</ipxact:name>
               <ipxact:displayName>Logical view</ipxact:displayName>
-              <ipxact:value>ip/ddr_board/ddr_board_acl_memory_bank_divider_1.ip</ipxact:value>
+              <ipxact:value>ip/ddr_board/ddr_board_memory_bank_divider.ip</ipxact:value>
             </ipxact:parameter>
             <ipxact:parameter parameterId="moduleAssignmentDefinition" type="string">
               <ipxact:name>moduleAssignmentDefinition</ipxact:name>
@@ -16491,7 +16491,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:module>
     </altera:modules>
     <altera:connections>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_memory_bank_divider_0.bank1" altera:end="ddr_channel_a.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="memory_bank_divider.bank1" altera:end="ddr_channel_a.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16512,7 +16512,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_memory_bank_divider_0.bank2" altera:end="ddr_channel_b.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="memory_bank_divider.bank2" altera:end="ddr_channel_b.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16533,7 +16533,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_memory_bank_divider_0.bank3" altera:end="ddr_channel_c.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="memory_bank_divider.bank3" altera:end="ddr_channel_c.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16554,7 +16554,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_memory_bank_divider_0.bank4" altera:end="ddr_channel_d.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="memory_bank_divider.bank4" altera:end="ddr_channel_d.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16575,7 +16575,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_avalon_mm_bridge_s10_1.m0" altera:end="acl_memory_bank_divider_0.s">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_avalon_mm_bridge_s10_1.m0" altera:end="memory_bank_divider.s">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16640,7 +16640,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="kernel_reset.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="global_reset.clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="acl_memory_bank_divider_0.clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="memory_bank_divider.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="dma_localmem_rd_pipe.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="dma_localmem_wr_pipe.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="acl_avalon_mm_bridge_s10_1.clk"></altera:connection>
@@ -16653,13 +16653,13 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="ddr_channel_b.host_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="ddr_channel_c.host_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="ddr_channel_d.host_clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="acl_memory_bank_divider_0.kernel_clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="memory_bank_divider.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_a.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_b.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_c.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_d.kernel_clk"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_reset.out_reset" altera:end="acl_memory_bank_divider_0.kernel_reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="acl_memory_bank_divider_0.reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_reset.out_reset" altera:end="memory_bank_divider.kernel_reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="memory_bank_divider.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="null_dfh_inst.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="dma_localmem_wr_pipe.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="dma_localmem_rd_pipe.reset"></altera:connection>
@@ -16675,7 +16675,7 @@ https://fpgasoftware.intel.com/eula.-->
     <altera:hdl_parameter_mappings></altera:hdl_parameter_mappings>
     <altera:preserved_ports_for_debug></altera:preserved_ports_for_debug>
     <altera:altera_interface_boundary>
-      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="acl_memory_bank_divider_0.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end"></altera:interface_mapping>
+      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="memory_bank_divider.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="ddr_clk_a" altera:internal="ddr_clk_a.in_clk" altera:type="clock" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="ddr_clk_b" altera:internal="ddr_clk_b.in_clk" altera:type="clock" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="ddr_clk_c" altera:internal="ddr_clk_c.in_clk" altera:type="clock" altera:dir="end"></altera:interface_mapping>
@@ -16708,10 +16708,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank1</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank1</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank1">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank1">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -16721,10 +16721,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank2</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank2</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank2">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank2">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -16734,10 +16734,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank3</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank3</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank3">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank3">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -16747,10 +16747,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank4</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank4</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank4">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank4">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -16760,7 +16760,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+            <ipxact:name>memory_bank_divider.s</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -16777,7 +16777,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+            <ipxact:name>memory_bank_divider.s</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -16790,7 +16790,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:master>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+            <ipxact:name>memory_bank_divider.s</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -16825,7 +16825,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:busInterfaces>
         <ipxact:addressSpaces>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank1</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank1</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_a.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -16835,7 +16835,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank2</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank2</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_b.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -16845,7 +16845,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank3</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank3</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_c.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -16855,7 +16855,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank4</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank4</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_d.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -16873,7 +16873,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>
               <ipxact:segment>
-                <ipxact:name>acl_memory_bank_divider_0.s via acl_avalon_mm_bridge_s10_1</ipxact:name>
+                <ipxact:name>memory_bank_divider.s via acl_avalon_mm_bridge_s10_1</ipxact:name>
                 <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>
@@ -16888,7 +16888,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>
               <ipxact:segment>
-                <ipxact:name>acl_memory_bank_divider_0.s via acl_avalon_mm_bridge_s10_1</ipxact:name>
+                <ipxact:name>memory_bank_divider.s via acl_avalon_mm_bridge_s10_1</ipxact:name>
                 <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>
@@ -16898,7 +16898,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:name>acl_avalon_mm_bridge_s10_1.m0</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
-                <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+                <ipxact:name>memory_bank_divider.s</ipxact:name>
                 <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>

--- a/n6001/hardware/ofs_n6001/build/hw_iface.iipx
+++ b/n6001/hardware/ofs_n6001/build/hw_iface.iipx
@@ -194,94 +194,6 @@
   <tag2 key="TCL_PACKAGE_VERSION" value="10.0" />
  </component>
  <component
-   name="acl_kernel_clk"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/iface/acl_kernel_clk.qsys"
-   displayName="OpenCL Kernel Clock Generator"
-   version="1.0"
-   description="Generates the kernel clocks for ACL"
-   tags="INTERNAL_COMPONENT=false"
-   categories="OpenCL BSP Components"
-   factory="QsysFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPONENT_HIDE_FROM_QUARTUS" value="true" />
- </component>
- <component
-   name="acl_kernel_clk_a10"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_clk_a10_hw.tcl"
-   displayName="OpenCL A10 Kernel Clock Generator"
-   version="16.1"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="comp" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="16.1" />
- </component>
- <component
-   name="acl_kernel_clk_noreconfig"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/iface/acl_kernel_clk_noreconfig.qsys"
-   displayName="OpenCL Kernel Clock Generator - no Dynamic Reconfig"
-   version="1.0"
-   description="Generates the kernel clocks for ACL"
-   tags="INTERNAL_COMPONENT=false"
-   categories="OpenCL BSP Components"
-   factory="QsysFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPONENT_HIDE_FROM_QUARTUS" value="true" />
- </component>
- <component
-   name="acl_kernel_clk_s10"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_clk_s10_hw.tcl"
-   displayName="OpenCL S10 Kernel Clock Generator"
-   version="17.0"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="comp" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="16.1" />
- </component>
- <component
-   name="acl_kernel_clk_s10_reconfig"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_clk_s10_reconfig_hw.tcl"
-   displayName="OpenCL S10 reconfigurable kernel clock generator"
-   version="17.0"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="comp" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="16.1" />
- </component>
- <component
-   name="acl_kernel_interface_soc"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/iface/acl_kernel_interface_soc.qsys"
-   displayName="acl_kernel_interface_soc"
-   version="1.0"
-   description="ACL Kernel Interface"
-   tags=""
-   categories="ACL BSP Components"
-   factory="QsysFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPONENT_HIDE_FROM_QUARTUS" value="true" />
- </component>
- <component
-   name="acl_memory_bank_divider"
-   file="./ip/acl_memory_bank_divider_hw.tcl"
-   displayName="OpenCL Memory Bank Divider"
-   version="21.3"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="compose" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="17.0" />
- </component>
- <component
    name="acl_snoop_adapter"
    file="${INTELFPGAOCLSDKROOT}/ip/board/export/snoop_adapter_hw.tcl"
    displayName="Avalon Snoop Adapter"
@@ -709,36 +621,6 @@
   <tag2 key="OPAQUE_ADDRESS_MAP" value="true" />
   <tag2 key="SUPPORTED_FILE_SETS" value="QUARTUS_SYNTH,SIM_VERILOG" />
   <tag2 key="TCL_PACKAGE_VERSION" value="12.1" />
- </component>
- <component
-   name="kernel_interface"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_interface_hw.tcl"
-   displayName="OpenCL Kernel Interface"
-   version="15.1"
-   description="Connects the OpenCL host to the FPGA kernel"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="compose" />
-  <tag2 key="OPAQUE_ADDRESS_MAP" value="false" />
-  <tag2 key="PARAMETER_UPGRADE_CALLBACK" value="ip_upgrade" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="13.1" />
- </component>
- <component
-   name="kernel_interface_s10"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_interface_s10_hw.tcl"
-   displayName="OpenCL Kernel Interface for S10"
-   version="17.1"
-   description="Connects the OpenCL host to the FPGA kernel"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="compose" />
-  <tag2 key="OPAQUE_ADDRESS_MAP" value="false" />
-  <tag2 key="PARAMETER_UPGRADE_CALLBACK" value="ip_upgrade" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="17.0" />
  </component>
  <component
    name="mem_org_mode"

--- a/n6001/hardware/ofs_n6001/build/ip/board/board_kernel_interface.ip
+++ b/n6001/hardware/ofs_n6001/build/ip/board/board_kernel_interface.ip
@@ -14,9 +14,9 @@ refer to the applicable agreement for further details, at
 https://fpgasoftware.intel.com/eula.-->
 <ipxact:component xmlns:altera="http://www.altera.com/XMLSchema/IPXact2014/extensions" xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2014">
   <ipxact:vendor>author</ipxact:vendor>
-  <ipxact:library>board_kernel_interface_agilex_0</ipxact:library>
-  <ipxact:name>kernel_interface_agilex_0</ipxact:name>
-  <ipxact:version>17.1</ipxact:version>
+  <ipxact:library>board_kernel_interface</ipxact:library>
+  <ipxact:name>kernel_interface</ipxact:name>
+  <ipxact:version>23.2</ipxact:version>
   <ipxact:busInterfaces>
     <ipxact:busInterface>
       <ipxact:name>kernel_cra</ipxact:name>
@@ -819,7 +819,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="bridgesToReceiver" type="string">
           <ipxact:name>bridgesToReceiver</ipxact:name>
           <ipxact:displayName>Bridges to receiver</ipxact:displayName>
-          <ipxact:value>board_kernel_interface_agilex_0.kernel_irq_from_kernel</ipxact:value>
+          <ipxact:value>board_kernel_interface.kernel_irq_from_kernel</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="irqScheme" type="string">
           <ipxact:name>irqScheme</ipxact:name>
@@ -993,7 +993,7 @@ https://fpgasoftware.intel.com/eula.-->
     <ipxact:instantiations>
       <ipxact:componentInstantiation>
         <ipxact:name>QUARTUS_SYNTH</ipxact:name>
-        <ipxact:moduleName>kernel_interface_agilex</ipxact:moduleName>
+        <ipxact:moduleName>kernel_interface</ipxact:moduleName>
         <ipxact:fileSetRef>
           <ipxact:localName>QUARTUS_SYNTH</ipxact:localName>
         </ipxact:fileSetRef>
@@ -1407,8 +1407,8 @@ https://fpgasoftware.intel.com/eula.-->
   <ipxact:vendorExtensions>
     <altera:entity_info>
       <ipxact:vendor>author</ipxact:vendor>
-      <ipxact:library>board_kernel_interface_agilex_0</ipxact:library>
-      <ipxact:name>kernel_interface_agilex</ipxact:name>
+      <ipxact:library>board_kernel_interface</ipxact:library>
+      <ipxact:name>kernel_interface</ipxact:name>
       <ipxact:version>17.1</ipxact:version>
     </altera:entity_info>
     <altera:altera_module_parameters>
@@ -2195,7 +2195,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;bridgesToReceiver&lt;/key&gt;
-                        &lt;value&gt;board_kernel_interface_agilex_0.kernel_irq_from_kernel&lt;/value&gt;
+                        &lt;value&gt;board_kernel_interface.kernel_irq_from_kernel&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;irqScheme&lt;/key&gt;
@@ -2382,13 +2382,13 @@ https://fpgasoftware.intel.com/eula.-->
       </ipxact:parameters>
     </altera:altera_system_parameters>
     <altera:altera_interface_boundary>
-      <altera:interface_mapping altera:name="acl_bsp_memorg_host0x018" altera:internal="kernel_interface_agilex_0.acl_bsp_memorg_host0x018" altera:type="conduit" altera:dir="end">
+      <altera:interface_mapping altera:name="acl_bsp_memorg_host0x018" altera:internal="kernel_interface.acl_bsp_memorg_host0x018" altera:type="conduit" altera:dir="end">
         <altera:port_mapping altera:name="acl_bsp_memorg_host0x018_mode" altera:internal="acl_bsp_memorg_host0x018_mode"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="clk" altera:internal="kernel_interface_agilex_0.clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="clk" altera:internal="kernel_interface.clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="clk_clk" altera:internal="clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="ctrl" altera:internal="kernel_interface_agilex_0.ctrl" altera:type="avalon" altera:dir="end">
+      <altera:interface_mapping altera:name="ctrl" altera:internal="kernel_interface.ctrl" altera:type="avalon" altera:dir="end">
         <altera:port_mapping altera:name="ctrl_address" altera:internal="ctrl_address"></altera:port_mapping>
         <altera:port_mapping altera:name="ctrl_burstcount" altera:internal="ctrl_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="ctrl_byteenable" altera:internal="ctrl_byteenable"></altera:port_mapping>
@@ -2400,10 +2400,10 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="ctrl_write" altera:internal="ctrl_write"></altera:port_mapping>
         <altera:port_mapping altera:name="ctrl_writedata" altera:internal="ctrl_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_clk" altera:internal="kernel_interface_agilex_0.kernel_clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_clk" altera:internal="kernel_interface.kernel_clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="kernel_clk_clk" altera:internal="kernel_clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_cra" altera:internal="kernel_interface_agilex_0.kernel_cra" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="kernel_cra" altera:internal="kernel_interface.kernel_cra" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="kernel_cra_address" altera:internal="kernel_cra_address"></altera:port_mapping>
         <altera:port_mapping altera:name="kernel_cra_burstcount" altera:internal="kernel_cra_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="kernel_cra_byteenable" altera:internal="kernel_cra_byteenable"></altera:port_mapping>
@@ -2415,22 +2415,22 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="kernel_cra_write" altera:internal="kernel_cra_write"></altera:port_mapping>
         <altera:port_mapping altera:name="kernel_cra_writedata" altera:internal="kernel_cra_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_irq_from_kernel" altera:internal="kernel_interface_agilex_0.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start">
+      <altera:interface_mapping altera:name="kernel_irq_from_kernel" altera:internal="kernel_interface.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start">
         <altera:port_mapping altera:name="kernel_irq_from_kernel_irq" altera:internal="kernel_irq_from_kernel_irq"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_irq_to_host" altera:internal="kernel_interface_agilex_0.kernel_irq_to_host" altera:type="interrupt" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_irq_to_host" altera:internal="kernel_interface.kernel_irq_to_host" altera:type="interrupt" altera:dir="end">
         <altera:port_mapping altera:name="kernel_irq_to_host_irq" altera:internal="kernel_irq_to_host_irq"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_reset" altera:internal="kernel_interface_agilex_0.kernel_reset" altera:type="reset" altera:dir="start">
+      <altera:interface_mapping altera:name="kernel_reset" altera:internal="kernel_interface.kernel_reset" altera:type="reset" altera:dir="start">
         <altera:port_mapping altera:name="kernel_reset_reset_n" altera:internal="kernel_reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="reset" altera:internal="kernel_interface_agilex_0.reset" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="reset" altera:internal="kernel_interface.reset" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="reset_reset_n" altera:internal="reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="sw_reset_export" altera:internal="kernel_interface_agilex_0.sw_reset_export" altera:type="reset" altera:dir="start">
+      <altera:interface_mapping altera:name="sw_reset_export" altera:internal="kernel_interface.sw_reset_export" altera:type="reset" altera:dir="start">
         <altera:port_mapping altera:name="sw_reset_export_reset_n" altera:internal="sw_reset_export_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="sw_reset_in" altera:internal="kernel_interface_agilex_0.sw_reset_in" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="sw_reset_in" altera:internal="kernel_interface.sw_reset_in" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="sw_reset_in_reset" altera:internal="sw_reset_in_reset"></altera:port_mapping>
       </altera:interface_mapping>
     </altera:altera_interface_boundary>

--- a/n6001/hardware/ofs_n6001/build/ip/ddr_board/ddr_board_memory_bank_divider.ip
+++ b/n6001/hardware/ofs_n6001/build/ip/ddr_board/ddr_board_memory_bank_divider.ip
@@ -14,16 +14,16 @@ refer to the applicable agreement for further details, at
 https://fpgasoftware.intel.com/eula.-->
 <ipxact:component xmlns:altera="http://www.altera.com/XMLSchema/IPXact2014/extensions" xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2014">
   <ipxact:vendor>author</ipxact:vendor>
-  <ipxact:library>ddr_board_acl_memory_bank_divider_1</ipxact:library>
-  <ipxact:name>acl_memory_bank_divider_1</ipxact:name>
-  <ipxact:version>21.3</ipxact:version>
+  <ipxact:library>ddr_board_memory_bank_divider</ipxact:library>
+  <ipxact:name>memory_bank_divider</ipxact:name>
+  <ipxact:version>23.2</ipxact:version>
   <ipxact:busInterfaces>
     <ipxact:busInterface>
       <ipxact:name>clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -67,10 +67,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -109,10 +109,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>acl_bsp_snoop</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon_streaming" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon_streaming" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon_streaming" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon_streaming" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -161,7 +161,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="dataBitsPerSymbol" type="int">
           <ipxact:name>dataBitsPerSymbol</ipxact:name>
           <ipxact:displayName>Data bits per symbol</ipxact:displayName>
-          <ipxact:value>37</ipxact:value>
+          <ipxact:value>36</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="emptyWithinPacket" type="bit">
           <ipxact:name>emptyWithinPacket</ipxact:name>
@@ -217,10 +217,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -264,10 +264,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -306,10 +306,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>s</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -401,7 +401,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="addressSpan" type="string">
           <ipxact:name>addressSpan</ipxact:name>
           <ipxact:displayName>Address span</ipxact:displayName>
-          <ipxact:value>34359738368</ipxact:value>
+          <ipxact:value>17179869184</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="addressUnits" type="string">
           <ipxact:name>addressUnits</ipxact:name>
@@ -619,10 +619,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>acl_bsp_memorg_host</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="conduit" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="conduit" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="conduit" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="conduit" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -656,10 +656,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>bank1</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -920,10 +920,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>bank2</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -1184,10 +1184,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>bank3</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -1448,10 +1448,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>bank4</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -1722,7 +1722,7 @@ https://fpgasoftware.intel.com/eula.-->
     <ipxact:instantiations>
       <ipxact:componentInstantiation>
         <ipxact:name>QUARTUS_SYNTH</ipxact:name>
-        <ipxact:moduleName>acl_memory_bank_divider</ipxact:moduleName>
+        <ipxact:moduleName>memory_bank_divider</ipxact:moduleName>
         <ipxact:fileSetRef>
           <ipxact:localName>QUARTUS_SYNTH</ipxact:localName>
         </ipxact:fileSetRef>
@@ -1763,7 +1763,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>36</ipxact:right>
+              <ipxact:right>35</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -1957,7 +1957,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>28</ipxact:right>
+              <ipxact:right>27</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2073,7 +2073,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>32</ipxact:right>
+              <ipxact:right>31</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2228,7 +2228,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>32</ipxact:right>
+              <ipxact:right>31</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2383,7 +2383,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>32</ipxact:right>
+              <ipxact:right>31</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2538,7 +2538,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>32</ipxact:right>
+              <ipxact:right>31</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2611,9 +2611,9 @@ https://fpgasoftware.intel.com/eula.-->
   <ipxact:vendorExtensions>
     <altera:entity_info>
       <ipxact:vendor>author</ipxact:vendor>
-      <ipxact:library>ddr_board_acl_memory_bank_divider_1</ipxact:library>
-      <ipxact:name>acl_memory_bank_divider</ipxact:name>
-      <ipxact:version>21.3</ipxact:version>
+      <ipxact:library>ddr_board_memory_bank_divider</ipxact:library>
+      <ipxact:name>memory_bank_divider</ipxact:name>
+      <ipxact:version>23.2</ipxact:version>
     </altera:entity_info>
     <altera:altera_module_parameters>
       <ipxact:parameters>
@@ -2645,7 +2645,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="ADDRESS_WIDTH" type="int">
           <ipxact:name>ADDRESS_WIDTH</ipxact:name>
           <ipxact:displayName>Address Width (total addressable)</ipxact:displayName>
-          <ipxact:value>35</ipxact:value>
+          <ipxact:value>34</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="BURST_SIZE" type="int">
           <ipxact:name>BURST_SIZE</ipxact:name>
@@ -2665,17 +2665,17 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="SYNCHRONIZE_RESET" type="int">
           <ipxact:name>SYNCHRONIZE_RESET</ipxact:name>
           <ipxact:displayName>SYNCHRONIZE_RESET</ipxact:displayName>
-          <ipxact:value>0</ipxact:value>
+          <ipxact:value>1</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE_FAMILY" type="string">
           <ipxact:name>AUTO_DEVICE_FAMILY</ipxact:name>
           <ipxact:displayName>Auto DEVICE_FAMILY</ipxact:displayName>
-          <ipxact:value>Stratix 10</ipxact:value>
+          <ipxact:value>Agilex</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE" type="string">
           <ipxact:name>AUTO_DEVICE</ipxact:name>
           <ipxact:displayName>Auto DEVICE</ipxact:displayName>
-          <ipxact:value>1SX280HN2F43E2VG</ipxact:value>
+          <ipxact:value>AGFB014R24A2E2V</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE_SPEEDGRADE" type="string">
           <ipxact:name>AUTO_DEVICE_SPEEDGRADE</ipxact:name>
@@ -2686,20 +2686,15 @@ https://fpgasoftware.intel.com/eula.-->
     </altera:altera_module_parameters>
     <altera:altera_system_parameters>
       <ipxact:parameters>
-        <ipxact:parameter parameterId="board" type="string">
-          <ipxact:name>board</ipxact:name>
-          <ipxact:displayName>Board</ipxact:displayName>
-          <ipxact:value>default</ipxact:value>
-        </ipxact:parameter>
         <ipxact:parameter parameterId="device" type="string">
           <ipxact:name>device</ipxact:name>
           <ipxact:displayName>Device</ipxact:displayName>
-          <ipxact:value>1SX280HN2F43E2VG</ipxact:value>
+          <ipxact:value>AGFB014R24A2E2V</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="deviceFamily" type="string">
           <ipxact:name>deviceFamily</ipxact:name>
           <ipxact:displayName>Device family</ipxact:displayName>
-          <ipxact:value>Stratix 10</ipxact:value>
+          <ipxact:value>Agilex</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="deviceSpeedGrade" type="string">
           <ipxact:name>deviceSpeedGrade</ipxact:name>
@@ -2720,12 +2715,17 @@ https://fpgasoftware.intel.com/eula.-->
    {
       datum _originalDeviceFamily
       {
-         value = "Stratix 10";
+         value = "Agilex";
          type = "String";
       }
    }
-   element acl_memory_bank_divider_1
+   element memory_bank_divider
    {
+      datum _originalVersion
+      {
+         value = "1.0";
+         type = "String";
+      }
    }
 }
 </ipxact:value>
@@ -2824,7 +2824,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;acl_bsp_snoop_data&lt;/name&gt;
                     &lt;role&gt;data&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;37&lt;/width&gt;
+                    &lt;width&gt;36&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -2867,7 +2867,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;dataBitsPerSymbol&lt;/key&gt;
-                        &lt;value&gt;37&lt;/value&gt;
+                        &lt;value&gt;36&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;emptyWithinPacket&lt;/key&gt;
@@ -3066,7 +3066,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;s_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Input&lt;/direction&gt;
-                    &lt;width&gt;29&lt;/width&gt;
+                    &lt;width&gt;28&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -3104,7 +3104,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;addressSpan&lt;/key&gt;
-                        &lt;value&gt;34359738368&lt;/value&gt;
+                        &lt;value&gt;17179869184&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;addressUnits&lt;/key&gt;
@@ -3347,7 +3347,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;bank1_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;33&lt;/width&gt;
+                    &lt;width&gt;32&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -3586,7 +3586,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;bank2_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;33&lt;/width&gt;
+                    &lt;width&gt;32&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -3825,7 +3825,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;bank3_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;33&lt;/width&gt;
+                    &lt;width&gt;32&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -4064,7 +4064,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;bank4_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;33&lt;/width&gt;
+                    &lt;width&gt;32&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -4265,11 +4265,11 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='s' start='0x0' end='0x800000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
-                        &lt;value&gt;35&lt;/value&gt;
+                        &lt;value&gt;34&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;MAX_SLAVE_DATA_WIDTH&lt;/key&gt;
@@ -4281,23 +4281,18 @@ https://fpgasoftware.intel.com/eula.-->
     &lt;/connPtSystemInfos&gt;
 &lt;/systemInfosDefinition&gt;</ipxact:value>
         </ipxact:parameter>
-        <ipxact:parameter parameterId="pinAssignmentListDefinition" type="string">
-          <ipxact:name>pinAssignmentListDefinition</ipxact:name>
-          <ipxact:displayName>pinAssignmentListDefinition</ipxact:displayName>
-          <ipxact:value>&lt;pinAssignmentListDefinition/&gt;</ipxact:value>
-        </ipxact:parameter>
       </ipxact:parameters>
     </altera:altera_system_parameters>
     <altera:altera_interface_boundary>
-      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="acl_memory_bank_divider_1.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end">
+      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="memory_bank_divider.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end">
         <altera:port_mapping altera:name="acl_bsp_memorg_host_mode" altera:internal="acl_bsp_memorg_host_mode"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="acl_bsp_snoop" altera:internal="acl_memory_bank_divider_1.acl_bsp_snoop" altera:type="avalon_streaming" altera:dir="start">
+      <altera:interface_mapping altera:name="acl_bsp_snoop" altera:internal="memory_bank_divider.acl_bsp_snoop" altera:type="avalon_streaming" altera:dir="start">
         <altera:port_mapping altera:name="acl_bsp_snoop_data" altera:internal="acl_bsp_snoop_data"></altera:port_mapping>
         <altera:port_mapping altera:name="acl_bsp_snoop_ready" altera:internal="acl_bsp_snoop_ready"></altera:port_mapping>
         <altera:port_mapping altera:name="acl_bsp_snoop_valid" altera:internal="acl_bsp_snoop_valid"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank1" altera:internal="acl_memory_bank_divider_1.bank1" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank1" altera:internal="memory_bank_divider.bank1" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank1_address" altera:internal="bank1_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank1_burstcount" altera:internal="bank1_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank1_byteenable" altera:internal="bank1_byteenable"></altera:port_mapping>
@@ -4309,7 +4304,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank1_write" altera:internal="bank1_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank1_writedata" altera:internal="bank1_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank2" altera:internal="acl_memory_bank_divider_1.bank2" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank2" altera:internal="memory_bank_divider.bank2" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank2_address" altera:internal="bank2_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank2_burstcount" altera:internal="bank2_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank2_byteenable" altera:internal="bank2_byteenable"></altera:port_mapping>
@@ -4321,7 +4316,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank2_write" altera:internal="bank2_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank2_writedata" altera:internal="bank2_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank3" altera:internal="acl_memory_bank_divider_1.bank3" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank3" altera:internal="memory_bank_divider.bank3" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank3_address" altera:internal="bank3_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank3_burstcount" altera:internal="bank3_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank3_byteenable" altera:internal="bank3_byteenable"></altera:port_mapping>
@@ -4333,7 +4328,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank3_write" altera:internal="bank3_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank3_writedata" altera:internal="bank3_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank4" altera:internal="acl_memory_bank_divider_1.bank4" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank4" altera:internal="memory_bank_divider.bank4" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank4_address" altera:internal="bank4_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank4_burstcount" altera:internal="bank4_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank4_byteenable" altera:internal="bank4_byteenable"></altera:port_mapping>
@@ -4345,19 +4340,19 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank4_write" altera:internal="bank4_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank4_writedata" altera:internal="bank4_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="clk" altera:internal="acl_memory_bank_divider_1.clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="clk" altera:internal="memory_bank_divider.clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="clk_clk" altera:internal="clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_clk" altera:internal="acl_memory_bank_divider_1.kernel_clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_clk" altera:internal="memory_bank_divider.kernel_clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="kernel_clk_clk" altera:internal="kernel_clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_reset" altera:internal="acl_memory_bank_divider_1.kernel_reset" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_reset" altera:internal="memory_bank_divider.kernel_reset" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="kernel_reset_reset_n" altera:internal="kernel_reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="reset" altera:internal="acl_memory_bank_divider_1.reset" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="reset" altera:internal="memory_bank_divider.reset" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="reset_reset_n" altera:internal="reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="s" altera:internal="acl_memory_bank_divider_1.s" altera:type="avalon" altera:dir="end">
+      <altera:interface_mapping altera:name="s" altera:internal="memory_bank_divider.s" altera:type="avalon" altera:dir="end">
         <altera:port_mapping altera:name="s_address" altera:internal="s_address"></altera:port_mapping>
         <altera:port_mapping altera:name="s_burstcount" altera:internal="s_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="s_byteenable" altera:internal="s_byteenable"></altera:port_mapping>

--- a/n6001/hardware/ofs_n6001/build/ip/kernel_interface_hw.tcl
+++ b/n6001/hardware/ofs_n6001/build/ip/kernel_interface_hw.tcl
@@ -17,14 +17,14 @@
 package require -exact qsys 17.0
 
 # module properties
-set_module_property NAME {kernel_interface_agilex}
-set_module_property DISPLAY_NAME {OpenCL Kernel Interface for Agilex}
+set_module_property NAME {kernel_interface}
+set_module_property DISPLAY_NAME {oneAPI Kernel Interface}
 
 # default module properties
-set_module_property VERSION {17.1}
-set_module_property GROUP {OpenCL BSP Components}
-set_module_property DESCRIPTION {Connects the OpenCL host to the FPGA kernel}
-set_module_property AUTHOR {author}
+set_module_property VERSION {23.2}
+set_module_property GROUP {oneAPI ASP Components}
+set_module_property DESCRIPTION {Connects the oneAPI host to the FPGA kernel}
+set_module_property AUTHOR {OFS}
 
 set_module_property COMPOSITION_CALLBACK compose
 set_module_property opaque_address_map false

--- a/n6001/hardware/ofs_n6001/build/ip/memory_bank_divider_hw.tcl
+++ b/n6001/hardware/ofs_n6001/build/ip/memory_bank_divider_hw.tcl
@@ -1,14 +1,14 @@
 package require -exact qsys 17.0
 
 # module properties
-set_module_property NAME {acl_memory_bank_divider}
-set_module_property DISPLAY_NAME {OpenCL Memory Bank Divider}
+set_module_property NAME {memory_bank_divider}
+set_module_property DISPLAY_NAME {oneAPI Memory Bank Divider}
 
 # default module properties
-set_module_property VERSION {21.3}
-set_module_property GROUP {OpenCL BSP Components}
-set_module_property DESCRIPTION {default description}
-set_module_property AUTHOR {author}
+set_module_property VERSION {23.2}
+set_module_property GROUP {oneAPI ASP Components}
+set_module_property DESCRIPTION {Handles multiple global memory banks}
+set_module_property AUTHOR {OFS}
 
 # Set the name of the procedure to manipulate parameters
 set_module_property COMPOSITION_CALLBACK compose

--- a/n6001/hardware/ofs_n6001_iopipes/build/board.qsys
+++ b/n6001/hardware/ofs_n6001_iopipes/build/board.qsys
@@ -253,7 +253,7 @@ https://fpgasoftware.intel.com/eula.-->
          type = "int";
       }
    }
-   element kernel_interface_agilex_0
+   element kernel_interface
    {
       datum _sortIndex
       {
@@ -261,7 +261,7 @@ https://fpgasoftware.intel.com/eula.-->
          type = "int";
       }
    }
-   element kernel_interface_agilex_0.ctrl
+   element kernel_interface.ctrl
    {
       datum baseAddress
       {
@@ -382,7 +382,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='board_afu_id_avmm_slave_0.afu_cfg_slave' start='0x0' end='0x40' datawidth='64' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Read_Slave' start='0x100' end='0x104' datawidth='32' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Mask_Slave' start='0x108' end='0x10C' datawidth='32' /&amp;gt;&amp;lt;slave name='kernel_interface_agilex_0.ctrl' start='0x4000' end='0x8000' datawidth='32' /&amp;gt;&amp;lt;slave name='pipe_stage_dma_csr.s0' start='0x20000' end='0x20800' datawidth='64' /&amp;gt;&amp;lt;slave name='pipe_stage_uoe_csr.s0' start='0x20800' end='0x21000' datawidth='64' /&amp;gt;&amp;lt;slave name='ddr_board.null_dfh_id' start='0x21000' end='0x21040' datawidth='64' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='board_afu_id_avmm_slave_0.afu_cfg_slave' start='0x0' end='0x40' datawidth='64' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Read_Slave' start='0x100' end='0x104' datawidth='32' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Mask_Slave' start='0x108' end='0x10C' datawidth='32' /&amp;gt;&amp;lt;slave name='kernel_interface.ctrl' start='0x4000' end='0x8000' datawidth='32' /&amp;gt;&amp;lt;slave name='pipe_stage_dma_csr.s0' start='0x20000' end='0x20800' datawidth='64' /&amp;gt;&amp;lt;slave name='pipe_stage_uoe_csr.s0' start='0x20800' end='0x21000' datawidth='64' /&amp;gt;&amp;lt;slave name='ddr_board.null_dfh_id' start='0x21000' end='0x21040' datawidth='64' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
@@ -10958,7 +10958,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:module altera:enabled="true" altera:auto_export="false">
         <altera:entity_info>
           <ipxact:vendor>Altera Corporation</ipxact:vendor>
-          <ipxact:library>kernel_interface_agilex_0</ipxact:library>
+          <ipxact:library>kernel_interface</ipxact:library>
           <ipxact:name>altera_generic_component</ipxact:name>
           <ipxact:version>1.0</ipxact:version>
         </altera:entity_info>
@@ -11684,7 +11684,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;bridgesToReceiver&lt;/key&gt;
-                            &lt;value&gt;kernel_interface_agilex_0.kernel_irq_from_kernel&lt;/value&gt;
+                            &lt;value&gt;kernel_interface.kernel_irq_from_kernel&lt;/value&gt;
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;irqScheme&lt;/key&gt;
@@ -11839,9 +11839,9 @@ https://fpgasoftware.intel.com/eula.-->
         &lt;/interfaces&gt;
     &lt;/boundary&gt;
     &lt;originalModuleInfo&gt;
-        &lt;className&gt;kernel_interface_agilex&lt;/className&gt;
-        &lt;version&gt;17.1&lt;/version&gt;
-        &lt;displayName&gt;OpenCL Kernel Interface for Agilex&lt;/displayName&gt;
+        &lt;className&gt;kernel_interface&lt;/className&gt;
+        &lt;version&gt;23.2&lt;/version&gt;
+        &lt;displayName&gt;oneAPI Kernel Interface&lt;/displayName&gt;
     &lt;/originalModuleInfo&gt;
     &lt;systemInfoParameterDescriptors&gt;
         &lt;descriptors&gt;
@@ -12607,7 +12607,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;bridgesToReceiver&lt;/key&gt;
-                        &lt;value&gt;kernel_interface_agilex_0.kernel_irq_from_kernel&lt;/value&gt;
+                        &lt;value&gt;kernel_interface.kernel_irq_from_kernel&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;irqScheme&lt;/key&gt;
@@ -12766,35 +12766,35 @@ https://fpgasoftware.intel.com/eula.-->
               <ipxact:name>generationInfoDefinition</ipxact:name>
               <ipxact:displayName>Generation Behavior</ipxact:displayName>
               <ipxact:value>&lt;generationInfoDefinition&gt;
-    &lt;hdlLibraryName&gt;board_kernel_interface_agilex_0&lt;/hdlLibraryName&gt;
+    &lt;hdlLibraryName&gt;board_kernel_interface&lt;/hdlLibraryName&gt;
     &lt;fileSets&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_agilex_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_agilex_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;QUARTUS_SYNTH&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_agilex_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_agilex_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VERILOG&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_agilex_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_agilex_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_agilex_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_agilex_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_agilex_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_agilex_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;CDC_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
@@ -12814,7 +12814,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:parameter parameterId="logicalView" type="string">
               <ipxact:name>logicalView</ipxact:name>
               <ipxact:displayName>Logical view</ipxact:displayName>
-              <ipxact:value>ip/board/board_kernel_interface_agilex_0.ip</ipxact:value>
+              <ipxact:value>ip/board/board_kernel_interface.ip</ipxact:value>
             </ipxact:parameter>
             <ipxact:parameter parameterId="moduleAssignmentDefinition" type="string">
               <ipxact:name>moduleAssignmentDefinition</ipxact:name>
@@ -16991,7 +16991,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:module>
     </altera:modules>
     <altera:connections>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="kernel_interface_agilex_0.kernel_cra" altera:end="board_kernel_cra_pipe.s0">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="kernel_interface.kernel_cra" altera:end="board_kernel_cra_pipe.s0">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -17075,7 +17075,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="pipe_stage_host_ctrl.m0" altera:end="kernel_interface_agilex_0.ctrl">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="pipe_stage_host_ctrl.m0" altera:end="kernel_interface.ctrl">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x4000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -17165,7 +17165,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="board_kernel_cra_reset.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="board_kernel_cra_pipe.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="pipe_stage_dma_csr.clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="kernel_interface_agilex_0.clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="kernel_interface.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="pipe_stage_uoe_csr.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="kernel_clk_export.clk_in"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="board_afu_id_avmm_slave_0.clock"></altera:connection>
@@ -17175,19 +17175,19 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="emif_ddr4d_clk.out_clk" altera:end="ddr_board.ddr_clk_d"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="ddr_board.host_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="ddr_board.kernel_clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="kernel_interface_agilex_0.kernel_clk"></altera:connection>
-      <altera:connection altera:kind="conduit" altera:version="23.1" altera:start="kernel_interface_agilex_0.acl_bsp_memorg_host0x018" altera:end="ddr_board.acl_bsp_memorg_host">
+      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="kernel_interface.kernel_clk"></altera:connection>
+      <altera:connection altera:kind="conduit" altera:version="23.1" altera:start="kernel_interface.acl_bsp_memorg_host0x018" altera:end="ddr_board.acl_bsp_memorg_host">
         <altera:connection_parameter altera:parameter_name="endPort" altera:parameter_value=""></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="endPortLSB" altera:parameter_value="0"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="startPort" altera:parameter_value=""></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="startPortLSB" altera:parameter_value="0"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="width" altera:parameter_value="0"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="interrupt" altera:version="23.1" altera:start="board_irq_ctrl_0.interrupt_receiver" altera:end="kernel_interface_agilex_0.kernel_irq_to_host">
+      <altera:connection altera:kind="interrupt" altera:version="23.1" altera:start="board_irq_ctrl_0.interrupt_receiver" altera:end="kernel_interface.kernel_irq_to_host">
         <altera:connection_parameter altera:parameter_name="irqNumber" altera:parameter_value="0"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_interface_agilex_0.kernel_reset" altera:end="kernel_clk_export.clk_in_reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_interface_agilex_0.kernel_reset" altera:end="ddr_board.kernel_reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_interface.kernel_reset" altera:end="kernel_clk_export.clk_in_reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_interface.kernel_reset" altera:end="ddr_board.kernel_reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="board_irq_ctrl_0.Resetn"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="ddr_board.global_reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="board_kernel_cra_reset.in_reset"></altera:connection>
@@ -17195,9 +17195,9 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="pipe_stage_host_ctrl.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="board_kernel_cra_reset.out_reset" altera:end="board_kernel_cra_pipe.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="pipe_stage_dma_csr.reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="kernel_interface_agilex_0.reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="kernel_interface.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="pipe_stage_uoe_csr.reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="kernel_interface_agilex_0.sw_reset_in"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="kernel_interface.sw_reset_in"></altera:connection>
     </altera:connections>
     <altera:interconnect_requirements></altera:interconnect_requirements>
     <altera:wire_level_connections></altera:wire_level_connections>
@@ -17227,7 +17227,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:interface_mapping altera:name="kernel_ddr4b" altera:internal="ddr_board.kernel_ddr4b" altera:type="avalon" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="kernel_ddr4c" altera:internal="ddr_board.kernel_ddr4c" altera:type="avalon" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="kernel_ddr4d" altera:internal="ddr_board.kernel_ddr4d" altera:type="avalon" altera:dir="end"></altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_irq" altera:internal="kernel_interface_agilex_0.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start"></altera:interface_mapping>
+      <altera:interface_mapping altera:name="kernel_irq" altera:internal="kernel_interface.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start"></altera:interface_mapping>
       <altera:interface_mapping altera:name="kernel_reset" altera:internal="kernel_clk_export.clk_reset" altera:type="reset" altera:dir="start"></altera:interface_mapping>
       <altera:interface_mapping altera:name="uoe_csr_mmio64" altera:internal="pipe_stage_uoe_csr.m0" altera:type="avalon" altera:dir="start"></altera:interface_mapping>
     </altera:altera_interface_boundary>
@@ -17248,10 +17248,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>kernel_interface_agilex_0.kernel_cra</ipxact:name>
+            <ipxact:name>kernel_interface.kernel_cra</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="kernel_interface_agilex_0.kernel_cra">
+              <ipxact:addressSpaceRef addressSpaceRef="kernel_interface.kernel_cra">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -17274,7 +17274,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>kernel_interface_agilex_0.ctrl</ipxact:name>
+            <ipxact:name>kernel_interface.ctrl</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -17326,7 +17326,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:busInterfaces>
         <ipxact:addressSpaces>
           <ipxact:addressSpace>
-            <ipxact:name>kernel_interface_agilex_0.kernel_cra</ipxact:name>
+            <ipxact:name>kernel_interface.kernel_cra</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>board_kernel_cra_pipe.s0</ipxact:name>
@@ -17354,7 +17354,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:range>0x0000_0040</ipxact:range>
               </ipxact:segment>
               <ipxact:segment>
-                <ipxact:name>kernel_interface_agilex_0.ctrl</ipxact:name>
+                <ipxact:name>kernel_interface.ctrl</ipxact:name>
                 <ipxact:addressOffset>0x0000_4000</ipxact:addressOffset>
                 <ipxact:range>0x0000_4000</ipxact:range>
               </ipxact:segment>

--- a/n6001/hardware/ofs_n6001_iopipes/build/ddr_board.qsys
+++ b/n6001/hardware/ofs_n6001_iopipes/build/ddr_board.qsys
@@ -51,7 +51,7 @@ https://fpgasoftware.intel.com/eula.-->
          type = "int";
       }
    }
-   element acl_memory_bank_divider_0
+   element memory_bank_divider
    {
       datum _sortIndex
       {
@@ -416,7 +416,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='acl_memory_bank_divider_0.s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='memory_bank_divider.s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
@@ -437,7 +437,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='acl_memory_bank_divider_0.s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='memory_bank_divider.s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
@@ -2092,7 +2092,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:module altera:enabled="true" altera:auto_export="false">
         <altera:entity_info>
           <ipxact:vendor>Altera Corporation</ipxact:vendor>
-          <ipxact:library>acl_memory_bank_divider_0</ipxact:library>
+          <ipxact:library>memory_bank_divider</ipxact:library>
           <ipxact:name>altera_generic_component</ipxact:name>
           <ipxact:version>1.0</ipxact:version>
         </altera:entity_info>
@@ -3632,9 +3632,9 @@ https://fpgasoftware.intel.com/eula.-->
         &lt;/interfaces&gt;
     &lt;/boundary&gt;
     &lt;originalModuleInfo&gt;
-        &lt;className&gt;acl_memory_bank_divider&lt;/className&gt;
-        &lt;version&gt;21.3&lt;/version&gt;
-        &lt;displayName&gt;OpenCL Memory Bank Divider&lt;/displayName&gt;
+        &lt;className&gt;memory_bank_divider&lt;/className&gt;
+        &lt;version&gt;23.2&lt;/version&gt;
+        &lt;displayName&gt;oneAPI Memory Bank Divider&lt;/displayName&gt;
     &lt;/originalModuleInfo&gt;
     &lt;systemInfoParameterDescriptors&gt;
         &lt;descriptors&gt;
@@ -5206,29 +5206,29 @@ https://fpgasoftware.intel.com/eula.-->
               <ipxact:name>generationInfoDefinition</ipxact:name>
               <ipxact:displayName>Generation Behavior</ipxact:displayName>
               <ipxact:value>&lt;generationInfoDefinition&gt;
-    &lt;hdlLibraryName&gt;ddr_board_acl_memory_bank_divider_1&lt;/hdlLibraryName&gt;
+    &lt;hdlLibraryName&gt;ddr_board_memory_bank_divider&lt;/hdlLibraryName&gt;
     &lt;fileSets&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;QUARTUS_SYNTH&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VERILOG&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
@@ -5248,7 +5248,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:parameter parameterId="logicalView" type="string">
               <ipxact:name>logicalView</ipxact:name>
               <ipxact:displayName>Logical view</ipxact:displayName>
-              <ipxact:value>ip/ddr_board/ddr_board_acl_memory_bank_divider_1.ip</ipxact:value>
+              <ipxact:value>ip/ddr_board/ddr_board_memory_bank_divider.ip</ipxact:value>
             </ipxact:parameter>
             <ipxact:parameter parameterId="moduleAssignmentDefinition" type="string">
               <ipxact:name>moduleAssignmentDefinition</ipxact:name>
@@ -16491,7 +16491,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:module>
     </altera:modules>
     <altera:connections>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_memory_bank_divider_0.bank1" altera:end="ddr_channel_a.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="memory_bank_divider.bank1" altera:end="ddr_channel_a.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16512,7 +16512,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_memory_bank_divider_0.bank2" altera:end="ddr_channel_b.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="memory_bank_divider.bank2" altera:end="ddr_channel_b.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16533,7 +16533,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_memory_bank_divider_0.bank3" altera:end="ddr_channel_c.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="memory_bank_divider.bank3" altera:end="ddr_channel_c.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16554,7 +16554,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_memory_bank_divider_0.bank4" altera:end="ddr_channel_d.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="memory_bank_divider.bank4" altera:end="ddr_channel_d.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16575,7 +16575,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_avalon_mm_bridge_s10_1.m0" altera:end="acl_memory_bank_divider_0.s">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_avalon_mm_bridge_s10_1.m0" altera:end="memory_bank_divider.s">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16640,7 +16640,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="kernel_reset.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="global_reset.clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="acl_memory_bank_divider_0.clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="memory_bank_divider.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="dma_localmem_rd_pipe.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="dma_localmem_wr_pipe.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="acl_avalon_mm_bridge_s10_1.clk"></altera:connection>
@@ -16653,13 +16653,13 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="ddr_channel_b.host_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="ddr_channel_c.host_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="ddr_channel_d.host_clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="acl_memory_bank_divider_0.kernel_clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="memory_bank_divider.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_a.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_b.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_c.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_d.kernel_clk"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_reset.out_reset" altera:end="acl_memory_bank_divider_0.kernel_reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="acl_memory_bank_divider_0.reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_reset.out_reset" altera:end="memory_bank_divider.kernel_reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="memory_bank_divider.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="null_dfh_inst.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="dma_localmem_wr_pipe.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="dma_localmem_rd_pipe.reset"></altera:connection>
@@ -16675,7 +16675,7 @@ https://fpgasoftware.intel.com/eula.-->
     <altera:hdl_parameter_mappings></altera:hdl_parameter_mappings>
     <altera:preserved_ports_for_debug></altera:preserved_ports_for_debug>
     <altera:altera_interface_boundary>
-      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="acl_memory_bank_divider_0.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end"></altera:interface_mapping>
+      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="memory_bank_divider.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="ddr_clk_a" altera:internal="ddr_clk_a.in_clk" altera:type="clock" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="ddr_clk_b" altera:internal="ddr_clk_b.in_clk" altera:type="clock" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="ddr_clk_c" altera:internal="ddr_clk_c.in_clk" altera:type="clock" altera:dir="end"></altera:interface_mapping>
@@ -16708,10 +16708,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank1</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank1</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank1">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank1">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -16721,10 +16721,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank2</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank2</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank2">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank2">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -16734,10 +16734,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank3</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank3</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank3">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank3">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -16747,10 +16747,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank4</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank4</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank4">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank4">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -16760,7 +16760,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+            <ipxact:name>memory_bank_divider.s</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -16777,7 +16777,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+            <ipxact:name>memory_bank_divider.s</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -16790,7 +16790,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:master>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+            <ipxact:name>memory_bank_divider.s</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -16825,7 +16825,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:busInterfaces>
         <ipxact:addressSpaces>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank1</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank1</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_a.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -16835,7 +16835,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank2</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank2</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_b.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -16845,7 +16845,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank3</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank3</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_c.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -16855,7 +16855,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank4</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank4</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_d.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -16873,7 +16873,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>
               <ipxact:segment>
-                <ipxact:name>acl_memory_bank_divider_0.s via acl_avalon_mm_bridge_s10_1</ipxact:name>
+                <ipxact:name>memory_bank_divider.s via acl_avalon_mm_bridge_s10_1</ipxact:name>
                 <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>
@@ -16888,7 +16888,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>
               <ipxact:segment>
-                <ipxact:name>acl_memory_bank_divider_0.s via acl_avalon_mm_bridge_s10_1</ipxact:name>
+                <ipxact:name>memory_bank_divider.s via acl_avalon_mm_bridge_s10_1</ipxact:name>
                 <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>
@@ -16898,7 +16898,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:name>acl_avalon_mm_bridge_s10_1.m0</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
-                <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+                <ipxact:name>memory_bank_divider.s</ipxact:name>
                 <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>

--- a/n6001/hardware/ofs_n6001_iopipes/build/hw_iface.iipx
+++ b/n6001/hardware/ofs_n6001_iopipes/build/hw_iface.iipx
@@ -194,94 +194,6 @@
   <tag2 key="TCL_PACKAGE_VERSION" value="10.0" />
  </component>
  <component
-   name="acl_kernel_clk"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/iface/acl_kernel_clk.qsys"
-   displayName="OpenCL Kernel Clock Generator"
-   version="1.0"
-   description="Generates the kernel clocks for ACL"
-   tags="INTERNAL_COMPONENT=false"
-   categories="OpenCL BSP Components"
-   factory="QsysFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPONENT_HIDE_FROM_QUARTUS" value="true" />
- </component>
- <component
-   name="acl_kernel_clk_a10"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_clk_a10_hw.tcl"
-   displayName="OpenCL A10 Kernel Clock Generator"
-   version="16.1"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="comp" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="16.1" />
- </component>
- <component
-   name="acl_kernel_clk_noreconfig"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/iface/acl_kernel_clk_noreconfig.qsys"
-   displayName="OpenCL Kernel Clock Generator - no Dynamic Reconfig"
-   version="1.0"
-   description="Generates the kernel clocks for ACL"
-   tags="INTERNAL_COMPONENT=false"
-   categories="OpenCL BSP Components"
-   factory="QsysFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPONENT_HIDE_FROM_QUARTUS" value="true" />
- </component>
- <component
-   name="acl_kernel_clk_s10"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_clk_s10_hw.tcl"
-   displayName="OpenCL S10 Kernel Clock Generator"
-   version="17.0"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="comp" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="16.1" />
- </component>
- <component
-   name="acl_kernel_clk_s10_reconfig"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_clk_s10_reconfig_hw.tcl"
-   displayName="OpenCL S10 reconfigurable kernel clock generator"
-   version="17.0"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="comp" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="16.1" />
- </component>
- <component
-   name="acl_kernel_interface_soc"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/iface/acl_kernel_interface_soc.qsys"
-   displayName="acl_kernel_interface_soc"
-   version="1.0"
-   description="ACL Kernel Interface"
-   tags=""
-   categories="ACL BSP Components"
-   factory="QsysFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPONENT_HIDE_FROM_QUARTUS" value="true" />
- </component>
- <component
-   name="acl_memory_bank_divider"
-   file="./ip/acl_memory_bank_divider_hw.tcl"
-   displayName="OpenCL Memory Bank Divider"
-   version="21.3"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="compose" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="17.0" />
- </component>
- <component
    name="acl_snoop_adapter"
    file="${INTELFPGAOCLSDKROOT}/ip/board/export/snoop_adapter_hw.tcl"
    displayName="Avalon Snoop Adapter"
@@ -709,36 +621,6 @@
   <tag2 key="OPAQUE_ADDRESS_MAP" value="true" />
   <tag2 key="SUPPORTED_FILE_SETS" value="QUARTUS_SYNTH,SIM_VERILOG" />
   <tag2 key="TCL_PACKAGE_VERSION" value="12.1" />
- </component>
- <component
-   name="kernel_interface"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_interface_hw.tcl"
-   displayName="OpenCL Kernel Interface"
-   version="15.1"
-   description="Connects the OpenCL host to the FPGA kernel"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="compose" />
-  <tag2 key="OPAQUE_ADDRESS_MAP" value="false" />
-  <tag2 key="PARAMETER_UPGRADE_CALLBACK" value="ip_upgrade" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="13.1" />
- </component>
- <component
-   name="kernel_interface_s10"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_interface_s10_hw.tcl"
-   displayName="OpenCL Kernel Interface for S10"
-   version="17.1"
-   description="Connects the OpenCL host to the FPGA kernel"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="compose" />
-  <tag2 key="OPAQUE_ADDRESS_MAP" value="false" />
-  <tag2 key="PARAMETER_UPGRADE_CALLBACK" value="ip_upgrade" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="17.0" />
  </component>
  <component
    name="mem_org_mode"

--- a/n6001/hardware/ofs_n6001_iopipes/build/ip/board/board_kernel_interface.ip
+++ b/n6001/hardware/ofs_n6001_iopipes/build/ip/board/board_kernel_interface.ip
@@ -14,9 +14,9 @@ refer to the applicable agreement for further details, at
 https://fpgasoftware.intel.com/eula.-->
 <ipxact:component xmlns:altera="http://www.altera.com/XMLSchema/IPXact2014/extensions" xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2014">
   <ipxact:vendor>author</ipxact:vendor>
-  <ipxact:library>board_kernel_interface_agilex_0</ipxact:library>
-  <ipxact:name>kernel_interface_agilex_0</ipxact:name>
-  <ipxact:version>17.1</ipxact:version>
+  <ipxact:library>board_kernel_interface</ipxact:library>
+  <ipxact:name>kernel_interface</ipxact:name>
+  <ipxact:version>23.2</ipxact:version>
   <ipxact:busInterfaces>
     <ipxact:busInterface>
       <ipxact:name>kernel_cra</ipxact:name>
@@ -819,7 +819,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="bridgesToReceiver" type="string">
           <ipxact:name>bridgesToReceiver</ipxact:name>
           <ipxact:displayName>Bridges to receiver</ipxact:displayName>
-          <ipxact:value>board_kernel_interface_agilex_0.kernel_irq_from_kernel</ipxact:value>
+          <ipxact:value>board_kernel_interface.kernel_irq_from_kernel</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="irqScheme" type="string">
           <ipxact:name>irqScheme</ipxact:name>
@@ -993,7 +993,7 @@ https://fpgasoftware.intel.com/eula.-->
     <ipxact:instantiations>
       <ipxact:componentInstantiation>
         <ipxact:name>QUARTUS_SYNTH</ipxact:name>
-        <ipxact:moduleName>kernel_interface_agilex</ipxact:moduleName>
+        <ipxact:moduleName>kernel_interface</ipxact:moduleName>
         <ipxact:fileSetRef>
           <ipxact:localName>QUARTUS_SYNTH</ipxact:localName>
         </ipxact:fileSetRef>
@@ -1407,9 +1407,9 @@ https://fpgasoftware.intel.com/eula.-->
   <ipxact:vendorExtensions>
     <altera:entity_info>
       <ipxact:vendor>author</ipxact:vendor>
-      <ipxact:library>board_kernel_interface_agilex_0</ipxact:library>
-      <ipxact:name>kernel_interface_agilex</ipxact:name>
-      <ipxact:version>17.1</ipxact:version>
+      <ipxact:library>board_kernel_interface</ipxact:library>
+      <ipxact:name>kernel_interface</ipxact:name>
+      <ipxact:version>23.2</ipxact:version>
     </altera:entity_info>
     <altera:altera_module_parameters>
       <ipxact:parameters>
@@ -2195,7 +2195,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;bridgesToReceiver&lt;/key&gt;
-                        &lt;value&gt;board_kernel_interface_agilex_0.kernel_irq_from_kernel&lt;/value&gt;
+                        &lt;value&gt;board_kernel_interface.kernel_irq_from_kernel&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;irqScheme&lt;/key&gt;
@@ -2382,13 +2382,13 @@ https://fpgasoftware.intel.com/eula.-->
       </ipxact:parameters>
     </altera:altera_system_parameters>
     <altera:altera_interface_boundary>
-      <altera:interface_mapping altera:name="acl_bsp_memorg_host0x018" altera:internal="kernel_interface_agilex_0.acl_bsp_memorg_host0x018" altera:type="conduit" altera:dir="end">
+      <altera:interface_mapping altera:name="acl_bsp_memorg_host0x018" altera:internal="kernel_interface.acl_bsp_memorg_host0x018" altera:type="conduit" altera:dir="end">
         <altera:port_mapping altera:name="acl_bsp_memorg_host0x018_mode" altera:internal="acl_bsp_memorg_host0x018_mode"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="clk" altera:internal="kernel_interface_agilex_0.clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="clk" altera:internal="kernel_interface.clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="clk_clk" altera:internal="clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="ctrl" altera:internal="kernel_interface_agilex_0.ctrl" altera:type="avalon" altera:dir="end">
+      <altera:interface_mapping altera:name="ctrl" altera:internal="kernel_interface.ctrl" altera:type="avalon" altera:dir="end">
         <altera:port_mapping altera:name="ctrl_address" altera:internal="ctrl_address"></altera:port_mapping>
         <altera:port_mapping altera:name="ctrl_burstcount" altera:internal="ctrl_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="ctrl_byteenable" altera:internal="ctrl_byteenable"></altera:port_mapping>
@@ -2400,10 +2400,10 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="ctrl_write" altera:internal="ctrl_write"></altera:port_mapping>
         <altera:port_mapping altera:name="ctrl_writedata" altera:internal="ctrl_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_clk" altera:internal="kernel_interface_agilex_0.kernel_clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_clk" altera:internal="kernel_interface.kernel_clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="kernel_clk_clk" altera:internal="kernel_clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_cra" altera:internal="kernel_interface_agilex_0.kernel_cra" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="kernel_cra" altera:internal="kernel_interface.kernel_cra" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="kernel_cra_address" altera:internal="kernel_cra_address"></altera:port_mapping>
         <altera:port_mapping altera:name="kernel_cra_burstcount" altera:internal="kernel_cra_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="kernel_cra_byteenable" altera:internal="kernel_cra_byteenable"></altera:port_mapping>
@@ -2415,22 +2415,22 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="kernel_cra_write" altera:internal="kernel_cra_write"></altera:port_mapping>
         <altera:port_mapping altera:name="kernel_cra_writedata" altera:internal="kernel_cra_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_irq_from_kernel" altera:internal="kernel_interface_agilex_0.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start">
+      <altera:interface_mapping altera:name="kernel_irq_from_kernel" altera:internal="kernel_interface.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start">
         <altera:port_mapping altera:name="kernel_irq_from_kernel_irq" altera:internal="kernel_irq_from_kernel_irq"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_irq_to_host" altera:internal="kernel_interface_agilex_0.kernel_irq_to_host" altera:type="interrupt" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_irq_to_host" altera:internal="kernel_interface.kernel_irq_to_host" altera:type="interrupt" altera:dir="end">
         <altera:port_mapping altera:name="kernel_irq_to_host_irq" altera:internal="kernel_irq_to_host_irq"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_reset" altera:internal="kernel_interface_agilex_0.kernel_reset" altera:type="reset" altera:dir="start">
+      <altera:interface_mapping altera:name="kernel_reset" altera:internal="kernel_interface.kernel_reset" altera:type="reset" altera:dir="start">
         <altera:port_mapping altera:name="kernel_reset_reset_n" altera:internal="kernel_reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="reset" altera:internal="kernel_interface_agilex_0.reset" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="reset" altera:internal="kernel_interface.reset" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="reset_reset_n" altera:internal="reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="sw_reset_export" altera:internal="kernel_interface_agilex_0.sw_reset_export" altera:type="reset" altera:dir="start">
+      <altera:interface_mapping altera:name="sw_reset_export" altera:internal="kernel_interface.sw_reset_export" altera:type="reset" altera:dir="start">
         <altera:port_mapping altera:name="sw_reset_export_reset_n" altera:internal="sw_reset_export_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="sw_reset_in" altera:internal="kernel_interface_agilex_0.sw_reset_in" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="sw_reset_in" altera:internal="kernel_interface.sw_reset_in" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="sw_reset_in_reset" altera:internal="sw_reset_in_reset"></altera:port_mapping>
       </altera:interface_mapping>
     </altera:altera_interface_boundary>

--- a/n6001/hardware/ofs_n6001_iopipes/build/ip/ddr_board/ddr_board_memory_bank_divider.ip
+++ b/n6001/hardware/ofs_n6001_iopipes/build/ip/ddr_board/ddr_board_memory_bank_divider.ip
@@ -14,16 +14,16 @@ refer to the applicable agreement for further details, at
 https://fpgasoftware.intel.com/eula.-->
 <ipxact:component xmlns:altera="http://www.altera.com/XMLSchema/IPXact2014/extensions" xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2014">
   <ipxact:vendor>author</ipxact:vendor>
-  <ipxact:library>ddr_board_acl_memory_bank_divider_1</ipxact:library>
-  <ipxact:name>acl_memory_bank_divider_1</ipxact:name>
-  <ipxact:version>21.3</ipxact:version>
+  <ipxact:library>ddr_board_memory_bank_divider</ipxact:library>
+  <ipxact:name>memory_bank_divider</ipxact:name>
+  <ipxact:version>23.2</ipxact:version>
   <ipxact:busInterfaces>
     <ipxact:busInterface>
       <ipxact:name>clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -67,10 +67,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -109,10 +109,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>acl_bsp_snoop</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon_streaming" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon_streaming" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon_streaming" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon_streaming" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -161,7 +161,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="dataBitsPerSymbol" type="int">
           <ipxact:name>dataBitsPerSymbol</ipxact:name>
           <ipxact:displayName>Data bits per symbol</ipxact:displayName>
-          <ipxact:value>37</ipxact:value>
+          <ipxact:value>36</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="emptyWithinPacket" type="bit">
           <ipxact:name>emptyWithinPacket</ipxact:name>
@@ -217,10 +217,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -264,10 +264,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -306,10 +306,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>s</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -401,7 +401,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="addressSpan" type="string">
           <ipxact:name>addressSpan</ipxact:name>
           <ipxact:displayName>Address span</ipxact:displayName>
-          <ipxact:value>34359738368</ipxact:value>
+          <ipxact:value>17179869184</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="addressUnits" type="string">
           <ipxact:name>addressUnits</ipxact:name>
@@ -619,10 +619,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>acl_bsp_memorg_host</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="conduit" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="conduit" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="conduit" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="conduit" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -656,10 +656,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>bank1</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -920,10 +920,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>bank2</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -1184,10 +1184,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>bank3</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -1448,10 +1448,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>bank4</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="21.3"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -1722,7 +1722,7 @@ https://fpgasoftware.intel.com/eula.-->
     <ipxact:instantiations>
       <ipxact:componentInstantiation>
         <ipxact:name>QUARTUS_SYNTH</ipxact:name>
-        <ipxact:moduleName>acl_memory_bank_divider</ipxact:moduleName>
+        <ipxact:moduleName>memory_bank_divider</ipxact:moduleName>
         <ipxact:fileSetRef>
           <ipxact:localName>QUARTUS_SYNTH</ipxact:localName>
         </ipxact:fileSetRef>
@@ -1763,7 +1763,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>36</ipxact:right>
+              <ipxact:right>35</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -1957,7 +1957,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>28</ipxact:right>
+              <ipxact:right>27</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2073,7 +2073,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>32</ipxact:right>
+              <ipxact:right>31</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2228,7 +2228,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>32</ipxact:right>
+              <ipxact:right>31</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2383,7 +2383,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>32</ipxact:right>
+              <ipxact:right>31</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2538,7 +2538,7 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:vectors>
             <ipxact:vector>
               <ipxact:left>0</ipxact:left>
-              <ipxact:right>32</ipxact:right>
+              <ipxact:right>31</ipxact:right>
             </ipxact:vector>
           </ipxact:vectors>
           <ipxact:wireTypeDefs>
@@ -2611,9 +2611,9 @@ https://fpgasoftware.intel.com/eula.-->
   <ipxact:vendorExtensions>
     <altera:entity_info>
       <ipxact:vendor>author</ipxact:vendor>
-      <ipxact:library>ddr_board_acl_memory_bank_divider_1</ipxact:library>
-      <ipxact:name>acl_memory_bank_divider</ipxact:name>
-      <ipxact:version>21.3</ipxact:version>
+      <ipxact:library>ddr_board_memory_bank_divider</ipxact:library>
+      <ipxact:name>memory_bank_divider</ipxact:name>
+      <ipxact:version>23.2</ipxact:version>
     </altera:entity_info>
     <altera:altera_module_parameters>
       <ipxact:parameters>
@@ -2645,7 +2645,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="ADDRESS_WIDTH" type="int">
           <ipxact:name>ADDRESS_WIDTH</ipxact:name>
           <ipxact:displayName>Address Width (total addressable)</ipxact:displayName>
-          <ipxact:value>35</ipxact:value>
+          <ipxact:value>34</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="BURST_SIZE" type="int">
           <ipxact:name>BURST_SIZE</ipxact:name>
@@ -2665,17 +2665,17 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="SYNCHRONIZE_RESET" type="int">
           <ipxact:name>SYNCHRONIZE_RESET</ipxact:name>
           <ipxact:displayName>SYNCHRONIZE_RESET</ipxact:displayName>
-          <ipxact:value>0</ipxact:value>
+          <ipxact:value>1</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE_FAMILY" type="string">
           <ipxact:name>AUTO_DEVICE_FAMILY</ipxact:name>
           <ipxact:displayName>Auto DEVICE_FAMILY</ipxact:displayName>
-          <ipxact:value>Stratix 10</ipxact:value>
+          <ipxact:value>Agilex</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE" type="string">
           <ipxact:name>AUTO_DEVICE</ipxact:name>
           <ipxact:displayName>Auto DEVICE</ipxact:displayName>
-          <ipxact:value>1SX280HN2F43E2VG</ipxact:value>
+          <ipxact:value>AGFB014R24A2E2V</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE_SPEEDGRADE" type="string">
           <ipxact:name>AUTO_DEVICE_SPEEDGRADE</ipxact:name>
@@ -2686,20 +2686,15 @@ https://fpgasoftware.intel.com/eula.-->
     </altera:altera_module_parameters>
     <altera:altera_system_parameters>
       <ipxact:parameters>
-        <ipxact:parameter parameterId="board" type="string">
-          <ipxact:name>board</ipxact:name>
-          <ipxact:displayName>Board</ipxact:displayName>
-          <ipxact:value>default</ipxact:value>
-        </ipxact:parameter>
         <ipxact:parameter parameterId="device" type="string">
           <ipxact:name>device</ipxact:name>
           <ipxact:displayName>Device</ipxact:displayName>
-          <ipxact:value>1SX280HN2F43E2VG</ipxact:value>
+          <ipxact:value>AGFB014R24A2E2V</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="deviceFamily" type="string">
           <ipxact:name>deviceFamily</ipxact:name>
           <ipxact:displayName>Device family</ipxact:displayName>
-          <ipxact:value>Stratix 10</ipxact:value>
+          <ipxact:value>Agilex</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="deviceSpeedGrade" type="string">
           <ipxact:name>deviceSpeedGrade</ipxact:name>
@@ -2720,12 +2715,17 @@ https://fpgasoftware.intel.com/eula.-->
    {
       datum _originalDeviceFamily
       {
-         value = "Stratix 10";
+         value = "Agilex";
          type = "String";
       }
    }
-   element acl_memory_bank_divider_1
+   element memory_bank_divider
    {
+      datum _originalVersion
+      {
+         value = "1.0";
+         type = "String";
+      }
    }
 }
 </ipxact:value>
@@ -2824,7 +2824,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;acl_bsp_snoop_data&lt;/name&gt;
                     &lt;role&gt;data&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;37&lt;/width&gt;
+                    &lt;width&gt;36&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -2867,7 +2867,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;dataBitsPerSymbol&lt;/key&gt;
-                        &lt;value&gt;37&lt;/value&gt;
+                        &lt;value&gt;36&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;emptyWithinPacket&lt;/key&gt;
@@ -3066,7 +3066,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;s_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Input&lt;/direction&gt;
-                    &lt;width&gt;29&lt;/width&gt;
+                    &lt;width&gt;28&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -3104,7 +3104,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;addressSpan&lt;/key&gt;
-                        &lt;value&gt;34359738368&lt;/value&gt;
+                        &lt;value&gt;17179869184&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;addressUnits&lt;/key&gt;
@@ -3347,7 +3347,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;bank1_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;33&lt;/width&gt;
+                    &lt;width&gt;32&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -3586,7 +3586,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;bank2_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;33&lt;/width&gt;
+                    &lt;width&gt;32&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -3825,7 +3825,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;bank3_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;33&lt;/width&gt;
+                    &lt;width&gt;32&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -4064,7 +4064,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;name&gt;bank4_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
-                    &lt;width&gt;33&lt;/width&gt;
+                    &lt;width&gt;32&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC_VECTOR&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
@@ -4265,11 +4265,11 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='s' start='0x0' end='0x800000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
-                        &lt;value&gt;35&lt;/value&gt;
+                        &lt;value&gt;34&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;MAX_SLAVE_DATA_WIDTH&lt;/key&gt;
@@ -4281,23 +4281,18 @@ https://fpgasoftware.intel.com/eula.-->
     &lt;/connPtSystemInfos&gt;
 &lt;/systemInfosDefinition&gt;</ipxact:value>
         </ipxact:parameter>
-        <ipxact:parameter parameterId="pinAssignmentListDefinition" type="string">
-          <ipxact:name>pinAssignmentListDefinition</ipxact:name>
-          <ipxact:displayName>pinAssignmentListDefinition</ipxact:displayName>
-          <ipxact:value>&lt;pinAssignmentListDefinition/&gt;</ipxact:value>
-        </ipxact:parameter>
       </ipxact:parameters>
     </altera:altera_system_parameters>
     <altera:altera_interface_boundary>
-      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="acl_memory_bank_divider_1.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end">
+      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="memory_bank_divider.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end">
         <altera:port_mapping altera:name="acl_bsp_memorg_host_mode" altera:internal="acl_bsp_memorg_host_mode"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="acl_bsp_snoop" altera:internal="acl_memory_bank_divider_1.acl_bsp_snoop" altera:type="avalon_streaming" altera:dir="start">
+      <altera:interface_mapping altera:name="acl_bsp_snoop" altera:internal="memory_bank_divider.acl_bsp_snoop" altera:type="avalon_streaming" altera:dir="start">
         <altera:port_mapping altera:name="acl_bsp_snoop_data" altera:internal="acl_bsp_snoop_data"></altera:port_mapping>
         <altera:port_mapping altera:name="acl_bsp_snoop_ready" altera:internal="acl_bsp_snoop_ready"></altera:port_mapping>
         <altera:port_mapping altera:name="acl_bsp_snoop_valid" altera:internal="acl_bsp_snoop_valid"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank1" altera:internal="acl_memory_bank_divider_1.bank1" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank1" altera:internal="memory_bank_divider.bank1" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank1_address" altera:internal="bank1_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank1_burstcount" altera:internal="bank1_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank1_byteenable" altera:internal="bank1_byteenable"></altera:port_mapping>
@@ -4309,7 +4304,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank1_write" altera:internal="bank1_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank1_writedata" altera:internal="bank1_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank2" altera:internal="acl_memory_bank_divider_1.bank2" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank2" altera:internal="memory_bank_divider.bank2" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank2_address" altera:internal="bank2_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank2_burstcount" altera:internal="bank2_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank2_byteenable" altera:internal="bank2_byteenable"></altera:port_mapping>
@@ -4321,7 +4316,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank2_write" altera:internal="bank2_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank2_writedata" altera:internal="bank2_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank3" altera:internal="acl_memory_bank_divider_1.bank3" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank3" altera:internal="memory_bank_divider.bank3" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank3_address" altera:internal="bank3_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank3_burstcount" altera:internal="bank3_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank3_byteenable" altera:internal="bank3_byteenable"></altera:port_mapping>
@@ -4333,7 +4328,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank3_write" altera:internal="bank3_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank3_writedata" altera:internal="bank3_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank4" altera:internal="acl_memory_bank_divider_1.bank4" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank4" altera:internal="memory_bank_divider.bank4" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank4_address" altera:internal="bank4_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank4_burstcount" altera:internal="bank4_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank4_byteenable" altera:internal="bank4_byteenable"></altera:port_mapping>
@@ -4345,19 +4340,19 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank4_write" altera:internal="bank4_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank4_writedata" altera:internal="bank4_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="clk" altera:internal="acl_memory_bank_divider_1.clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="clk" altera:internal="memory_bank_divider.clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="clk_clk" altera:internal="clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_clk" altera:internal="acl_memory_bank_divider_1.kernel_clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_clk" altera:internal="memory_bank_divider.kernel_clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="kernel_clk_clk" altera:internal="kernel_clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_reset" altera:internal="acl_memory_bank_divider_1.kernel_reset" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_reset" altera:internal="memory_bank_divider.kernel_reset" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="kernel_reset_reset_n" altera:internal="kernel_reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="reset" altera:internal="acl_memory_bank_divider_1.reset" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="reset" altera:internal="memory_bank_divider.reset" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="reset_reset_n" altera:internal="reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="s" altera:internal="acl_memory_bank_divider_1.s" altera:type="avalon" altera:dir="end">
+      <altera:interface_mapping altera:name="s" altera:internal="memory_bank_divider.s" altera:type="avalon" altera:dir="end">
         <altera:port_mapping altera:name="s_address" altera:internal="s_address"></altera:port_mapping>
         <altera:port_mapping altera:name="s_burstcount" altera:internal="s_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="s_byteenable" altera:internal="s_byteenable"></altera:port_mapping>

--- a/n6001/hardware/ofs_n6001_iopipes/build/ip/kernel_interface_hw.tcl
+++ b/n6001/hardware/ofs_n6001_iopipes/build/ip/kernel_interface_hw.tcl
@@ -17,14 +17,14 @@
 package require -exact qsys 17.0
 
 # module properties
-set_module_property NAME {kernel_interface_agilex}
-set_module_property DISPLAY_NAME {OpenCL Kernel Interface for Agilex}
+set_module_property NAME {kernel_interface}
+set_module_property DISPLAY_NAME {oneAPI Kernel Interface}
 
 # default module properties
-set_module_property VERSION {17.1}
-set_module_property GROUP {OpenCL BSP Components}
-set_module_property DESCRIPTION {Connects the OpenCL host to the FPGA kernel}
-set_module_property AUTHOR {author}
+set_module_property VERSION {23.2}
+set_module_property GROUP {oneAPI ASP Components}
+set_module_property DESCRIPTION {Connects the oneAPI host to the FPGA kernel}
+set_module_property AUTHOR {OFS}
 
 set_module_property COMPOSITION_CALLBACK compose
 set_module_property opaque_address_map false

--- a/n6001/hardware/ofs_n6001_iopipes/build/ip/memory_bank_divider_hw.tcl
+++ b/n6001/hardware/ofs_n6001_iopipes/build/ip/memory_bank_divider_hw.tcl
@@ -1,14 +1,14 @@
 package require -exact qsys 17.0
 
 # module properties
-set_module_property NAME {acl_memory_bank_divider}
-set_module_property DISPLAY_NAME {OpenCL Memory Bank Divider}
+set_module_property NAME {memory_bank_divider}
+set_module_property DISPLAY_NAME {oneAPI Memory Bank Divider}
 
 # default module properties
-set_module_property VERSION {21.3}
-set_module_property GROUP {OpenCL BSP Components}
-set_module_property DESCRIPTION {default description}
-set_module_property AUTHOR {author}
+set_module_property VERSION {23.2}
+set_module_property GROUP {oneAPI ASP Components}
+set_module_property DESCRIPTION {Handles multiple global memory banks}
+set_module_property AUTHOR {OFS}
 
 # Set the name of the procedure to manipulate parameters
 set_module_property COMPOSITION_CALLBACK compose

--- a/n6001/hardware/ofs_n6001_usm/build/board.qsys
+++ b/n6001/hardware/ofs_n6001_usm/build/board.qsys
@@ -256,7 +256,7 @@ https://fpgasoftware.intel.com/eula.-->
          type = "int";
       }
    }
-   element kernel_interface_agilex_0
+   element kernel_interface
    {
       datum _sortIndex
       {
@@ -264,7 +264,7 @@ https://fpgasoftware.intel.com/eula.-->
          type = "int";
       }
    }
-   element kernel_interface_agilex_0.ctrl
+   element kernel_interface.ctrl
    {
       datum baseAddress
       {
@@ -369,7 +369,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='board_afu_id_avmm_slave_0.afu_cfg_slave' start='0x0' end='0x40' datawidth='64' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Read_Slave' start='0x100' end='0x104' datawidth='32' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Mask_Slave' start='0x108' end='0x10C' datawidth='32' /&amp;gt;&amp;lt;slave name='kernel_interface_agilex_0.ctrl' start='0x4000' end='0x8000' datawidth='32' /&amp;gt;&amp;lt;slave name='pipe_stage_dma_csr.s0' start='0x20000' end='0x20800' datawidth='64' /&amp;gt;&amp;lt;slave name='ddr_board.null_dfh_id' start='0x20800' end='0x20840' datawidth='64' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='board_afu_id_avmm_slave_0.afu_cfg_slave' start='0x0' end='0x40' datawidth='64' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Read_Slave' start='0x100' end='0x104' datawidth='32' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Mask_Slave' start='0x108' end='0x10C' datawidth='32' /&amp;gt;&amp;lt;slave name='kernel_interface.ctrl' start='0x4000' end='0x8000' datawidth='32' /&amp;gt;&amp;lt;slave name='pipe_stage_dma_csr.s0' start='0x20000' end='0x20800' datawidth='64' /&amp;gt;&amp;lt;slave name='ddr_board.null_dfh_id' start='0x20800' end='0x20840' datawidth='64' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
@@ -10861,7 +10861,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:module altera:enabled="true" altera:auto_export="false">
         <altera:entity_info>
           <ipxact:vendor>Altera Corporation</ipxact:vendor>
-          <ipxact:library>kernel_interface_agilex_0</ipxact:library>
+          <ipxact:library>kernel_interface</ipxact:library>
           <ipxact:name>altera_generic_component</ipxact:name>
           <ipxact:version>1.0</ipxact:version>
         </altera:entity_info>
@@ -11587,7 +11587,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;bridgesToReceiver&lt;/key&gt;
-                            &lt;value&gt;kernel_interface_agilex_0.kernel_irq_from_kernel&lt;/value&gt;
+                            &lt;value&gt;kernel_interface.kernel_irq_from_kernel&lt;/value&gt;
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;irqScheme&lt;/key&gt;
@@ -11742,9 +11742,9 @@ https://fpgasoftware.intel.com/eula.-->
         &lt;/interfaces&gt;
     &lt;/boundary&gt;
     &lt;originalModuleInfo&gt;
-        &lt;className&gt;kernel_interface_agilex&lt;/className&gt;
-        &lt;version&gt;17.1&lt;/version&gt;
-        &lt;displayName&gt;OpenCL Kernel Interface for Agilex&lt;/displayName&gt;
+        &lt;className&gt;kernel_interface&lt;/className&gt;
+        &lt;version&gt;23.2&lt;/version&gt;
+        &lt;displayName&gt;oneAPI Kernel Interface&lt;/displayName&gt;
     &lt;/originalModuleInfo&gt;
     &lt;systemInfoParameterDescriptors&gt;
         &lt;descriptors&gt;
@@ -12510,7 +12510,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;bridgesToReceiver&lt;/key&gt;
-                        &lt;value&gt;kernel_interface_agilex_0.kernel_irq_from_kernel&lt;/value&gt;
+                        &lt;value&gt;kernel_interface.kernel_irq_from_kernel&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;irqScheme&lt;/key&gt;
@@ -12669,29 +12669,29 @@ https://fpgasoftware.intel.com/eula.-->
               <ipxact:name>generationInfoDefinition</ipxact:name>
               <ipxact:displayName>Generation Behavior</ipxact:displayName>
               <ipxact:value>&lt;generationInfoDefinition&gt;
-    &lt;hdlLibraryName&gt;board_kernel_interface_agilex_0&lt;/hdlLibraryName&gt;
+    &lt;hdlLibraryName&gt;board_kernel_interface&lt;/hdlLibraryName&gt;
     &lt;fileSets&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_agilex_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_agilex_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;QUARTUS_SYNTH&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_agilex_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_agilex_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VERILOG&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_agilex_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_agilex_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_agilex_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_agilex_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
@@ -12711,7 +12711,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:parameter parameterId="logicalView" type="string">
               <ipxact:name>logicalView</ipxact:name>
               <ipxact:displayName>Logical view</ipxact:displayName>
-              <ipxact:value>ip/board/board_kernel_interface_agilex_0.ip</ipxact:value>
+              <ipxact:value>ip/board/board_kernel_interface.ip</ipxact:value>
             </ipxact:parameter>
             <ipxact:parameter parameterId="moduleAssignmentDefinition" type="string">
               <ipxact:name>moduleAssignmentDefinition</ipxact:name>
@@ -15480,7 +15480,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:module>
     </altera:modules>
     <altera:connections>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="kernel_interface_agilex_0.kernel_cra" altera:end="board_kernel_cra_pipe.s0">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="kernel_interface.kernel_cra" altera:end="board_kernel_cra_pipe.s0">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15564,7 +15564,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="pipe_stage_host_ctrl.m0" altera:end="kernel_interface_agilex_0.ctrl">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="pipe_stage_host_ctrl.m0" altera:end="kernel_interface.ctrl">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x4000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -15633,7 +15633,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="board_kernel_cra_reset.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="board_kernel_cra_pipe.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="pipe_stage_dma_csr.clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="kernel_interface_agilex_0.clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="kernel_interface.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="kernel_clk_export.clk_in"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="board_afu_id_avmm_slave_0.clock"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="emif_ddr4a_clk.out_clk" altera:end="ddr_board.ddr_clk_a"></altera:connection>
@@ -15642,19 +15642,19 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="emif_ddr4d_clk.out_clk" altera:end="ddr_board.ddr_clk_d"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="ddr_board.host_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="ddr_board.kernel_clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="kernel_interface_agilex_0.kernel_clk"></altera:connection>
-      <altera:connection altera:kind="conduit" altera:version="23.1" altera:start="kernel_interface_agilex_0.acl_bsp_memorg_host0x018" altera:end="ddr_board.acl_bsp_memorg_host">
+      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="kernel_interface.kernel_clk"></altera:connection>
+      <altera:connection altera:kind="conduit" altera:version="23.1" altera:start="kernel_interface.acl_bsp_memorg_host0x018" altera:end="ddr_board.acl_bsp_memorg_host">
         <altera:connection_parameter altera:parameter_name="endPort" altera:parameter_value=""></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="endPortLSB" altera:parameter_value="0"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="startPort" altera:parameter_value=""></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="startPortLSB" altera:parameter_value="0"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="width" altera:parameter_value="0"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="interrupt" altera:version="23.1" altera:start="board_irq_ctrl_0.interrupt_receiver" altera:end="kernel_interface_agilex_0.kernel_irq_to_host">
+      <altera:connection altera:kind="interrupt" altera:version="23.1" altera:start="board_irq_ctrl_0.interrupt_receiver" altera:end="kernel_interface.kernel_irq_to_host">
         <altera:connection_parameter altera:parameter_name="irqNumber" altera:parameter_value="0"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_interface_agilex_0.kernel_reset" altera:end="kernel_clk_export.clk_in_reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_interface_agilex_0.kernel_reset" altera:end="ddr_board.kernel_reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_interface.kernel_reset" altera:end="kernel_clk_export.clk_in_reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_interface.kernel_reset" altera:end="ddr_board.kernel_reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="board_irq_ctrl_0.Resetn"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="ddr_board.global_reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="board_kernel_cra_reset.in_reset"></altera:connection>
@@ -15662,8 +15662,8 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="pipe_stage_host_ctrl.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="board_kernel_cra_reset.out_reset" altera:end="board_kernel_cra_pipe.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="pipe_stage_dma_csr.reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="kernel_interface_agilex_0.reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="kernel_interface_agilex_0.sw_reset_in"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="kernel_interface.reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="kernel_interface.sw_reset_in"></altera:connection>
     </altera:connections>
     <altera:interconnect_requirements></altera:interconnect_requirements>
     <altera:wire_level_connections></altera:wire_level_connections>
@@ -15693,7 +15693,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:interface_mapping altera:name="kernel_ddr4b" altera:internal="ddr_board.kernel_ddr4b" altera:type="avalon" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="kernel_ddr4c" altera:internal="ddr_board.kernel_ddr4c" altera:type="avalon" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="kernel_ddr4d" altera:internal="ddr_board.kernel_ddr4d" altera:type="avalon" altera:dir="end"></altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_irq" altera:internal="kernel_interface_agilex_0.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start"></altera:interface_mapping>
+      <altera:interface_mapping altera:name="kernel_irq" altera:internal="kernel_interface.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start"></altera:interface_mapping>
       <altera:interface_mapping altera:name="kernel_reset" altera:internal="kernel_clk_export.clk_reset" altera:type="reset" altera:dir="start"></altera:interface_mapping>
     </altera:altera_interface_boundary>
     <ipxact:components>
@@ -15713,10 +15713,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>kernel_interface_agilex_0.kernel_cra</ipxact:name>
+            <ipxact:name>kernel_interface.kernel_cra</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="kernel_interface_agilex_0.kernel_cra">
+              <ipxact:addressSpaceRef addressSpaceRef="kernel_interface.kernel_cra">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -15739,7 +15739,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>kernel_interface_agilex_0.ctrl</ipxact:name>
+            <ipxact:name>kernel_interface.ctrl</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -15782,7 +15782,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:busInterfaces>
         <ipxact:addressSpaces>
           <ipxact:addressSpace>
-            <ipxact:name>kernel_interface_agilex_0.kernel_cra</ipxact:name>
+            <ipxact:name>kernel_interface.kernel_cra</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>board_kernel_cra_pipe.s0</ipxact:name>
@@ -15810,7 +15810,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:range>0x0000_0040</ipxact:range>
               </ipxact:segment>
               <ipxact:segment>
-                <ipxact:name>kernel_interface_agilex_0.ctrl</ipxact:name>
+                <ipxact:name>kernel_interface.ctrl</ipxact:name>
                 <ipxact:addressOffset>0x0000_4000</ipxact:addressOffset>
                 <ipxact:range>0x0000_4000</ipxact:range>
               </ipxact:segment>

--- a/n6001/hardware/ofs_n6001_usm/build/ddr_board.qsys
+++ b/n6001/hardware/ofs_n6001_usm/build/ddr_board.qsys
@@ -51,7 +51,7 @@ https://fpgasoftware.intel.com/eula.-->
          type = "int";
       }
    }
-   element acl_memory_bank_divider_0
+   element memory_bank_divider
    {
       datum _sortIndex
       {
@@ -416,7 +416,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='acl_memory_bank_divider_0.s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='memory_bank_divider.s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
@@ -437,7 +437,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='acl_memory_bank_divider_0.s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='memory_bank_divider.s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
@@ -2092,7 +2092,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:module altera:enabled="true" altera:auto_export="false">
         <altera:entity_info>
           <ipxact:vendor>Altera Corporation</ipxact:vendor>
-          <ipxact:library>acl_memory_bank_divider_0</ipxact:library>
+          <ipxact:library>memory_bank_divider</ipxact:library>
           <ipxact:name>altera_generic_component</ipxact:name>
           <ipxact:version>1.0</ipxact:version>
         </altera:entity_info>
@@ -3632,9 +3632,9 @@ https://fpgasoftware.intel.com/eula.-->
         &lt;/interfaces&gt;
     &lt;/boundary&gt;
     &lt;originalModuleInfo&gt;
-        &lt;className&gt;acl_memory_bank_divider&lt;/className&gt;
-        &lt;version&gt;21.3&lt;/version&gt;
-        &lt;displayName&gt;OpenCL Memory Bank Divider&lt;/displayName&gt;
+        &lt;className&gt;memory_bank_divider&lt;/className&gt;
+        &lt;version&gt;23.2&lt;/version&gt;
+        &lt;displayName&gt;oneAPI Memory Bank Divider&lt;/displayName&gt;
     &lt;/originalModuleInfo&gt;
     &lt;systemInfoParameterDescriptors&gt;
         &lt;descriptors&gt;
@@ -5206,29 +5206,29 @@ https://fpgasoftware.intel.com/eula.-->
               <ipxact:name>generationInfoDefinition</ipxact:name>
               <ipxact:displayName>Generation Behavior</ipxact:displayName>
               <ipxact:value>&lt;generationInfoDefinition&gt;
-    &lt;hdlLibraryName&gt;ddr_board_acl_memory_bank_divider_1&lt;/hdlLibraryName&gt;
+    &lt;hdlLibraryName&gt;ddr_board_memory_bank_divider&lt;/hdlLibraryName&gt;
     &lt;fileSets&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;QUARTUS_SYNTH&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VERILOG&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
@@ -5248,7 +5248,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:parameter parameterId="logicalView" type="string">
               <ipxact:name>logicalView</ipxact:name>
               <ipxact:displayName>Logical view</ipxact:displayName>
-              <ipxact:value>ip/ddr_board/ddr_board_acl_memory_bank_divider_1.ip</ipxact:value>
+              <ipxact:value>ip/ddr_board/ddr_board_memory_bank_divider.ip</ipxact:value>
             </ipxact:parameter>
             <ipxact:parameter parameterId="moduleAssignmentDefinition" type="string">
               <ipxact:name>moduleAssignmentDefinition</ipxact:name>
@@ -16491,7 +16491,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:module>
     </altera:modules>
     <altera:connections>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_memory_bank_divider_0.bank1" altera:end="ddr_channel_a.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="memory_bank_divider.bank1" altera:end="ddr_channel_a.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16512,7 +16512,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_memory_bank_divider_0.bank2" altera:end="ddr_channel_b.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="memory_bank_divider.bank2" altera:end="ddr_channel_b.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16533,7 +16533,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_memory_bank_divider_0.bank3" altera:end="ddr_channel_c.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="memory_bank_divider.bank3" altera:end="ddr_channel_c.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16554,7 +16554,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_memory_bank_divider_0.bank4" altera:end="ddr_channel_d.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="memory_bank_divider.bank4" altera:end="ddr_channel_d.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16575,7 +16575,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_avalon_mm_bridge_s10_1.m0" altera:end="acl_memory_bank_divider_0.s">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_avalon_mm_bridge_s10_1.m0" altera:end="memory_bank_divider.s">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16640,7 +16640,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="kernel_reset.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="global_reset.clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="acl_memory_bank_divider_0.clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="memory_bank_divider.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="dma_localmem_rd_pipe.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="dma_localmem_wr_pipe.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="acl_avalon_mm_bridge_s10_1.clk"></altera:connection>
@@ -16653,13 +16653,13 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="ddr_channel_b.host_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="ddr_channel_c.host_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="ddr_channel_d.host_clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="acl_memory_bank_divider_0.kernel_clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="memory_bank_divider.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_a.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_b.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_c.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_d.kernel_clk"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_reset.out_reset" altera:end="acl_memory_bank_divider_0.kernel_reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="acl_memory_bank_divider_0.reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_reset.out_reset" altera:end="memory_bank_divider.kernel_reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="memory_bank_divider.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="null_dfh_inst.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="dma_localmem_wr_pipe.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="dma_localmem_rd_pipe.reset"></altera:connection>
@@ -16675,7 +16675,7 @@ https://fpgasoftware.intel.com/eula.-->
     <altera:hdl_parameter_mappings></altera:hdl_parameter_mappings>
     <altera:preserved_ports_for_debug></altera:preserved_ports_for_debug>
     <altera:altera_interface_boundary>
-      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="acl_memory_bank_divider_0.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end"></altera:interface_mapping>
+      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="memory_bank_divider.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="ddr_clk_a" altera:internal="ddr_clk_a.in_clk" altera:type="clock" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="ddr_clk_b" altera:internal="ddr_clk_b.in_clk" altera:type="clock" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="ddr_clk_c" altera:internal="ddr_clk_c.in_clk" altera:type="clock" altera:dir="end"></altera:interface_mapping>
@@ -16708,10 +16708,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank1</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank1</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank1">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank1">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -16721,10 +16721,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank2</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank2</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank2">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank2">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -16734,10 +16734,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank3</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank3</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank3">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank3">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -16747,10 +16747,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank4</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank4</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank4">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank4">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -16760,7 +16760,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+            <ipxact:name>memory_bank_divider.s</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -16777,7 +16777,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+            <ipxact:name>memory_bank_divider.s</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -16790,7 +16790,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:master>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+            <ipxact:name>memory_bank_divider.s</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -16825,7 +16825,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:busInterfaces>
         <ipxact:addressSpaces>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank1</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank1</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_a.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -16835,7 +16835,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank2</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank2</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_b.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -16845,7 +16845,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank3</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank3</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_c.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -16855,7 +16855,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank4</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank4</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_d.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -16873,7 +16873,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>
               <ipxact:segment>
-                <ipxact:name>acl_memory_bank_divider_0.s via acl_avalon_mm_bridge_s10_1</ipxact:name>
+                <ipxact:name>memory_bank_divider.s via acl_avalon_mm_bridge_s10_1</ipxact:name>
                 <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>
@@ -16888,7 +16888,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>
               <ipxact:segment>
-                <ipxact:name>acl_memory_bank_divider_0.s via acl_avalon_mm_bridge_s10_1</ipxact:name>
+                <ipxact:name>memory_bank_divider.s via acl_avalon_mm_bridge_s10_1</ipxact:name>
                 <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>
@@ -16898,7 +16898,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:name>acl_avalon_mm_bridge_s10_1.m0</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
-                <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+                <ipxact:name>memory_bank_divider.s</ipxact:name>
                 <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>

--- a/n6001/hardware/ofs_n6001_usm/build/hw_iface.iipx
+++ b/n6001/hardware/ofs_n6001_usm/build/hw_iface.iipx
@@ -194,94 +194,6 @@
   <tag2 key="TCL_PACKAGE_VERSION" value="10.0" />
  </component>
  <component
-   name="acl_kernel_clk"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/iface/acl_kernel_clk.qsys"
-   displayName="OpenCL Kernel Clock Generator"
-   version="1.0"
-   description="Generates the kernel clocks for ACL"
-   tags="INTERNAL_COMPONENT=false"
-   categories="OpenCL BSP Components"
-   factory="QsysFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPONENT_HIDE_FROM_QUARTUS" value="true" />
- </component>
- <component
-   name="acl_kernel_clk_a10"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_clk_a10_hw.tcl"
-   displayName="OpenCL A10 Kernel Clock Generator"
-   version="16.1"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="comp" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="16.1" />
- </component>
- <component
-   name="acl_kernel_clk_noreconfig"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/iface/acl_kernel_clk_noreconfig.qsys"
-   displayName="OpenCL Kernel Clock Generator - no Dynamic Reconfig"
-   version="1.0"
-   description="Generates the kernel clocks for ACL"
-   tags="INTERNAL_COMPONENT=false"
-   categories="OpenCL BSP Components"
-   factory="QsysFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPONENT_HIDE_FROM_QUARTUS" value="true" />
- </component>
- <component
-   name="acl_kernel_clk_s10"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_clk_s10_hw.tcl"
-   displayName="OpenCL S10 Kernel Clock Generator"
-   version="17.0"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="comp" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="16.1" />
- </component>
- <component
-   name="acl_kernel_clk_s10_reconfig"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_clk_s10_reconfig_hw.tcl"
-   displayName="OpenCL S10 reconfigurable kernel clock generator"
-   version="17.0"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="comp" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="16.1" />
- </component>
- <component
-   name="acl_kernel_interface_soc"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/iface/acl_kernel_interface_soc.qsys"
-   displayName="acl_kernel_interface_soc"
-   version="1.0"
-   description="ACL Kernel Interface"
-   tags=""
-   categories="ACL BSP Components"
-   factory="QsysFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPONENT_HIDE_FROM_QUARTUS" value="true" />
- </component>
- <component
-   name="acl_memory_bank_divider"
-   file="./ip/acl_memory_bank_divider_hw.tcl"
-   displayName="OpenCL Memory Bank Divider"
-   version="21.3"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="compose" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="17.0" />
- </component>
- <component
    name="acl_snoop_adapter"
    file="${INTELFPGAOCLSDKROOT}/ip/board/export/snoop_adapter_hw.tcl"
    displayName="Avalon Snoop Adapter"
@@ -709,36 +621,6 @@
   <tag2 key="OPAQUE_ADDRESS_MAP" value="true" />
   <tag2 key="SUPPORTED_FILE_SETS" value="QUARTUS_SYNTH,SIM_VERILOG" />
   <tag2 key="TCL_PACKAGE_VERSION" value="12.1" />
- </component>
- <component
-   name="kernel_interface"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_interface_hw.tcl"
-   displayName="OpenCL Kernel Interface"
-   version="15.1"
-   description="Connects the OpenCL host to the FPGA kernel"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="compose" />
-  <tag2 key="OPAQUE_ADDRESS_MAP" value="false" />
-  <tag2 key="PARAMETER_UPGRADE_CALLBACK" value="ip_upgrade" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="13.1" />
- </component>
- <component
-   name="kernel_interface_s10"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_interface_s10_hw.tcl"
-   displayName="OpenCL Kernel Interface for S10"
-   version="17.1"
-   description="Connects the OpenCL host to the FPGA kernel"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="compose" />
-  <tag2 key="OPAQUE_ADDRESS_MAP" value="false" />
-  <tag2 key="PARAMETER_UPGRADE_CALLBACK" value="ip_upgrade" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="17.0" />
  </component>
  <component
    name="mem_org_mode"

--- a/n6001/hardware/ofs_n6001_usm/build/ip/board/board_kernel_interface.ip
+++ b/n6001/hardware/ofs_n6001_usm/build/ip/board/board_kernel_interface.ip
@@ -14,16 +14,16 @@ refer to the applicable agreement for further details, at
 https://fpgasoftware.intel.com/eula.-->
 <ipxact:component xmlns:altera="http://www.altera.com/XMLSchema/IPXact2014/extensions" xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2014">
   <ipxact:vendor>author</ipxact:vendor>
-  <ipxact:library>board_kernel_interface_s10_0</ipxact:library>
-  <ipxact:name>kernel_interface_s10_0</ipxact:name>
-  <ipxact:version>17.1</ipxact:version>
+  <ipxact:library>board_kernel_interface</ipxact:library>
+  <ipxact:name>kernel_interface</ipxact:name>
+  <ipxact:version>23.2</ipxact:version>
   <ipxact:busInterfaces>
     <ipxact:busInterface>
       <ipxact:name>kernel_cra</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -284,10 +284,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>ctrl</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -605,10 +605,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>acl_bsp_memorg_host0x018</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="conduit" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="conduit" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="conduit" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="conduit" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -642,10 +642,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -689,10 +689,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -731,10 +731,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_irq_from_kernel</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -778,10 +778,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_irq_to_host</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -819,7 +819,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="bridgesToReceiver" type="string">
           <ipxact:name>bridgesToReceiver</ipxact:name>
           <ipxact:displayName>Bridges to receiver</ipxact:displayName>
-          <ipxact:value>board_kernel_interface_s10_0.kernel_irq_from_kernel</ipxact:value>
+          <ipxact:value>board_kernel_interface.kernel_irq_from_kernel</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="irqScheme" type="string">
           <ipxact:name>irqScheme</ipxact:name>
@@ -830,10 +830,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>sw_reset_in</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -862,10 +862,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -899,10 +899,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -941,10 +941,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>sw_reset_export</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -993,11 +993,10 @@ https://fpgasoftware.intel.com/eula.-->
     <ipxact:instantiations>
       <ipxact:componentInstantiation>
         <ipxact:name>QUARTUS_SYNTH</ipxact:name>
-        <ipxact:moduleName>kernel_interface_s10</ipxact:moduleName>
+        <ipxact:moduleName>kernel_interface</ipxact:moduleName>
         <ipxact:fileSetRef>
           <ipxact:localName>QUARTUS_SYNTH</ipxact:localName>
         </ipxact:fileSetRef>
-        <ipxact:parameters></ipxact:parameters>
       </ipxact:componentInstantiation>
     </ipxact:instantiations>
     <ipxact:ports>
@@ -1005,7 +1004,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_waitrequest</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1036,7 +1034,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_readdatavalid</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1049,7 +1046,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_burstcount</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC_VECTOR</ipxact:typeName>
@@ -1098,7 +1094,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_write</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1111,7 +1106,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_read</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1142,7 +1136,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_debugaccess</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1155,7 +1148,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_waitrequest</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1186,7 +1178,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_readdatavalid</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1199,7 +1190,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_burstcount</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC_VECTOR</ipxact:typeName>
@@ -1248,7 +1238,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_write</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1261,7 +1250,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_read</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1292,7 +1280,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_debugaccess</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1323,7 +1310,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>clk_clk</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1336,7 +1322,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>reset_reset_n</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1349,7 +1334,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_irq_from_kernel_irq</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC_VECTOR</ipxact:typeName>
@@ -1362,7 +1346,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_irq_to_host_irq</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1375,7 +1358,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>sw_reset_in_reset</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1388,7 +1370,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_clk_clk</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1401,7 +1382,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_reset_reset_n</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1414,7 +1394,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>sw_reset_export_reset_n</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1428,9 +1407,9 @@ https://fpgasoftware.intel.com/eula.-->
   <ipxact:vendorExtensions>
     <altera:entity_info>
       <ipxact:vendor>author</ipxact:vendor>
-      <ipxact:library>board_kernel_interface_s10_0</ipxact:library>
-      <ipxact:name>kernel_interface_s10</ipxact:name>
-      <ipxact:version>17.1</ipxact:version>
+      <ipxact:library>board_kernel_interface</ipxact:library>
+      <ipxact:name>kernel_interface</ipxact:name>
+      <ipxact:version>23.2</ipxact:version>
     </altera:entity_info>
     <altera:altera_module_parameters>
       <ipxact:parameters>
@@ -1447,12 +1426,12 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="AUTO_DEVICE_FAMILY" type="string">
           <ipxact:name>AUTO_DEVICE_FAMILY</ipxact:name>
           <ipxact:displayName>Auto DEVICE_FAMILY</ipxact:displayName>
-          <ipxact:value>Stratix 10</ipxact:value>
+          <ipxact:value>Agilex</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE" type="string">
           <ipxact:name>AUTO_DEVICE</ipxact:name>
           <ipxact:displayName>Auto DEVICE</ipxact:displayName>
-          <ipxact:value>1SX280HN2F43E2VG</ipxact:value>
+          <ipxact:value>AGFB014R24A2E2V</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE_SPEEDGRADE" type="string">
           <ipxact:name>AUTO_DEVICE_SPEEDGRADE</ipxact:name>
@@ -1466,17 +1445,17 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="board" type="string">
           <ipxact:name>board</ipxact:name>
           <ipxact:displayName>Board</ipxact:displayName>
-          <ipxact:value>default</ipxact:value>
+          <ipxact:value>Unknown</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="device" type="string">
           <ipxact:name>device</ipxact:name>
           <ipxact:displayName>Device</ipxact:displayName>
-          <ipxact:value>1SX280HN2F43E2VG</ipxact:value>
+          <ipxact:value>AGFB014R24A2E2V</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="deviceFamily" type="string">
           <ipxact:name>deviceFamily</ipxact:name>
           <ipxact:displayName>Device family</ipxact:displayName>
-          <ipxact:value>Stratix 10</ipxact:value>
+          <ipxact:value>Agilex</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="deviceSpeedGrade" type="string">
           <ipxact:name>deviceSpeedGrade</ipxact:name>
@@ -1493,17 +1472,6 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:displayName>bonusData</ipxact:displayName>
           <ipxact:value>bonusData 
 {
-   element $system
-   {
-      datum _originalDeviceFamily
-      {
-         value = "Stratix 10";
-         type = "String";
-      }
-   }
-   element kernel_interface_s10_0
-   {
-   }
 }
 </ipxact:value>
         </ipxact:parameter>
@@ -2227,7 +2195,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;bridgesToReceiver&lt;/key&gt;
-                        &lt;value&gt;board_kernel_interface_s10_0.kernel_irq_from_kernel&lt;/value&gt;
+                        &lt;value&gt;board_kernel_interface.kernel_irq_from_kernel&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;irqScheme&lt;/key&gt;
@@ -2411,21 +2379,16 @@ https://fpgasoftware.intel.com/eula.-->
     &lt;/connPtSystemInfos&gt;
 &lt;/systemInfosDefinition&gt;</ipxact:value>
         </ipxact:parameter>
-        <ipxact:parameter parameterId="pinAssignmentListDefinition" type="string">
-          <ipxact:name>pinAssignmentListDefinition</ipxact:name>
-          <ipxact:displayName>pinAssignmentListDefinition</ipxact:displayName>
-          <ipxact:value>&lt;pinAssignmentListDefinition/&gt;</ipxact:value>
-        </ipxact:parameter>
       </ipxact:parameters>
     </altera:altera_system_parameters>
     <altera:altera_interface_boundary>
-      <altera:interface_mapping altera:name="acl_bsp_memorg_host0x018" altera:internal="kernel_interface_s10_0.acl_bsp_memorg_host0x018" altera:type="conduit" altera:dir="end">
+      <altera:interface_mapping altera:name="acl_bsp_memorg_host0x018" altera:internal="kernel_interface.acl_bsp_memorg_host0x018" altera:type="conduit" altera:dir="end">
         <altera:port_mapping altera:name="acl_bsp_memorg_host0x018_mode" altera:internal="acl_bsp_memorg_host0x018_mode"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="clk" altera:internal="kernel_interface_s10_0.clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="clk" altera:internal="kernel_interface.clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="clk_clk" altera:internal="clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="ctrl" altera:internal="kernel_interface_s10_0.ctrl" altera:type="avalon" altera:dir="end">
+      <altera:interface_mapping altera:name="ctrl" altera:internal="kernel_interface.ctrl" altera:type="avalon" altera:dir="end">
         <altera:port_mapping altera:name="ctrl_address" altera:internal="ctrl_address"></altera:port_mapping>
         <altera:port_mapping altera:name="ctrl_burstcount" altera:internal="ctrl_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="ctrl_byteenable" altera:internal="ctrl_byteenable"></altera:port_mapping>
@@ -2437,10 +2400,10 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="ctrl_write" altera:internal="ctrl_write"></altera:port_mapping>
         <altera:port_mapping altera:name="ctrl_writedata" altera:internal="ctrl_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_clk" altera:internal="kernel_interface_s10_0.kernel_clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_clk" altera:internal="kernel_interface.kernel_clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="kernel_clk_clk" altera:internal="kernel_clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_cra" altera:internal="kernel_interface_s10_0.kernel_cra" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="kernel_cra" altera:internal="kernel_interface.kernel_cra" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="kernel_cra_address" altera:internal="kernel_cra_address"></altera:port_mapping>
         <altera:port_mapping altera:name="kernel_cra_burstcount" altera:internal="kernel_cra_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="kernel_cra_byteenable" altera:internal="kernel_cra_byteenable"></altera:port_mapping>
@@ -2452,22 +2415,22 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="kernel_cra_write" altera:internal="kernel_cra_write"></altera:port_mapping>
         <altera:port_mapping altera:name="kernel_cra_writedata" altera:internal="kernel_cra_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_irq_from_kernel" altera:internal="kernel_interface_s10_0.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start">
+      <altera:interface_mapping altera:name="kernel_irq_from_kernel" altera:internal="kernel_interface.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start">
         <altera:port_mapping altera:name="kernel_irq_from_kernel_irq" altera:internal="kernel_irq_from_kernel_irq"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_irq_to_host" altera:internal="kernel_interface_s10_0.kernel_irq_to_host" altera:type="interrupt" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_irq_to_host" altera:internal="kernel_interface.kernel_irq_to_host" altera:type="interrupt" altera:dir="end">
         <altera:port_mapping altera:name="kernel_irq_to_host_irq" altera:internal="kernel_irq_to_host_irq"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_reset" altera:internal="kernel_interface_s10_0.kernel_reset" altera:type="reset" altera:dir="start">
+      <altera:interface_mapping altera:name="kernel_reset" altera:internal="kernel_interface.kernel_reset" altera:type="reset" altera:dir="start">
         <altera:port_mapping altera:name="kernel_reset_reset_n" altera:internal="kernel_reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="reset" altera:internal="kernel_interface_s10_0.reset" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="reset" altera:internal="kernel_interface.reset" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="reset_reset_n" altera:internal="reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="sw_reset_export" altera:internal="kernel_interface_s10_0.sw_reset_export" altera:type="reset" altera:dir="start">
+      <altera:interface_mapping altera:name="sw_reset_export" altera:internal="kernel_interface.sw_reset_export" altera:type="reset" altera:dir="start">
         <altera:port_mapping altera:name="sw_reset_export_reset_n" altera:internal="sw_reset_export_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="sw_reset_in" altera:internal="kernel_interface_s10_0.sw_reset_in" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="sw_reset_in" altera:internal="kernel_interface.sw_reset_in" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="sw_reset_in_reset" altera:internal="sw_reset_in_reset"></altera:port_mapping>
       </altera:interface_mapping>
     </altera:altera_interface_boundary>
@@ -2480,52 +2443,52 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:busInterfaces>
           <ipxact:busInterface>
             <ipxact:name>kernel_cra.s0</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>clock_crosser.slave</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>address_span_extender_0.windowed_slave</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>address_span_extender_0.cntl</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>sw_reset.s</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>ctrl.s0</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>mem_org_mode0.s</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>version_id_0.s</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>kernel_cra.m0</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:master></ipxact:master>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>clock_crosser.master</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:master>
               <ipxact:addressSpaceRef addressSpaceRef="clock_crosser.master">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
@@ -2534,7 +2497,7 @@ https://fpgasoftware.intel.com/eula.-->
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>address_span_extender_0.expanded_master</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:master>
               <ipxact:addressSpaceRef addressSpaceRef="address_span_extender_0.expanded_master">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
@@ -2543,7 +2506,7 @@ https://fpgasoftware.intel.com/eula.-->
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>ctrl.m0</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:master>
               <ipxact:addressSpaceRef addressSpaceRef="ctrl.m0">
                 <ipxact:baseAddress>0x1000</ipxact:baseAddress>

--- a/n6001/hardware/ofs_n6001_usm/build/ip/ddr_board/ddr_board_memory_bank_divider.ip
+++ b/n6001/hardware/ofs_n6001_usm/build/ip/ddr_board/ddr_board_memory_bank_divider.ip
@@ -14,9 +14,9 @@ refer to the applicable agreement for further details, at
 https://fpgasoftware.intel.com/eula.-->
 <ipxact:component xmlns:altera="http://www.altera.com/XMLSchema/IPXact2014/extensions" xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2014">
   <ipxact:vendor>author</ipxact:vendor>
-  <ipxact:library>ddr_board_acl_memory_bank_divider_1</ipxact:library>
-  <ipxact:name>acl_memory_bank_divider_1</ipxact:name>
-  <ipxact:version>21.3</ipxact:version>
+  <ipxact:library>ddr_board_memory_bank_divider</ipxact:library>
+  <ipxact:name>memory_bank_divider</ipxact:name>
+  <ipxact:version>23.2</ipxact:version>
   <ipxact:busInterfaces>
     <ipxact:busInterface>
       <ipxact:name>clk</ipxact:name>
@@ -1722,7 +1722,7 @@ https://fpgasoftware.intel.com/eula.-->
     <ipxact:instantiations>
       <ipxact:componentInstantiation>
         <ipxact:name>QUARTUS_SYNTH</ipxact:name>
-        <ipxact:moduleName>acl_memory_bank_divider</ipxact:moduleName>
+        <ipxact:moduleName>memory_bank_divider</ipxact:moduleName>
         <ipxact:fileSetRef>
           <ipxact:localName>QUARTUS_SYNTH</ipxact:localName>
         </ipxact:fileSetRef>
@@ -2611,9 +2611,9 @@ https://fpgasoftware.intel.com/eula.-->
   <ipxact:vendorExtensions>
     <altera:entity_info>
       <ipxact:vendor>author</ipxact:vendor>
-      <ipxact:library>ddr_board_acl_memory_bank_divider_1</ipxact:library>
-      <ipxact:name>acl_memory_bank_divider</ipxact:name>
-      <ipxact:version>21.3</ipxact:version>
+      <ipxact:library>ddr_board_memory_bank_divider</ipxact:library>
+      <ipxact:name>memory_bank_divider</ipxact:name>
+      <ipxact:version>23.2</ipxact:version>
     </altera:entity_info>
     <altera:altera_module_parameters>
       <ipxact:parameters>
@@ -2719,7 +2719,7 @@ https://fpgasoftware.intel.com/eula.-->
          type = "String";
       }
    }
-   element acl_memory_bank_divider_1
+   element memory_bank_divider
    {
       datum _originalVersion
       {
@@ -4284,15 +4284,15 @@ https://fpgasoftware.intel.com/eula.-->
       </ipxact:parameters>
     </altera:altera_system_parameters>
     <altera:altera_interface_boundary>
-      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="acl_memory_bank_divider_1.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end">
+      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="memory_bank_divider.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end">
         <altera:port_mapping altera:name="acl_bsp_memorg_host_mode" altera:internal="acl_bsp_memorg_host_mode"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="acl_bsp_snoop" altera:internal="acl_memory_bank_divider_1.acl_bsp_snoop" altera:type="avalon_streaming" altera:dir="start">
+      <altera:interface_mapping altera:name="acl_bsp_snoop" altera:internal="memory_bank_divider.acl_bsp_snoop" altera:type="avalon_streaming" altera:dir="start">
         <altera:port_mapping altera:name="acl_bsp_snoop_data" altera:internal="acl_bsp_snoop_data"></altera:port_mapping>
         <altera:port_mapping altera:name="acl_bsp_snoop_ready" altera:internal="acl_bsp_snoop_ready"></altera:port_mapping>
         <altera:port_mapping altera:name="acl_bsp_snoop_valid" altera:internal="acl_bsp_snoop_valid"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank1" altera:internal="acl_memory_bank_divider_1.bank1" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank1" altera:internal="memory_bank_divider.bank1" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank1_address" altera:internal="bank1_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank1_burstcount" altera:internal="bank1_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank1_byteenable" altera:internal="bank1_byteenable"></altera:port_mapping>
@@ -4304,7 +4304,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank1_write" altera:internal="bank1_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank1_writedata" altera:internal="bank1_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank2" altera:internal="acl_memory_bank_divider_1.bank2" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank2" altera:internal="memory_bank_divider.bank2" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank2_address" altera:internal="bank2_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank2_burstcount" altera:internal="bank2_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank2_byteenable" altera:internal="bank2_byteenable"></altera:port_mapping>
@@ -4316,7 +4316,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank2_write" altera:internal="bank2_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank2_writedata" altera:internal="bank2_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank3" altera:internal="acl_memory_bank_divider_1.bank3" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank3" altera:internal="memory_bank_divider.bank3" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank3_address" altera:internal="bank3_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank3_burstcount" altera:internal="bank3_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank3_byteenable" altera:internal="bank3_byteenable"></altera:port_mapping>
@@ -4328,7 +4328,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank3_write" altera:internal="bank3_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank3_writedata" altera:internal="bank3_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank4" altera:internal="acl_memory_bank_divider_1.bank4" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank4" altera:internal="memory_bank_divider.bank4" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank4_address" altera:internal="bank4_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank4_burstcount" altera:internal="bank4_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank4_byteenable" altera:internal="bank4_byteenable"></altera:port_mapping>
@@ -4340,19 +4340,19 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank4_write" altera:internal="bank4_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank4_writedata" altera:internal="bank4_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="clk" altera:internal="acl_memory_bank_divider_1.clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="clk" altera:internal="memory_bank_divider.clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="clk_clk" altera:internal="clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_clk" altera:internal="acl_memory_bank_divider_1.kernel_clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_clk" altera:internal="memory_bank_divider.kernel_clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="kernel_clk_clk" altera:internal="kernel_clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_reset" altera:internal="acl_memory_bank_divider_1.kernel_reset" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_reset" altera:internal="memory_bank_divider.kernel_reset" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="kernel_reset_reset_n" altera:internal="kernel_reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="reset" altera:internal="acl_memory_bank_divider_1.reset" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="reset" altera:internal="memory_bank_divider.reset" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="reset_reset_n" altera:internal="reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="s" altera:internal="acl_memory_bank_divider_1.s" altera:type="avalon" altera:dir="end">
+      <altera:interface_mapping altera:name="s" altera:internal="memory_bank_divider.s" altera:type="avalon" altera:dir="end">
         <altera:port_mapping altera:name="s_address" altera:internal="s_address"></altera:port_mapping>
         <altera:port_mapping altera:name="s_burstcount" altera:internal="s_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="s_byteenable" altera:internal="s_byteenable"></altera:port_mapping>

--- a/n6001/hardware/ofs_n6001_usm/build/ip/kernel_interface_hw.tcl
+++ b/n6001/hardware/ofs_n6001_usm/build/ip/kernel_interface_hw.tcl
@@ -1,0 +1,383 @@
+# (c) 1992-2020 Intel Corporation.                            
+# Intel, the Intel logo, Intel, MegaCore, NIOS II, Quartus and TalkBack words    
+# and logos are trademarks of Intel Corporation or its subsidiaries in the U.S.  
+# and/or other countries. Other marks and brands may be claimed as the property  
+# of others. See Trademarks on intel.com for full list of Intel trademarks or    
+# the Trademarks & Brands Names Database (if Intel) or See www.Intel.com/legal (if Altera) 
+# Your use of Intel Corporation's design tools, logic functions and other        
+# software and tools, and its AMPP partner logic functions, and any output       
+# files any of the foregoing (including device programming or simulation         
+# files), and any associated documentation or information are expressly subject  
+# to the terms and conditions of the Altera Program License Subscription         
+# Agreement, Intel MegaCore Function License Agreement, or other applicable      
+# license agreement, including, without limitation, that your use is for the     
+# sole purpose of programming logic devices manufactured by Intel and sold by    
+# Intel or its authorized distributors.  Please refer to the applicable          
+# agreement for further details.                                                 
+package require -exact qsys 17.0
+
+# module properties
+set_module_property NAME {kernel_interface}
+set_module_property DISPLAY_NAME {oneAPI Kernel Interface}
+
+# default module properties
+set_module_property VERSION {23.2}
+set_module_property GROUP {oneAPI ASP Components}
+set_module_property DESCRIPTION {Connects the oneAPI host to the FPGA kernel}
+set_module_property AUTHOR {OFS}
+
+set_module_property COMPOSITION_CALLBACK compose
+set_module_property opaque_address_map false
+set_module_property PARAMETER_UPGRADE_CALLBACK ip_upgrade
+
+# +-----------------------------------
+# | parameters
+# | 
+add_parameter NUM_GLOBAL_MEMS INTEGER 1
+set_parameter_property NUM_GLOBAL_MEMS DEFAULT_VALUE 1
+set_parameter_property NUM_GLOBAL_MEMS DISPLAY_NAME "Number of global memory systems"
+set_parameter_property NUM_GLOBAL_MEMS AFFECTS_ELABORATION true
+
+add_parameter ENABLE_ROM_RECONFIGURE INTEGER 1
+set_parameter_property ENABLE_ROM_RECONFIGURE DEFAULT_VALUE 1
+set_parameter_property ENABLE_ROM_RECONFIGURE DISPLAY_NAME "Enable sys description rom PR"
+#set_parameter_property ENABLE_ROM_RECONFIGURE AFFECTS_ELABORATION false
+set_parameter_property ENABLE_ROM_RECONFIGURE VISIBLE false
+# | 
+# +-----------------------------------
+
+proc get_config_addr { i } {
+  if { $i == 0 } {
+    return [format 0x%03X 24 ]
+  } else {
+    return [format 0x%03X [ expr 256 + (($i -1) * 4) ] ]
+  }
+}
+
+proc compose { } {
+    set num_global_mems [ get_parameter_value NUM_GLOBAL_MEMS ]
+    set rom_reconfigure_en [get_parameter_value ENABLE_ROM_RECONFIGURE]
+
+    if { $num_global_mems > 6 } {
+      send_message -error "Can't have more than 6 global memories"
+    }
+
+    # Instances and instance parameters
+    # (disabled instances are intentionally culled)
+    add_instance kernel_cra acl_avalon_mm_bridge_s10 17.1
+    set_instance_parameter_value kernel_cra {DATA_WIDTH} {64}
+    set_instance_parameter_value kernel_cra {SYMBOL_WIDTH} {8}
+    set_instance_parameter_value kernel_cra {ADDRESS_WIDTH} {30}
+    set_instance_parameter_value kernel_cra {ADDRESS_UNITS} {SYMBOLS}
+    set_instance_parameter_value kernel_cra {MAX_BURST_SIZE} {1}
+    set_instance_parameter_value kernel_cra {MAX_PENDING_RESPONSES} {1}
+    set_instance_parameter_value kernel_cra {LINEWRAPBURSTS} {0}
+    set_instance_parameter_value kernel_cra {SYNCHRONIZE_RESET} {1}
+    set_instance_parameter_value kernel_cra {DISABLE_WAITREQUEST_BUFFERING} {1}
+
+    add_instance clock_crosser acl_clock_crossing_bridge 1.0
+    set_instance_parameter_value clock_crosser {ADDRESS_WIDTH} {30}
+    set_instance_parameter_value clock_crosser {DATA_WIDTH} {64}
+    set_instance_parameter_value clock_crosser {BURSTCOUNT_WIDTH} {1}
+    set_instance_parameter_value clock_crosser {BYTEENABLE_WIDTH} {8}
+    set_instance_parameter_value clock_crosser {CMD_DCFIFO_MIN_DEPTH} {8}
+    set_instance_parameter_value clock_crosser {RSP_DCFIFO_MIN_DEPTH} {8}
+    set_instance_parameter_value clock_crosser {SLAVE_STALL_LATENCY} {0}
+    set_instance_parameter_value clock_crosser {MASTER_STALL_LATENCY} {1}
+    set_instance_parameter_value clock_crosser {USE_WRITE_ACK} {0}
+
+    add_instance address_span_extender_0 altera_address_span_extender 17.1
+    set_instance_parameter_value address_span_extender_0 {DATA_WIDTH} {64}
+    set_instance_parameter_value address_span_extender_0 {MASTER_ADDRESS_WIDTH} {30}
+    set_instance_parameter_value address_span_extender_0 {SLAVE_ADDRESS_WIDTH} {9}
+    set_instance_parameter_value address_span_extender_0 {BURSTCOUNT_WIDTH} {1}
+    set_instance_parameter_value address_span_extender_0 {SUB_WINDOW_COUNT} {1}
+    set_instance_parameter_value address_span_extender_0 {MASTER_ADDRESS_DEF} {0}
+    set_instance_parameter_value address_span_extender_0 {ENABLE_SLAVE_PORT} {1}
+    set_instance_parameter_value address_span_extender_0 {MAX_PENDING_READS} {1}
+
+    add_instance sw_reset sw_reset 10.0
+    set_instance_parameter_value sw_reset {WIDTH} {64}
+    set_instance_parameter_value sw_reset {LOG2_RESET_CYCLES} {4}
+
+    add_instance ctrl altera_avalon_mm_bridge 17.1
+    set_instance_parameter_value ctrl {DATA_WIDTH} {32}
+    set_instance_parameter_value ctrl {SYMBOL_WIDTH} {8}
+    set_instance_parameter_value ctrl {ADDRESS_WIDTH} {14}
+    set_instance_parameter_value ctrl {ADDRESS_UNITS} {SYMBOLS}
+    set_instance_parameter_value ctrl {MAX_BURST_SIZE} {1}
+    set_instance_parameter_value ctrl {MAX_PENDING_RESPONSES} {1}
+    set_instance_parameter_value ctrl {LINEWRAPBURSTS} {0}
+    set_instance_parameter_value ctrl {PIPELINE_COMMAND} {1}
+    set_instance_parameter_value ctrl {PIPELINE_RESPONSE} {1}
+
+    for { set i 0} { $i < $num_global_mems } {incr i} {
+      add_instance mem_org_mode$i mem_org_mode 10.0
+      set_instance_parameter_value mem_org_mode$i {WIDTH} {32}
+    }
+
+    add_instance clk_reset clock_source 17.1
+    set_instance_parameter_value clk_reset {clockFrequency} {100000000.0}
+    set_instance_parameter_value clk_reset {clockFrequencyKnown} {1}
+    set_instance_parameter_value clk_reset {resetSynchronousEdges} {DEASSERT}
+
+    add_instance irq_bridge_0 altera_irq_bridge 17.1
+    set_instance_parameter_value irq_bridge_0 {IRQ_WIDTH} {1}
+    set_instance_parameter_value irq_bridge_0 {IRQ_N} {0}
+
+    add_instance sw_reset_in altera_reset_bridge 17.1
+    set_instance_parameter_value sw_reset_in {ACTIVE_LOW_RESET} {0}
+    set_instance_parameter_value sw_reset_in {SYNCHRONOUS_EDGES} {deassert}
+    set_instance_parameter_value sw_reset_in {NUM_RESET_OUTPUTS} {1}
+
+    add_instance version_id_0 version_id 10.0
+    set_instance_parameter_value version_id_0 {WIDTH} {32}
+    
+    # For non-PR: legacy support
+    if {$rom_reconfigure_en == 1} {
+      set_instance_parameter_value version_id_0 {VERSION_ID} {-1598029822}
+    } else {
+      set_instance_parameter_value version_id_0 {VERSION_ID} {-1598029823}
+    }
+
+    add_instance reset_controller_sw altera_reset_controller 17.1
+    set_instance_parameter_value reset_controller_sw {NUM_RESET_INPUTS} {2}
+    set_instance_parameter_value reset_controller_sw {OUTPUT_RESET_SYNC_EDGES} {deassert}
+    set_instance_parameter_value reset_controller_sw {SYNC_DEPTH} {2}
+    set_instance_parameter_value reset_controller_sw {RESET_REQUEST_PRESENT} {0}
+    set_instance_parameter_value reset_controller_sw {RESET_REQ_WAIT_TIME} {1}
+    set_instance_parameter_value reset_controller_sw {MIN_RST_ASSERTION_TIME} {3}
+    set_instance_parameter_value reset_controller_sw {RESET_REQ_EARLY_DSRT_TIME} {1}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN0} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN1} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN2} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN3} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN4} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN5} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN6} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN7} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN8} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN9} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN10} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN11} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN12} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN13} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN14} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN15} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_INPUT} {0}
+
+    add_instance kernel_clk altera_clock_bridge 17.1
+    set_instance_parameter_value kernel_clk {EXPLICIT_CLOCK_RATE} {0.0}
+    set_instance_parameter_value kernel_clk {NUM_CLOCK_OUTPUTS} {1}
+
+    add_instance reset_bridge_0 altera_reset_bridge 17.1
+    set_instance_parameter_value reset_bridge_0 {ACTIVE_LOW_RESET} {1}
+    set_instance_parameter_value reset_bridge_0 {SYNCHRONOUS_EDGES} {deassert}
+    set_instance_parameter_value reset_bridge_0 {NUM_RESET_OUTPUTS} {1}
+
+    add_instance reset_bridge_1 altera_reset_bridge 17.1 
+    set_instance_parameter_value reset_bridge_1 {ACTIVE_LOW_RESET} {1}
+    set_instance_parameter_value reset_bridge_1 {SYNCHRONOUS_EDGES} {deassert}
+    set_instance_parameter_value reset_bridge_1 {NUM_RESET_OUTPUTS} {1}
+    
+    # For non-PR: legacy support
+    if {$rom_reconfigure_en != 1} {
+      add_instance sys_description_rom altera_avalon_onchip_memory2 17.1
+      set_instance_parameter_value sys_description_rom {allowInSystemMemoryContentEditor} {0}
+      set_instance_parameter_value sys_description_rom {blockType} {AUTO}
+      set_instance_parameter_value sys_description_rom {dataWidth} {64}
+      set_instance_parameter_value sys_description_rom {dualPort} {0}
+      set_instance_parameter_value sys_description_rom {initMemContent} {1}
+      set_instance_parameter_value sys_description_rom {initializationFileName} {sys_description}
+      set_instance_parameter_value sys_description_rom {instanceID} {NONE}
+      set_instance_parameter_value sys_description_rom {memorySize} {4096.0}
+      set_instance_parameter_value sys_description_rom {readDuringWriteMode} {DONT_CARE}
+      set_instance_parameter_value sys_description_rom {simAllowMRAMContentsFile} {0}
+      set_instance_parameter_value sys_description_rom {simMemInitOnlyFilename} {0}
+      set_instance_parameter_value sys_description_rom {singleClockOperation} {0}
+      set_instance_parameter_value sys_description_rom {slave1Latency} {2}
+      set_instance_parameter_value sys_description_rom {slave2Latency} {1}
+      set_instance_parameter_value sys_description_rom {useNonDefaultInitFile} {1}
+      set_instance_parameter_value sys_description_rom {useShallowMemBlocks} {0}
+      set_instance_parameter_value sys_description_rom {writable} {0}
+      set_instance_parameter_value sys_description_rom {ecc_enabled} {0}
+    }
+    # connections and connection parameters
+    add_connection clock_crosser.master kernel_cra.s0 avalon
+    set_connection_parameter_value clock_crosser.master/kernel_cra.s0 arbitrationPriority {1}
+    set_connection_parameter_value clock_crosser.master/kernel_cra.s0 baseAddress {0x0000}
+    set_connection_parameter_value clock_crosser.master/kernel_cra.s0 defaultConnection {0}
+
+    add_connection address_span_extender_0.expanded_master clock_crosser.slave avalon
+    set_connection_parameter_value address_span_extender_0.expanded_master/clock_crosser.slave arbitrationPriority {1}
+    set_connection_parameter_value address_span_extender_0.expanded_master/clock_crosser.slave baseAddress {0x0000}
+    set_connection_parameter_value address_span_extender_0.expanded_master/clock_crosser.slave defaultConnection {0}
+
+    add_connection ctrl.m0 address_span_extender_0.windowed_slave avalon
+    set_connection_parameter_value ctrl.m0/address_span_extender_0.windowed_slave arbitrationPriority {1}
+    set_connection_parameter_value ctrl.m0/address_span_extender_0.windowed_slave baseAddress {0x1000}
+    set_connection_parameter_value ctrl.m0/address_span_extender_0.windowed_slave defaultConnection {0}
+
+    add_connection ctrl.m0 address_span_extender_0.cntl avalon
+    set_connection_parameter_value ctrl.m0/address_span_extender_0.cntl arbitrationPriority {1}
+    set_connection_parameter_value ctrl.m0/address_span_extender_0.cntl baseAddress {0x0020}
+    set_connection_parameter_value ctrl.m0/address_span_extender_0.cntl defaultConnection {0}
+
+    # For non-PR: legacy support
+    if {$rom_reconfigure_en != 1} {
+      add_connection ctrl.m0 sys_description_rom.s1 avalon
+      set_connection_parameter_value ctrl.m0/sys_description_rom.s1 arbitrationPriority {1}
+      set_connection_parameter_value ctrl.m0/sys_description_rom.s1 baseAddress {0x2000}
+      set_connection_parameter_value ctrl.m0/sys_description_rom.s1 defaultConnection {0}
+    }
+
+    add_connection ctrl.m0 sw_reset.s avalon
+    set_connection_parameter_value ctrl.m0/sw_reset.s arbitrationPriority {1}
+    set_connection_parameter_value ctrl.m0/sw_reset.s baseAddress {0x0030}
+    set_connection_parameter_value ctrl.m0/sw_reset.s defaultConnection {0}
+
+    for { set i 0} { $i < $num_global_mems } {incr i} {
+      add_connection clk_reset.clk mem_org_mode$i.clk clock
+
+      add_connection clk_reset.clk_reset mem_org_mode$i.clk_reset reset
+
+
+      add_connection ctrl.m0 mem_org_mode$i.s avalon
+      set_connection_parameter_value ctrl.m0/mem_org_mode$i.s arbitrationPriority {1}
+      set_connection_parameter_value ctrl.m0/mem_org_mode$i.s baseAddress [get_config_addr $i]
+      set_connection_parameter_value ctrl.m0/mem_org_mode$i.s defaultConnection {0}
+    }
+
+    add_connection clk_reset.clk ctrl.clk clock
+
+    # For non-PR: legacy support
+    if {$rom_reconfigure_en != 1} {
+      add_connection clk_reset.clk sys_description_rom.clk1 clock
+    }
+
+    # hook up clock crosser clocks
+    add_connection kernel_clk.out_clk clock_crosser.master_clk clock
+    add_connection reset_bridge_0.out_reset clock_crosser.master_reset reset
+    add_connection clk_reset.clk clock_crosser.slave_clk clock
+
+    add_connection clk_reset.clk sw_reset.clk clock
+
+    add_connection clk_reset.clk_reset ctrl.reset reset
+
+    add_connection clk_reset.clk_reset address_span_extender_0.reset reset
+
+    # For non-PR: legacy support
+    if {$rom_reconfigure_en != 1} {
+      add_connection clk_reset.clk_reset sys_description_rom.reset1 reset
+    }
+
+    add_connection clk_reset.clk_reset sw_reset.clk_reset reset
+
+    add_connection clk_reset.clk sw_reset_in.clk clock
+
+    add_connection sw_reset_in.out_reset sw_reset.clk_reset reset
+
+    add_connection clk_reset.clk version_id_0.clk clock
+
+    add_connection clk_reset.clk address_span_extender_0.clock clock
+
+    add_connection clk_reset.clk_reset version_id_0.clk_reset reset
+
+    add_connection ctrl.m0 version_id_0.s avalon
+    set_connection_parameter_value ctrl.m0/version_id_0.s arbitrationPriority {1}
+    set_connection_parameter_value ctrl.m0/version_id_0.s baseAddress {0x0000}
+    set_connection_parameter_value ctrl.m0/version_id_0.s defaultConnection {0}
+
+    add_connection clk_reset.clk_reset reset_controller_sw.reset_in0 reset
+
+    add_connection sw_reset.sw_reset reset_controller_sw.reset_in1 reset
+
+    add_connection kernel_clk.out_clk kernel_cra.clk clock
+
+    add_connection kernel_clk.out_clk irq_bridge_0.clk clock
+
+    add_connection kernel_clk.out_clk reset_controller_sw.clk clock
+
+    add_connection kernel_clk.out_clk reset_bridge_0.clk clock
+
+    add_connection clk_reset.clk reset_bridge_1.clk clock
+
+    add_connection sw_reset.sw_reset reset_bridge_1.in_reset reset
+
+    add_connection reset_controller_sw.reset_out reset_bridge_0.in_reset reset
+
+    add_connection reset_controller_sw.reset_out irq_bridge_0.clk_reset reset
+
+    add_connection reset_controller_sw.reset_out kernel_cra.reset reset
+
+    # exported interfaces
+    add_interface clk clock sink
+    set_interface_property clk EXPORT_OF clk_reset.clk_in
+    add_interface reset reset sink
+    set_interface_property reset EXPORT_OF clk_reset.clk_in_reset
+    add_interface ctrl avalon slave
+    set_interface_property ctrl EXPORT_OF ctrl.s0
+    add_interface kernel_clk clock sink
+    set_interface_property kernel_clk EXPORT_OF kernel_clk.in_clk
+    add_interface kernel_cra avalon master
+    set_interface_property kernel_cra EXPORT_OF kernel_cra.m0
+    add_interface sw_reset_in reset sink
+    set_interface_property sw_reset_in EXPORT_OF sw_reset_in.in_reset
+    add_interface kernel_reset reset source
+    set_interface_property kernel_reset EXPORT_OF reset_bridge_0.out_reset
+    add_interface sw_reset_export reset source
+    set_interface_property sw_reset_export EXPORT_OF reset_bridge_1.out_reset
+    for { set i 0} { $i < $num_global_mems } {incr i} {
+      set suffix [get_config_addr $i]
+      ## These will be useful if we can dynamically switch addressing in kernel
+      ## interconnect. For now hide them.
+      #add_interface acl_bsp_memorg_kernel$suffix conduit end
+      #set_interface_property acl_bsp_memorg_kernel$suffix EXPORT_OF mem_org_mode$i.mem_organization_kernel
+      add_interface acl_bsp_memorg_host$suffix conduit end
+      set_interface_property acl_bsp_memorg_host$suffix EXPORT_OF mem_org_mode$i.mem_organization_host
+    }
+    add_interface kernel_irq_from_kernel interrupt receiver
+    set_interface_property kernel_irq_from_kernel EXPORT_OF irq_bridge_0.receiver_irq
+    add_interface kernel_irq_to_host interrupt sender
+    set_interface_property kernel_irq_to_host EXPORT_OF irq_bridge_0.sender0_irq
+
+    # interconnect requirements
+    set_interconnect_requirement {$system} {qsys_mm.clockCrossingAdapter} {FIFO}
+    set_interconnect_requirement {$system} {qsys_mm.maxAdditionalLatency} {4}
+}
+
+# Whitelist Parameters
+set parameter_upgrade_map {
+  {PARAMETER }\
+  {NUM_GLOBAL_MEMS }\
+
+}
+
+proc upgrade {ip_name ip_version old_params param_map } {
+  set declared_param_list [get_parameters]
+
+  set headers       [lindex $param_map 0]
+  set parameter_index [lsearch $headers "PARAMETER"]
+
+  if { [expr {$parameter_index == -1 }] } {
+   send_message Error "Internal Error \[ip_upgrade\] invalid headers in param_map: ${param_map}"
+   return
+  }
+  
+  if {$ip_version < 15.1} {
+    set_parameter_value ENABLE_ROM_RECONFIGURE 0
+  }
+  foreach {param_name param_value} $old_params {
+    for {set i 1 } { $i < [llength $param_map] } { incr i } {
+      set data [lindex $param_map $i]
+      set parameter [lindex $data $parameter_index]
+      if {$parameter == $param_name} {
+        set_parameter_value $param_name $param_value
+      }
+    }
+  }
+}
+proc ip_upgrade {ip_name version old_params} {
+  variable parameter_upgrade_map
+  upgrade $ip_name $version $old_params $parameter_upgrade_map
+}

--- a/n6001/hardware/ofs_n6001_usm/build/ip/memory_bank_divider_hw.tcl
+++ b/n6001/hardware/ofs_n6001_usm/build/ip/memory_bank_divider_hw.tcl
@@ -1,14 +1,14 @@
 package require -exact qsys 17.0
 
 # module properties
-set_module_property NAME {acl_memory_bank_divider}
-set_module_property DISPLAY_NAME {OpenCL Memory Bank Divider}
+set_module_property NAME {memory_bank_divider}
+set_module_property DISPLAY_NAME {oneAPI Memory Bank Divider}
 
 # default module properties
-set_module_property VERSION {21.3}
-set_module_property GROUP {OpenCL BSP Components}
-set_module_property DESCRIPTION {default description}
-set_module_property AUTHOR {author}
+set_module_property VERSION {23.2}
+set_module_property GROUP {oneAPI ASP Components}
+set_module_property DESCRIPTION {Handles multiple global memory banks}
+set_module_property AUTHOR {OFS}
 
 # Set the name of the procedure to manipulate parameters
 set_module_property COMPOSITION_CALLBACK compose

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/board.qsys
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/board.qsys
@@ -253,7 +253,7 @@ https://fpgasoftware.intel.com/eula.-->
          type = "int";
       }
    }
-   element kernel_interface_agilex_0
+   element kernel_interface
    {
       datum _sortIndex
       {
@@ -261,7 +261,7 @@ https://fpgasoftware.intel.com/eula.-->
          type = "int";
       }
    }
-   element kernel_interface_agilex_0.ctrl
+   element kernel_interface.ctrl
    {
       datum baseAddress
       {
@@ -382,7 +382,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='board_afu_id_avmm_slave_0.afu_cfg_slave' start='0x0' end='0x40' datawidth='64' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Read_Slave' start='0x100' end='0x104' datawidth='32' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Mask_Slave' start='0x108' end='0x10C' datawidth='32' /&amp;gt;&amp;lt;slave name='kernel_interface_agilex_0.ctrl' start='0x4000' end='0x8000' datawidth='32' /&amp;gt;&amp;lt;slave name='pipe_stage_dma_csr.s0' start='0x20000' end='0x20800' datawidth='64' /&amp;gt;&amp;lt;slave name='pipe_stage_uoe_csr.s0' start='0x20800' end='0x21000' datawidth='64' /&amp;gt;&amp;lt;slave name='ddr_board.null_dfh_id' start='0x21000' end='0x21040' datawidth='64' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='board_afu_id_avmm_slave_0.afu_cfg_slave' start='0x0' end='0x40' datawidth='64' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Read_Slave' start='0x100' end='0x104' datawidth='32' /&amp;gt;&amp;lt;slave name='board_irq_ctrl_0.IRQ_Mask_Slave' start='0x108' end='0x10C' datawidth='32' /&amp;gt;&amp;lt;slave name='kernel_interface.ctrl' start='0x4000' end='0x8000' datawidth='32' /&amp;gt;&amp;lt;slave name='pipe_stage_dma_csr.s0' start='0x20000' end='0x20800' datawidth='64' /&amp;gt;&amp;lt;slave name='pipe_stage_uoe_csr.s0' start='0x20800' end='0x21000' datawidth='64' /&amp;gt;&amp;lt;slave name='ddr_board.null_dfh_id' start='0x21000' end='0x21040' datawidth='64' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
@@ -10958,7 +10958,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:module altera:enabled="true" altera:auto_export="false">
         <altera:entity_info>
           <ipxact:vendor>Altera Corporation</ipxact:vendor>
-          <ipxact:library>kernel_interface_agilex_0</ipxact:library>
+          <ipxact:library>kernel_interface</ipxact:library>
           <ipxact:name>altera_generic_component</ipxact:name>
           <ipxact:version>1.0</ipxact:version>
         </altera:entity_info>
@@ -11684,7 +11684,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;bridgesToReceiver&lt;/key&gt;
-                            &lt;value&gt;kernel_interface_agilex_0.kernel_irq_from_kernel&lt;/value&gt;
+                            &lt;value&gt;kernel_interface.kernel_irq_from_kernel&lt;/value&gt;
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;irqScheme&lt;/key&gt;
@@ -11839,9 +11839,9 @@ https://fpgasoftware.intel.com/eula.-->
         &lt;/interfaces&gt;
     &lt;/boundary&gt;
     &lt;originalModuleInfo&gt;
-        &lt;className&gt;kernel_interface_agilex&lt;/className&gt;
-        &lt;version&gt;17.1&lt;/version&gt;
-        &lt;displayName&gt;OpenCL Kernel Interface for Agilex&lt;/displayName&gt;
+        &lt;className&gt;kernel_interface&lt;/className&gt;
+        &lt;version&gt;23.2&lt;/version&gt;
+        &lt;displayName&gt;oneAPI Kernel Interface&lt;/displayName&gt;
     &lt;/originalModuleInfo&gt;
     &lt;systemInfoParameterDescriptors&gt;
         &lt;descriptors&gt;
@@ -12607,7 +12607,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;bridgesToReceiver&lt;/key&gt;
-                        &lt;value&gt;kernel_interface_agilex_0.kernel_irq_from_kernel&lt;/value&gt;
+                        &lt;value&gt;kernel_interface.kernel_irq_from_kernel&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;irqScheme&lt;/key&gt;
@@ -12766,35 +12766,35 @@ https://fpgasoftware.intel.com/eula.-->
               <ipxact:name>generationInfoDefinition</ipxact:name>
               <ipxact:displayName>Generation Behavior</ipxact:displayName>
               <ipxact:value>&lt;generationInfoDefinition&gt;
-    &lt;hdlLibraryName&gt;board_kernel_interface_agilex_0&lt;/hdlLibraryName&gt;
+    &lt;hdlLibraryName&gt;board_kernel_interface&lt;/hdlLibraryName&gt;
     &lt;fileSets&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_agilex_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_agilex_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;QUARTUS_SYNTH&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_agilex_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_agilex_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VERILOG&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_agilex_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_agilex_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_agilex_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_agilex_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;board_kernel_interface_agilex_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;board_kernel_interface_agilex_0&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;board_kernel_interface&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;board_kernel_interface&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;CDC_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
@@ -12814,7 +12814,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:parameter parameterId="logicalView" type="string">
               <ipxact:name>logicalView</ipxact:name>
               <ipxact:displayName>Logical view</ipxact:displayName>
-              <ipxact:value>ip/board/board_kernel_interface_agilex_0.ip</ipxact:value>
+              <ipxact:value>ip/board/board_kernel_interface.ip</ipxact:value>
             </ipxact:parameter>
             <ipxact:parameter parameterId="moduleAssignmentDefinition" type="string">
               <ipxact:name>moduleAssignmentDefinition</ipxact:name>
@@ -16991,7 +16991,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:module>
     </altera:modules>
     <altera:connections>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="kernel_interface_agilex_0.kernel_cra" altera:end="board_kernel_cra_pipe.s0">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="kernel_interface.kernel_cra" altera:end="board_kernel_cra_pipe.s0">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -17075,7 +17075,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="pipe_stage_host_ctrl.m0" altera:end="kernel_interface_agilex_0.ctrl">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="pipe_stage_host_ctrl.m0" altera:end="kernel_interface.ctrl">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x4000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -17165,7 +17165,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="board_kernel_cra_reset.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="board_kernel_cra_pipe.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="pipe_stage_dma_csr.clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="kernel_interface_agilex_0.clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="kernel_interface.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="pipe_stage_uoe_csr.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="kernel_clk_export.clk_in"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="board_afu_id_avmm_slave_0.clock"></altera:connection>
@@ -17175,19 +17175,19 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="emif_ddr4d_clk.out_clk" altera:end="ddr_board.ddr_clk_d"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="clk_200.out_clk" altera:end="ddr_board.host_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="ddr_board.kernel_clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="kernel_interface_agilex_0.kernel_clk"></altera:connection>
-      <altera:connection altera:kind="conduit" altera:version="23.1" altera:start="kernel_interface_agilex_0.acl_bsp_memorg_host0x018" altera:end="ddr_board.acl_bsp_memorg_host">
+      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk_in.out_clk" altera:end="kernel_interface.kernel_clk"></altera:connection>
+      <altera:connection altera:kind="conduit" altera:version="23.1" altera:start="kernel_interface.acl_bsp_memorg_host0x018" altera:end="ddr_board.acl_bsp_memorg_host">
         <altera:connection_parameter altera:parameter_name="endPort" altera:parameter_value=""></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="endPortLSB" altera:parameter_value="0"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="startPort" altera:parameter_value=""></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="startPortLSB" altera:parameter_value="0"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="width" altera:parameter_value="0"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="interrupt" altera:version="23.1" altera:start="board_irq_ctrl_0.interrupt_receiver" altera:end="kernel_interface_agilex_0.kernel_irq_to_host">
+      <altera:connection altera:kind="interrupt" altera:version="23.1" altera:start="board_irq_ctrl_0.interrupt_receiver" altera:end="kernel_interface.kernel_irq_to_host">
         <altera:connection_parameter altera:parameter_name="irqNumber" altera:parameter_value="0"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_interface_agilex_0.kernel_reset" altera:end="kernel_clk_export.clk_in_reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_interface_agilex_0.kernel_reset" altera:end="ddr_board.kernel_reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_interface.kernel_reset" altera:end="kernel_clk_export.clk_in_reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_interface.kernel_reset" altera:end="ddr_board.kernel_reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="board_irq_ctrl_0.Resetn"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="ddr_board.global_reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="board_kernel_cra_reset.in_reset"></altera:connection>
@@ -17195,9 +17195,9 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="pipe_stage_host_ctrl.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="board_kernel_cra_reset.out_reset" altera:end="board_kernel_cra_pipe.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="pipe_stage_dma_csr.reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="kernel_interface_agilex_0.reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="kernel_interface.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="pipe_stage_uoe_csr.reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="kernel_interface_agilex_0.sw_reset_in"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset_in.out_reset" altera:end="kernel_interface.sw_reset_in"></altera:connection>
     </altera:connections>
     <altera:interconnect_requirements></altera:interconnect_requirements>
     <altera:wire_level_connections></altera:wire_level_connections>
@@ -17227,7 +17227,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:interface_mapping altera:name="kernel_ddr4b" altera:internal="ddr_board.kernel_ddr4b" altera:type="avalon" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="kernel_ddr4c" altera:internal="ddr_board.kernel_ddr4c" altera:type="avalon" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="kernel_ddr4d" altera:internal="ddr_board.kernel_ddr4d" altera:type="avalon" altera:dir="end"></altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_irq" altera:internal="kernel_interface_agilex_0.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start"></altera:interface_mapping>
+      <altera:interface_mapping altera:name="kernel_irq" altera:internal="kernel_interface.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start"></altera:interface_mapping>
       <altera:interface_mapping altera:name="kernel_reset" altera:internal="kernel_clk_export.clk_reset" altera:type="reset" altera:dir="start"></altera:interface_mapping>
       <altera:interface_mapping altera:name="uoe_csr_mmio64" altera:internal="pipe_stage_uoe_csr.m0" altera:type="avalon" altera:dir="start"></altera:interface_mapping>
     </altera:altera_interface_boundary>
@@ -17248,10 +17248,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>kernel_interface_agilex_0.kernel_cra</ipxact:name>
+            <ipxact:name>kernel_interface.kernel_cra</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="kernel_interface_agilex_0.kernel_cra">
+              <ipxact:addressSpaceRef addressSpaceRef="kernel_interface.kernel_cra">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -17274,7 +17274,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>kernel_interface_agilex_0.ctrl</ipxact:name>
+            <ipxact:name>kernel_interface.ctrl</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -17326,7 +17326,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:busInterfaces>
         <ipxact:addressSpaces>
           <ipxact:addressSpace>
-            <ipxact:name>kernel_interface_agilex_0.kernel_cra</ipxact:name>
+            <ipxact:name>kernel_interface.kernel_cra</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>board_kernel_cra_pipe.s0</ipxact:name>
@@ -17354,7 +17354,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:range>0x0000_0040</ipxact:range>
               </ipxact:segment>
               <ipxact:segment>
-                <ipxact:name>kernel_interface_agilex_0.ctrl</ipxact:name>
+                <ipxact:name>kernel_interface.ctrl</ipxact:name>
                 <ipxact:addressOffset>0x0000_4000</ipxact:addressOffset>
                 <ipxact:range>0x0000_4000</ipxact:range>
               </ipxact:segment>

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/ddr_board.qsys
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/ddr_board.qsys
@@ -51,7 +51,7 @@ https://fpgasoftware.intel.com/eula.-->
          type = "int";
       }
    }
-   element acl_memory_bank_divider_0
+   element memory_bank_divider
    {
       datum _sortIndex
       {
@@ -416,7 +416,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='acl_memory_bank_divider_0.s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='memory_bank_divider.s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
@@ -437,7 +437,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;consumedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_MAP&lt;/key&gt;
-                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='acl_memory_bank_divider_0.s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
+                        &lt;value&gt;&amp;lt;address-map&amp;gt;&amp;lt;slave name='memory_bank_divider.s' start='0x0' end='0x400000000' datawidth='512' /&amp;gt;&amp;lt;/address-map&amp;gt;&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;ADDRESS_WIDTH&lt;/key&gt;
@@ -2092,7 +2092,7 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:module altera:enabled="true" altera:auto_export="false">
         <altera:entity_info>
           <ipxact:vendor>Altera Corporation</ipxact:vendor>
-          <ipxact:library>acl_memory_bank_divider_0</ipxact:library>
+          <ipxact:library>memory_bank_divider</ipxact:library>
           <ipxact:name>altera_generic_component</ipxact:name>
           <ipxact:version>1.0</ipxact:version>
         </altera:entity_info>
@@ -3632,9 +3632,9 @@ https://fpgasoftware.intel.com/eula.-->
         &lt;/interfaces&gt;
     &lt;/boundary&gt;
     &lt;originalModuleInfo&gt;
-        &lt;className&gt;acl_memory_bank_divider&lt;/className&gt;
-        &lt;version&gt;21.3&lt;/version&gt;
-        &lt;displayName&gt;OpenCL Memory Bank Divider&lt;/displayName&gt;
+        &lt;className&gt;memory_bank_divider&lt;/className&gt;
+        &lt;version&gt;23.2&lt;/version&gt;
+        &lt;displayName&gt;oneAPI Memory Bank Divider&lt;/displayName&gt;
     &lt;/originalModuleInfo&gt;
     &lt;systemInfoParameterDescriptors&gt;
         &lt;descriptors&gt;
@@ -5206,29 +5206,29 @@ https://fpgasoftware.intel.com/eula.-->
               <ipxact:name>generationInfoDefinition</ipxact:name>
               <ipxact:displayName>Generation Behavior</ipxact:displayName>
               <ipxact:value>&lt;generationInfoDefinition&gt;
-    &lt;hdlLibraryName&gt;ddr_board_acl_memory_bank_divider_1&lt;/hdlLibraryName&gt;
+    &lt;hdlLibraryName&gt;ddr_board_memory_bank_divider&lt;/hdlLibraryName&gt;
     &lt;fileSets&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;QUARTUS_SYNTH&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VERILOG&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
         &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_memory_bank_divider_1&lt;/fileSetFixedName&gt;
+            &lt;fileSetName&gt;ddr_board_memory_bank_divider&lt;/fileSetName&gt;
+            &lt;fileSetFixedName&gt;ddr_board_memory_bank_divider&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
@@ -5248,7 +5248,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:parameter parameterId="logicalView" type="string">
               <ipxact:name>logicalView</ipxact:name>
               <ipxact:displayName>Logical view</ipxact:displayName>
-              <ipxact:value>ip/ddr_board/ddr_board_acl_memory_bank_divider_1.ip</ipxact:value>
+              <ipxact:value>ip/ddr_board/ddr_board_memory_bank_divider.ip</ipxact:value>
             </ipxact:parameter>
             <ipxact:parameter parameterId="moduleAssignmentDefinition" type="string">
               <ipxact:name>moduleAssignmentDefinition</ipxact:name>
@@ -16491,7 +16491,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:module>
     </altera:modules>
     <altera:connections>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_memory_bank_divider_0.bank1" altera:end="ddr_channel_a.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="memory_bank_divider.bank1" altera:end="ddr_channel_a.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16512,7 +16512,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_memory_bank_divider_0.bank2" altera:end="ddr_channel_b.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="memory_bank_divider.bank2" altera:end="ddr_channel_b.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16533,7 +16533,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_memory_bank_divider_0.bank3" altera:end="ddr_channel_c.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="memory_bank_divider.bank3" altera:end="ddr_channel_c.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16554,7 +16554,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_memory_bank_divider_0.bank4" altera:end="ddr_channel_d.ddr4_pipe_to_bankdiv">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="memory_bank_divider.bank4" altera:end="ddr_channel_d.ddr4_pipe_to_bankdiv">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16575,7 +16575,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="TRUE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_avalon_mm_bridge_s10_1.m0" altera:end="acl_memory_bank_divider_0.s">
+      <altera:connection altera:kind="avalon" altera:version="23.1" altera:start="acl_avalon_mm_bridge_s10_1.m0" altera:end="memory_bank_divider.s">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -16640,7 +16640,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="kernel_reset.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="global_reset.clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="acl_memory_bank_divider_0.clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="memory_bank_divider.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="dma_localmem_rd_pipe.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="dma_localmem_wr_pipe.clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="acl_avalon_mm_bridge_s10_1.clk"></altera:connection>
@@ -16653,13 +16653,13 @@ https://fpgasoftware.intel.com/eula.-->
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="ddr_channel_b.host_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="ddr_channel_c.host_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="host_clk.out_clk" altera:end="ddr_channel_d.host_clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="acl_memory_bank_divider_0.kernel_clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="memory_bank_divider.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_a.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_b.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_c.kernel_clk"></altera:connection>
       <altera:connection altera:kind="clock" altera:version="23.1" altera:start="kernel_clk.out_clk" altera:end="ddr_channel_d.kernel_clk"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_reset.out_reset" altera:end="acl_memory_bank_divider_0.kernel_reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="acl_memory_bank_divider_0.reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="kernel_reset.out_reset" altera:end="memory_bank_divider.kernel_reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="memory_bank_divider.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="null_dfh_inst.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="dma_localmem_wr_pipe.reset"></altera:connection>
       <altera:connection altera:kind="reset" altera:version="23.1" altera:start="global_reset.out_reset" altera:end="dma_localmem_rd_pipe.reset"></altera:connection>
@@ -16675,7 +16675,7 @@ https://fpgasoftware.intel.com/eula.-->
     <altera:hdl_parameter_mappings></altera:hdl_parameter_mappings>
     <altera:preserved_ports_for_debug></altera:preserved_ports_for_debug>
     <altera:altera_interface_boundary>
-      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="acl_memory_bank_divider_0.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end"></altera:interface_mapping>
+      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="memory_bank_divider.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="ddr_clk_a" altera:internal="ddr_clk_a.in_clk" altera:type="clock" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="ddr_clk_b" altera:internal="ddr_clk_b.in_clk" altera:type="clock" altera:dir="end"></altera:interface_mapping>
       <altera:interface_mapping altera:name="ddr_clk_c" altera:internal="ddr_clk_c.in_clk" altera:type="clock" altera:dir="end"></altera:interface_mapping>
@@ -16708,10 +16708,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank1</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank1</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank1">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank1">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -16721,10 +16721,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank2</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank2</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank2">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank2">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -16734,10 +16734,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank3</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank3</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank3">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank3">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -16747,10 +16747,10 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.bank4</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank4</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="acl_memory_bank_divider_0.bank4">
+              <ipxact:addressSpaceRef addressSpaceRef="memory_bank_divider.bank4">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -16760,7 +16760,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+            <ipxact:name>memory_bank_divider.s</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -16777,7 +16777,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+            <ipxact:name>memory_bank_divider.s</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -16790,7 +16790,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:master>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+            <ipxact:name>memory_bank_divider.s</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
@@ -16825,7 +16825,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:busInterfaces>
         <ipxact:addressSpaces>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank1</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank1</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_a.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -16835,7 +16835,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank2</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank2</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_b.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -16845,7 +16845,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank3</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank3</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_c.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -16855,7 +16855,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>acl_memory_bank_divider_0.bank4</ipxact:name>
+            <ipxact:name>memory_bank_divider.bank4</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>ddr_channel_d.ddr4_pipe_to_bankdiv</ipxact:name>
@@ -16873,7 +16873,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>
               <ipxact:segment>
-                <ipxact:name>acl_memory_bank_divider_0.s via acl_avalon_mm_bridge_s10_1</ipxact:name>
+                <ipxact:name>memory_bank_divider.s via acl_avalon_mm_bridge_s10_1</ipxact:name>
                 <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>
@@ -16888,7 +16888,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>
               <ipxact:segment>
-                <ipxact:name>acl_memory_bank_divider_0.s via acl_avalon_mm_bridge_s10_1</ipxact:name>
+                <ipxact:name>memory_bank_divider.s via acl_avalon_mm_bridge_s10_1</ipxact:name>
                 <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>
@@ -16898,7 +16898,7 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:name>acl_avalon_mm_bridge_s10_1.m0</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
-                <ipxact:name>acl_memory_bank_divider_0.s</ipxact:name>
+                <ipxact:name>memory_bank_divider.s</ipxact:name>
                 <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
                 <ipxact:range>0x0000_0004_0000_0000</ipxact:range>
               </ipxact:segment>

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/hw_iface.iipx
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/hw_iface.iipx
@@ -194,94 +194,6 @@
   <tag2 key="TCL_PACKAGE_VERSION" value="10.0" />
  </component>
  <component
-   name="acl_kernel_clk"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/iface/acl_kernel_clk.qsys"
-   displayName="OpenCL Kernel Clock Generator"
-   version="1.0"
-   description="Generates the kernel clocks for ACL"
-   tags="INTERNAL_COMPONENT=false"
-   categories="OpenCL BSP Components"
-   factory="QsysFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPONENT_HIDE_FROM_QUARTUS" value="true" />
- </component>
- <component
-   name="acl_kernel_clk_a10"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_clk_a10_hw.tcl"
-   displayName="OpenCL A10 Kernel Clock Generator"
-   version="16.1"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="comp" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="16.1" />
- </component>
- <component
-   name="acl_kernel_clk_noreconfig"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/iface/acl_kernel_clk_noreconfig.qsys"
-   displayName="OpenCL Kernel Clock Generator - no Dynamic Reconfig"
-   version="1.0"
-   description="Generates the kernel clocks for ACL"
-   tags="INTERNAL_COMPONENT=false"
-   categories="OpenCL BSP Components"
-   factory="QsysFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPONENT_HIDE_FROM_QUARTUS" value="true" />
- </component>
- <component
-   name="acl_kernel_clk_s10"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_clk_s10_hw.tcl"
-   displayName="OpenCL S10 Kernel Clock Generator"
-   version="17.0"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="comp" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="16.1" />
- </component>
- <component
-   name="acl_kernel_clk_s10_reconfig"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_clk_s10_reconfig_hw.tcl"
-   displayName="OpenCL S10 reconfigurable kernel clock generator"
-   version="17.0"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="comp" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="16.1" />
- </component>
- <component
-   name="acl_kernel_interface_soc"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/iface/acl_kernel_interface_soc.qsys"
-   displayName="acl_kernel_interface_soc"
-   version="1.0"
-   description="ACL Kernel Interface"
-   tags=""
-   categories="ACL BSP Components"
-   factory="QsysFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPONENT_HIDE_FROM_QUARTUS" value="true" />
- </component>
- <component
-   name="acl_memory_bank_divider"
-   file="./ip/acl_memory_bank_divider_hw.tcl"
-   displayName="OpenCL Memory Bank Divider"
-   version="21.3"
-   description="default description"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="compose" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="17.0" />
- </component>
- <component
    name="acl_snoop_adapter"
    file="${INTELFPGAOCLSDKROOT}/ip/board/export/snoop_adapter_hw.tcl"
    displayName="Avalon Snoop Adapter"
@@ -709,36 +621,6 @@
   <tag2 key="OPAQUE_ADDRESS_MAP" value="true" />
   <tag2 key="SUPPORTED_FILE_SETS" value="QUARTUS_SYNTH,SIM_VERILOG" />
   <tag2 key="TCL_PACKAGE_VERSION" value="12.1" />
- </component>
- <component
-   name="kernel_interface"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_interface_hw.tcl"
-   displayName="OpenCL Kernel Interface"
-   version="15.1"
-   description="Connects the OpenCL host to the FPGA kernel"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="compose" />
-  <tag2 key="OPAQUE_ADDRESS_MAP" value="false" />
-  <tag2 key="PARAMETER_UPGRADE_CALLBACK" value="ip_upgrade" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="13.1" />
- </component>
- <component
-   name="kernel_interface_s10"
-   file="${INTELFPGAOCLSDKROOT}/ip/board/bsp/acl_kernel_interface_s10_hw.tcl"
-   displayName="OpenCL Kernel Interface for S10"
-   version="17.1"
-   description="Connects the OpenCL host to the FPGA kernel"
-   tags="AUTHORSHIP=author"
-   categories="OpenCL BSP Components"
-   factory="TclModuleFactory">
-  <tag2 key="COMPONENT_EDITABLE" value="false" />
-  <tag2 key="COMPOSITION_CALLBACK" value="compose" />
-  <tag2 key="OPAQUE_ADDRESS_MAP" value="false" />
-  <tag2 key="PARAMETER_UPGRADE_CALLBACK" value="ip_upgrade" />
-  <tag2 key="TCL_PACKAGE_VERSION" value="17.0" />
  </component>
  <component
    name="mem_org_mode"

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/ip/board/board_kernel_interface.ip
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/ip/board/board_kernel_interface.ip
@@ -14,16 +14,16 @@ refer to the applicable agreement for further details, at
 https://fpgasoftware.intel.com/eula.-->
 <ipxact:component xmlns:altera="http://www.altera.com/XMLSchema/IPXact2014/extensions" xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2014">
   <ipxact:vendor>author</ipxact:vendor>
-  <ipxact:library>board_kernel_interface_s10_0</ipxact:library>
-  <ipxact:name>kernel_interface_s10_0</ipxact:name>
-  <ipxact:version>17.1</ipxact:version>
+  <ipxact:library>board_kernel_interface</ipxact:library>
+  <ipxact:name>kernel_interface</ipxact:name>
+  <ipxact:version>23.2</ipxact:version>
   <ipxact:busInterfaces>
     <ipxact:busInterface>
       <ipxact:name>kernel_cra</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -284,10 +284,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>ctrl</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -605,10 +605,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>acl_bsp_memorg_host0x018</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="conduit" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="conduit" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="conduit" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="conduit" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -642,10 +642,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -689,10 +689,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -731,10 +731,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_irq_from_kernel</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -778,10 +778,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_irq_to_host</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -819,7 +819,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="bridgesToReceiver" type="string">
           <ipxact:name>bridgesToReceiver</ipxact:name>
           <ipxact:displayName>Bridges to receiver</ipxact:displayName>
-          <ipxact:value>board_kernel_interface_s10_0.kernel_irq_from_kernel</ipxact:value>
+          <ipxact:value>board_kernel_interface.kernel_irq_from_kernel</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="irqScheme" type="string">
           <ipxact:name>irqScheme</ipxact:name>
@@ -830,10 +830,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>sw_reset_in</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -862,10 +862,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -899,10 +899,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -941,10 +941,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>sw_reset_export</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="22.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="22.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -993,11 +993,10 @@ https://fpgasoftware.intel.com/eula.-->
     <ipxact:instantiations>
       <ipxact:componentInstantiation>
         <ipxact:name>QUARTUS_SYNTH</ipxact:name>
-        <ipxact:moduleName>kernel_interface_s10</ipxact:moduleName>
+        <ipxact:moduleName>kernel_interface</ipxact:moduleName>
         <ipxact:fileSetRef>
           <ipxact:localName>QUARTUS_SYNTH</ipxact:localName>
         </ipxact:fileSetRef>
-        <ipxact:parameters></ipxact:parameters>
       </ipxact:componentInstantiation>
     </ipxact:instantiations>
     <ipxact:ports>
@@ -1005,7 +1004,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_waitrequest</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1036,7 +1034,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_readdatavalid</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1049,7 +1046,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_burstcount</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC_VECTOR</ipxact:typeName>
@@ -1098,7 +1094,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_write</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1111,7 +1106,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_read</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1142,7 +1136,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_cra_debugaccess</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1155,7 +1148,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_waitrequest</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1186,7 +1178,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_readdatavalid</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1199,7 +1190,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_burstcount</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC_VECTOR</ipxact:typeName>
@@ -1248,7 +1238,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_write</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1261,7 +1250,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_read</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1292,7 +1280,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>ctrl_debugaccess</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1323,7 +1310,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>clk_clk</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1336,7 +1322,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>reset_reset_n</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1349,7 +1334,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_irq_from_kernel_irq</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC_VECTOR</ipxact:typeName>
@@ -1362,7 +1346,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_irq_to_host_irq</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1375,7 +1358,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>sw_reset_in_reset</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1388,7 +1370,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_clk_clk</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1401,7 +1382,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>kernel_reset_reset_n</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1414,7 +1394,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:name>sw_reset_export_reset_n</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
-          <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
               <ipxact:typeName>STD_LOGIC</ipxact:typeName>
@@ -1428,9 +1407,9 @@ https://fpgasoftware.intel.com/eula.-->
   <ipxact:vendorExtensions>
     <altera:entity_info>
       <ipxact:vendor>author</ipxact:vendor>
-      <ipxact:library>board_kernel_interface_s10_0</ipxact:library>
-      <ipxact:name>kernel_interface_s10</ipxact:name>
-      <ipxact:version>17.1</ipxact:version>
+      <ipxact:library>board_kernel_interface</ipxact:library>
+      <ipxact:name>kernel_interface</ipxact:name>
+      <ipxact:version>23.2</ipxact:version>
     </altera:entity_info>
     <altera:altera_module_parameters>
       <ipxact:parameters>
@@ -1447,12 +1426,12 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="AUTO_DEVICE_FAMILY" type="string">
           <ipxact:name>AUTO_DEVICE_FAMILY</ipxact:name>
           <ipxact:displayName>Auto DEVICE_FAMILY</ipxact:displayName>
-          <ipxact:value>Stratix 10</ipxact:value>
+          <ipxact:value>Agilex</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE" type="string">
           <ipxact:name>AUTO_DEVICE</ipxact:name>
           <ipxact:displayName>Auto DEVICE</ipxact:displayName>
-          <ipxact:value>1SX280HN2F43E2VG</ipxact:value>
+          <ipxact:value>AGFB014R24A2E2V</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_DEVICE_SPEEDGRADE" type="string">
           <ipxact:name>AUTO_DEVICE_SPEEDGRADE</ipxact:name>
@@ -1466,17 +1445,17 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="board" type="string">
           <ipxact:name>board</ipxact:name>
           <ipxact:displayName>Board</ipxact:displayName>
-          <ipxact:value>default</ipxact:value>
+          <ipxact:value>Unknown</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="device" type="string">
           <ipxact:name>device</ipxact:name>
           <ipxact:displayName>Device</ipxact:displayName>
-          <ipxact:value>1SX280HN2F43E2VG</ipxact:value>
+          <ipxact:value>AGFB014R24A2E2V</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="deviceFamily" type="string">
           <ipxact:name>deviceFamily</ipxact:name>
           <ipxact:displayName>Device family</ipxact:displayName>
-          <ipxact:value>Stratix 10</ipxact:value>
+          <ipxact:value>Agilex</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="deviceSpeedGrade" type="string">
           <ipxact:name>deviceSpeedGrade</ipxact:name>
@@ -1493,17 +1472,6 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:displayName>bonusData</ipxact:displayName>
           <ipxact:value>bonusData 
 {
-   element $system
-   {
-      datum _originalDeviceFamily
-      {
-         value = "Stratix 10";
-         type = "String";
-      }
-   }
-   element kernel_interface_s10_0
-   {
-   }
 }
 </ipxact:value>
         </ipxact:parameter>
@@ -2227,7 +2195,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;bridgesToReceiver&lt;/key&gt;
-                        &lt;value&gt;board_kernel_interface_s10_0.kernel_irq_from_kernel&lt;/value&gt;
+                        &lt;value&gt;board_kernel_interface.kernel_irq_from_kernel&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;irqScheme&lt;/key&gt;
@@ -2411,21 +2379,16 @@ https://fpgasoftware.intel.com/eula.-->
     &lt;/connPtSystemInfos&gt;
 &lt;/systemInfosDefinition&gt;</ipxact:value>
         </ipxact:parameter>
-        <ipxact:parameter parameterId="pinAssignmentListDefinition" type="string">
-          <ipxact:name>pinAssignmentListDefinition</ipxact:name>
-          <ipxact:displayName>pinAssignmentListDefinition</ipxact:displayName>
-          <ipxact:value>&lt;pinAssignmentListDefinition/&gt;</ipxact:value>
-        </ipxact:parameter>
       </ipxact:parameters>
     </altera:altera_system_parameters>
     <altera:altera_interface_boundary>
-      <altera:interface_mapping altera:name="acl_bsp_memorg_host0x018" altera:internal="kernel_interface_s10_0.acl_bsp_memorg_host0x018" altera:type="conduit" altera:dir="end">
+      <altera:interface_mapping altera:name="acl_bsp_memorg_host0x018" altera:internal="kernel_interface.acl_bsp_memorg_host0x018" altera:type="conduit" altera:dir="end">
         <altera:port_mapping altera:name="acl_bsp_memorg_host0x018_mode" altera:internal="acl_bsp_memorg_host0x018_mode"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="clk" altera:internal="kernel_interface_s10_0.clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="clk" altera:internal="kernel_interface.clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="clk_clk" altera:internal="clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="ctrl" altera:internal="kernel_interface_s10_0.ctrl" altera:type="avalon" altera:dir="end">
+      <altera:interface_mapping altera:name="ctrl" altera:internal="kernel_interface.ctrl" altera:type="avalon" altera:dir="end">
         <altera:port_mapping altera:name="ctrl_address" altera:internal="ctrl_address"></altera:port_mapping>
         <altera:port_mapping altera:name="ctrl_burstcount" altera:internal="ctrl_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="ctrl_byteenable" altera:internal="ctrl_byteenable"></altera:port_mapping>
@@ -2437,10 +2400,10 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="ctrl_write" altera:internal="ctrl_write"></altera:port_mapping>
         <altera:port_mapping altera:name="ctrl_writedata" altera:internal="ctrl_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_clk" altera:internal="kernel_interface_s10_0.kernel_clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_clk" altera:internal="kernel_interface.kernel_clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="kernel_clk_clk" altera:internal="kernel_clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_cra" altera:internal="kernel_interface_s10_0.kernel_cra" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="kernel_cra" altera:internal="kernel_interface.kernel_cra" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="kernel_cra_address" altera:internal="kernel_cra_address"></altera:port_mapping>
         <altera:port_mapping altera:name="kernel_cra_burstcount" altera:internal="kernel_cra_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="kernel_cra_byteenable" altera:internal="kernel_cra_byteenable"></altera:port_mapping>
@@ -2452,22 +2415,22 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="kernel_cra_write" altera:internal="kernel_cra_write"></altera:port_mapping>
         <altera:port_mapping altera:name="kernel_cra_writedata" altera:internal="kernel_cra_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_irq_from_kernel" altera:internal="kernel_interface_s10_0.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start">
+      <altera:interface_mapping altera:name="kernel_irq_from_kernel" altera:internal="kernel_interface.kernel_irq_from_kernel" altera:type="interrupt" altera:dir="start">
         <altera:port_mapping altera:name="kernel_irq_from_kernel_irq" altera:internal="kernel_irq_from_kernel_irq"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_irq_to_host" altera:internal="kernel_interface_s10_0.kernel_irq_to_host" altera:type="interrupt" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_irq_to_host" altera:internal="kernel_interface.kernel_irq_to_host" altera:type="interrupt" altera:dir="end">
         <altera:port_mapping altera:name="kernel_irq_to_host_irq" altera:internal="kernel_irq_to_host_irq"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_reset" altera:internal="kernel_interface_s10_0.kernel_reset" altera:type="reset" altera:dir="start">
+      <altera:interface_mapping altera:name="kernel_reset" altera:internal="kernel_interface.kernel_reset" altera:type="reset" altera:dir="start">
         <altera:port_mapping altera:name="kernel_reset_reset_n" altera:internal="kernel_reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="reset" altera:internal="kernel_interface_s10_0.reset" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="reset" altera:internal="kernel_interface.reset" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="reset_reset_n" altera:internal="reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="sw_reset_export" altera:internal="kernel_interface_s10_0.sw_reset_export" altera:type="reset" altera:dir="start">
+      <altera:interface_mapping altera:name="sw_reset_export" altera:internal="kernel_interface.sw_reset_export" altera:type="reset" altera:dir="start">
         <altera:port_mapping altera:name="sw_reset_export_reset_n" altera:internal="sw_reset_export_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="sw_reset_in" altera:internal="kernel_interface_s10_0.sw_reset_in" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="sw_reset_in" altera:internal="kernel_interface.sw_reset_in" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="sw_reset_in_reset" altera:internal="sw_reset_in_reset"></altera:port_mapping>
       </altera:interface_mapping>
     </altera:altera_interface_boundary>
@@ -2480,52 +2443,52 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:busInterfaces>
           <ipxact:busInterface>
             <ipxact:name>kernel_cra.s0</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>clock_crosser.slave</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>address_span_extender_0.windowed_slave</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>address_span_extender_0.cntl</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>sw_reset.s</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>ctrl.s0</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>mem_org_mode0.s</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>version_id_0.s</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:slave></ipxact:slave>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>kernel_cra.m0</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:master></ipxact:master>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>clock_crosser.master</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:master>
               <ipxact:addressSpaceRef addressSpaceRef="clock_crosser.master">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
@@ -2534,7 +2497,7 @@ https://fpgasoftware.intel.com/eula.-->
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>address_span_extender_0.expanded_master</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:master>
               <ipxact:addressSpaceRef addressSpaceRef="address_span_extender_0.expanded_master">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
@@ -2543,7 +2506,7 @@ https://fpgasoftware.intel.com/eula.-->
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>ctrl.m0</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.1"></ipxact:busType>
             <ipxact:master>
               <ipxact:addressSpaceRef addressSpaceRef="ctrl.m0">
                 <ipxact:baseAddress>0x1000</ipxact:baseAddress>

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/ip/ddr_board/ddr_board_memory_bank_divider.ip
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/ip/ddr_board/ddr_board_memory_bank_divider.ip
@@ -14,9 +14,9 @@ refer to the applicable agreement for further details, at
 https://fpgasoftware.intel.com/eula.-->
 <ipxact:component xmlns:altera="http://www.altera.com/XMLSchema/IPXact2014/extensions" xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2014">
   <ipxact:vendor>author</ipxact:vendor>
-  <ipxact:library>ddr_board_acl_memory_bank_divider_1</ipxact:library>
-  <ipxact:name>acl_memory_bank_divider_1</ipxact:name>
-  <ipxact:version>21.3</ipxact:version>
+  <ipxact:library>ddr_board_memory_bank_divider</ipxact:library>
+  <ipxact:name>memory_bank_divider</ipxact:name>
+  <ipxact:version>23.2</ipxact:version>
   <ipxact:busInterfaces>
     <ipxact:busInterface>
       <ipxact:name>clk</ipxact:name>
@@ -1722,7 +1722,7 @@ https://fpgasoftware.intel.com/eula.-->
     <ipxact:instantiations>
       <ipxact:componentInstantiation>
         <ipxact:name>QUARTUS_SYNTH</ipxact:name>
-        <ipxact:moduleName>acl_memory_bank_divider</ipxact:moduleName>
+        <ipxact:moduleName>memory_bank_divider</ipxact:moduleName>
         <ipxact:fileSetRef>
           <ipxact:localName>QUARTUS_SYNTH</ipxact:localName>
         </ipxact:fileSetRef>
@@ -2611,9 +2611,9 @@ https://fpgasoftware.intel.com/eula.-->
   <ipxact:vendorExtensions>
     <altera:entity_info>
       <ipxact:vendor>author</ipxact:vendor>
-      <ipxact:library>ddr_board_acl_memory_bank_divider_1</ipxact:library>
-      <ipxact:name>acl_memory_bank_divider</ipxact:name>
-      <ipxact:version>21.3</ipxact:version>
+      <ipxact:library>ddr_board_memory_bank_divider</ipxact:library>
+      <ipxact:name>memory_bank_divider</ipxact:name>
+      <ipxact:version>23.2</ipxact:version>
     </altera:entity_info>
     <altera:altera_module_parameters>
       <ipxact:parameters>
@@ -2719,7 +2719,7 @@ https://fpgasoftware.intel.com/eula.-->
          type = "String";
       }
    }
-   element acl_memory_bank_divider_1
+   element memory_bank_divider
    {
       datum _originalVersion
       {
@@ -4284,15 +4284,15 @@ https://fpgasoftware.intel.com/eula.-->
       </ipxact:parameters>
     </altera:altera_system_parameters>
     <altera:altera_interface_boundary>
-      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="acl_memory_bank_divider_1.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end">
+      <altera:interface_mapping altera:name="acl_bsp_memorg_host" altera:internal="memory_bank_divider.acl_bsp_memorg_host" altera:type="conduit" altera:dir="end">
         <altera:port_mapping altera:name="acl_bsp_memorg_host_mode" altera:internal="acl_bsp_memorg_host_mode"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="acl_bsp_snoop" altera:internal="acl_memory_bank_divider_1.acl_bsp_snoop" altera:type="avalon_streaming" altera:dir="start">
+      <altera:interface_mapping altera:name="acl_bsp_snoop" altera:internal="memory_bank_divider.acl_bsp_snoop" altera:type="avalon_streaming" altera:dir="start">
         <altera:port_mapping altera:name="acl_bsp_snoop_data" altera:internal="acl_bsp_snoop_data"></altera:port_mapping>
         <altera:port_mapping altera:name="acl_bsp_snoop_ready" altera:internal="acl_bsp_snoop_ready"></altera:port_mapping>
         <altera:port_mapping altera:name="acl_bsp_snoop_valid" altera:internal="acl_bsp_snoop_valid"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank1" altera:internal="acl_memory_bank_divider_1.bank1" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank1" altera:internal="memory_bank_divider.bank1" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank1_address" altera:internal="bank1_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank1_burstcount" altera:internal="bank1_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank1_byteenable" altera:internal="bank1_byteenable"></altera:port_mapping>
@@ -4304,7 +4304,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank1_write" altera:internal="bank1_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank1_writedata" altera:internal="bank1_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank2" altera:internal="acl_memory_bank_divider_1.bank2" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank2" altera:internal="memory_bank_divider.bank2" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank2_address" altera:internal="bank2_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank2_burstcount" altera:internal="bank2_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank2_byteenable" altera:internal="bank2_byteenable"></altera:port_mapping>
@@ -4316,7 +4316,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank2_write" altera:internal="bank2_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank2_writedata" altera:internal="bank2_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank3" altera:internal="acl_memory_bank_divider_1.bank3" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank3" altera:internal="memory_bank_divider.bank3" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank3_address" altera:internal="bank3_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank3_burstcount" altera:internal="bank3_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank3_byteenable" altera:internal="bank3_byteenable"></altera:port_mapping>
@@ -4328,7 +4328,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank3_write" altera:internal="bank3_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank3_writedata" altera:internal="bank3_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="bank4" altera:internal="acl_memory_bank_divider_1.bank4" altera:type="avalon" altera:dir="start">
+      <altera:interface_mapping altera:name="bank4" altera:internal="memory_bank_divider.bank4" altera:type="avalon" altera:dir="start">
         <altera:port_mapping altera:name="bank4_address" altera:internal="bank4_address"></altera:port_mapping>
         <altera:port_mapping altera:name="bank4_burstcount" altera:internal="bank4_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="bank4_byteenable" altera:internal="bank4_byteenable"></altera:port_mapping>
@@ -4340,19 +4340,19 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:port_mapping altera:name="bank4_write" altera:internal="bank4_write"></altera:port_mapping>
         <altera:port_mapping altera:name="bank4_writedata" altera:internal="bank4_writedata"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="clk" altera:internal="acl_memory_bank_divider_1.clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="clk" altera:internal="memory_bank_divider.clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="clk_clk" altera:internal="clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_clk" altera:internal="acl_memory_bank_divider_1.kernel_clk" altera:type="clock" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_clk" altera:internal="memory_bank_divider.kernel_clk" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="kernel_clk_clk" altera:internal="kernel_clk_clk"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="kernel_reset" altera:internal="acl_memory_bank_divider_1.kernel_reset" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="kernel_reset" altera:internal="memory_bank_divider.kernel_reset" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="kernel_reset_reset_n" altera:internal="kernel_reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="reset" altera:internal="acl_memory_bank_divider_1.reset" altera:type="reset" altera:dir="end">
+      <altera:interface_mapping altera:name="reset" altera:internal="memory_bank_divider.reset" altera:type="reset" altera:dir="end">
         <altera:port_mapping altera:name="reset_reset_n" altera:internal="reset_reset_n"></altera:port_mapping>
       </altera:interface_mapping>
-      <altera:interface_mapping altera:name="s" altera:internal="acl_memory_bank_divider_1.s" altera:type="avalon" altera:dir="end">
+      <altera:interface_mapping altera:name="s" altera:internal="memory_bank_divider.s" altera:type="avalon" altera:dir="end">
         <altera:port_mapping altera:name="s_address" altera:internal="s_address"></altera:port_mapping>
         <altera:port_mapping altera:name="s_burstcount" altera:internal="s_burstcount"></altera:port_mapping>
         <altera:port_mapping altera:name="s_byteenable" altera:internal="s_byteenable"></altera:port_mapping>

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/ip/kernel_interface_hw.tcl
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/ip/kernel_interface_hw.tcl
@@ -1,0 +1,383 @@
+# (c) 1992-2020 Intel Corporation.                            
+# Intel, the Intel logo, Intel, MegaCore, NIOS II, Quartus and TalkBack words    
+# and logos are trademarks of Intel Corporation or its subsidiaries in the U.S.  
+# and/or other countries. Other marks and brands may be claimed as the property  
+# of others. See Trademarks on intel.com for full list of Intel trademarks or    
+# the Trademarks & Brands Names Database (if Intel) or See www.Intel.com/legal (if Altera) 
+# Your use of Intel Corporation's design tools, logic functions and other        
+# software and tools, and its AMPP partner logic functions, and any output       
+# files any of the foregoing (including device programming or simulation         
+# files), and any associated documentation or information are expressly subject  
+# to the terms and conditions of the Altera Program License Subscription         
+# Agreement, Intel MegaCore Function License Agreement, or other applicable      
+# license agreement, including, without limitation, that your use is for the     
+# sole purpose of programming logic devices manufactured by Intel and sold by    
+# Intel or its authorized distributors.  Please refer to the applicable          
+# agreement for further details.                                                 
+package require -exact qsys 17.0
+
+# module properties
+set_module_property NAME {kernel_interface}
+set_module_property DISPLAY_NAME {oneAPI Kernel Interface}
+
+# default module properties
+set_module_property VERSION {23.2}
+set_module_property GROUP {oneAPI ASP Components}
+set_module_property DESCRIPTION {Connects the oneAPI host to the FPGA kernel}
+set_module_property AUTHOR {OFS}
+
+set_module_property COMPOSITION_CALLBACK compose
+set_module_property opaque_address_map false
+set_module_property PARAMETER_UPGRADE_CALLBACK ip_upgrade
+
+# +-----------------------------------
+# | parameters
+# | 
+add_parameter NUM_GLOBAL_MEMS INTEGER 1
+set_parameter_property NUM_GLOBAL_MEMS DEFAULT_VALUE 1
+set_parameter_property NUM_GLOBAL_MEMS DISPLAY_NAME "Number of global memory systems"
+set_parameter_property NUM_GLOBAL_MEMS AFFECTS_ELABORATION true
+
+add_parameter ENABLE_ROM_RECONFIGURE INTEGER 1
+set_parameter_property ENABLE_ROM_RECONFIGURE DEFAULT_VALUE 1
+set_parameter_property ENABLE_ROM_RECONFIGURE DISPLAY_NAME "Enable sys description rom PR"
+#set_parameter_property ENABLE_ROM_RECONFIGURE AFFECTS_ELABORATION false
+set_parameter_property ENABLE_ROM_RECONFIGURE VISIBLE false
+# | 
+# +-----------------------------------
+
+proc get_config_addr { i } {
+  if { $i == 0 } {
+    return [format 0x%03X 24 ]
+  } else {
+    return [format 0x%03X [ expr 256 + (($i -1) * 4) ] ]
+  }
+}
+
+proc compose { } {
+    set num_global_mems [ get_parameter_value NUM_GLOBAL_MEMS ]
+    set rom_reconfigure_en [get_parameter_value ENABLE_ROM_RECONFIGURE]
+
+    if { $num_global_mems > 6 } {
+      send_message -error "Can't have more than 6 global memories"
+    }
+
+    # Instances and instance parameters
+    # (disabled instances are intentionally culled)
+    add_instance kernel_cra acl_avalon_mm_bridge_s10 17.1
+    set_instance_parameter_value kernel_cra {DATA_WIDTH} {64}
+    set_instance_parameter_value kernel_cra {SYMBOL_WIDTH} {8}
+    set_instance_parameter_value kernel_cra {ADDRESS_WIDTH} {30}
+    set_instance_parameter_value kernel_cra {ADDRESS_UNITS} {SYMBOLS}
+    set_instance_parameter_value kernel_cra {MAX_BURST_SIZE} {1}
+    set_instance_parameter_value kernel_cra {MAX_PENDING_RESPONSES} {1}
+    set_instance_parameter_value kernel_cra {LINEWRAPBURSTS} {0}
+    set_instance_parameter_value kernel_cra {SYNCHRONIZE_RESET} {1}
+    set_instance_parameter_value kernel_cra {DISABLE_WAITREQUEST_BUFFERING} {1}
+
+    add_instance clock_crosser acl_clock_crossing_bridge 1.0
+    set_instance_parameter_value clock_crosser {ADDRESS_WIDTH} {30}
+    set_instance_parameter_value clock_crosser {DATA_WIDTH} {64}
+    set_instance_parameter_value clock_crosser {BURSTCOUNT_WIDTH} {1}
+    set_instance_parameter_value clock_crosser {BYTEENABLE_WIDTH} {8}
+    set_instance_parameter_value clock_crosser {CMD_DCFIFO_MIN_DEPTH} {8}
+    set_instance_parameter_value clock_crosser {RSP_DCFIFO_MIN_DEPTH} {8}
+    set_instance_parameter_value clock_crosser {SLAVE_STALL_LATENCY} {0}
+    set_instance_parameter_value clock_crosser {MASTER_STALL_LATENCY} {1}
+    set_instance_parameter_value clock_crosser {USE_WRITE_ACK} {0}
+
+    add_instance address_span_extender_0 altera_address_span_extender 17.1
+    set_instance_parameter_value address_span_extender_0 {DATA_WIDTH} {64}
+    set_instance_parameter_value address_span_extender_0 {MASTER_ADDRESS_WIDTH} {30}
+    set_instance_parameter_value address_span_extender_0 {SLAVE_ADDRESS_WIDTH} {9}
+    set_instance_parameter_value address_span_extender_0 {BURSTCOUNT_WIDTH} {1}
+    set_instance_parameter_value address_span_extender_0 {SUB_WINDOW_COUNT} {1}
+    set_instance_parameter_value address_span_extender_0 {MASTER_ADDRESS_DEF} {0}
+    set_instance_parameter_value address_span_extender_0 {ENABLE_SLAVE_PORT} {1}
+    set_instance_parameter_value address_span_extender_0 {MAX_PENDING_READS} {1}
+
+    add_instance sw_reset sw_reset 10.0
+    set_instance_parameter_value sw_reset {WIDTH} {64}
+    set_instance_parameter_value sw_reset {LOG2_RESET_CYCLES} {4}
+
+    add_instance ctrl altera_avalon_mm_bridge 17.1
+    set_instance_parameter_value ctrl {DATA_WIDTH} {32}
+    set_instance_parameter_value ctrl {SYMBOL_WIDTH} {8}
+    set_instance_parameter_value ctrl {ADDRESS_WIDTH} {14}
+    set_instance_parameter_value ctrl {ADDRESS_UNITS} {SYMBOLS}
+    set_instance_parameter_value ctrl {MAX_BURST_SIZE} {1}
+    set_instance_parameter_value ctrl {MAX_PENDING_RESPONSES} {1}
+    set_instance_parameter_value ctrl {LINEWRAPBURSTS} {0}
+    set_instance_parameter_value ctrl {PIPELINE_COMMAND} {1}
+    set_instance_parameter_value ctrl {PIPELINE_RESPONSE} {1}
+
+    for { set i 0} { $i < $num_global_mems } {incr i} {
+      add_instance mem_org_mode$i mem_org_mode 10.0
+      set_instance_parameter_value mem_org_mode$i {WIDTH} {32}
+    }
+
+    add_instance clk_reset clock_source 17.1
+    set_instance_parameter_value clk_reset {clockFrequency} {100000000.0}
+    set_instance_parameter_value clk_reset {clockFrequencyKnown} {1}
+    set_instance_parameter_value clk_reset {resetSynchronousEdges} {DEASSERT}
+
+    add_instance irq_bridge_0 altera_irq_bridge 17.1
+    set_instance_parameter_value irq_bridge_0 {IRQ_WIDTH} {1}
+    set_instance_parameter_value irq_bridge_0 {IRQ_N} {0}
+
+    add_instance sw_reset_in altera_reset_bridge 17.1
+    set_instance_parameter_value sw_reset_in {ACTIVE_LOW_RESET} {0}
+    set_instance_parameter_value sw_reset_in {SYNCHRONOUS_EDGES} {deassert}
+    set_instance_parameter_value sw_reset_in {NUM_RESET_OUTPUTS} {1}
+
+    add_instance version_id_0 version_id 10.0
+    set_instance_parameter_value version_id_0 {WIDTH} {32}
+    
+    # For non-PR: legacy support
+    if {$rom_reconfigure_en == 1} {
+      set_instance_parameter_value version_id_0 {VERSION_ID} {-1598029822}
+    } else {
+      set_instance_parameter_value version_id_0 {VERSION_ID} {-1598029823}
+    }
+
+    add_instance reset_controller_sw altera_reset_controller 17.1
+    set_instance_parameter_value reset_controller_sw {NUM_RESET_INPUTS} {2}
+    set_instance_parameter_value reset_controller_sw {OUTPUT_RESET_SYNC_EDGES} {deassert}
+    set_instance_parameter_value reset_controller_sw {SYNC_DEPTH} {2}
+    set_instance_parameter_value reset_controller_sw {RESET_REQUEST_PRESENT} {0}
+    set_instance_parameter_value reset_controller_sw {RESET_REQ_WAIT_TIME} {1}
+    set_instance_parameter_value reset_controller_sw {MIN_RST_ASSERTION_TIME} {3}
+    set_instance_parameter_value reset_controller_sw {RESET_REQ_EARLY_DSRT_TIME} {1}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN0} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN1} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN2} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN3} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN4} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN5} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN6} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN7} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN8} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN9} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN10} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN11} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN12} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN13} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN14} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_IN15} {0}
+    set_instance_parameter_value reset_controller_sw {USE_RESET_REQUEST_INPUT} {0}
+
+    add_instance kernel_clk altera_clock_bridge 17.1
+    set_instance_parameter_value kernel_clk {EXPLICIT_CLOCK_RATE} {0.0}
+    set_instance_parameter_value kernel_clk {NUM_CLOCK_OUTPUTS} {1}
+
+    add_instance reset_bridge_0 altera_reset_bridge 17.1
+    set_instance_parameter_value reset_bridge_0 {ACTIVE_LOW_RESET} {1}
+    set_instance_parameter_value reset_bridge_0 {SYNCHRONOUS_EDGES} {deassert}
+    set_instance_parameter_value reset_bridge_0 {NUM_RESET_OUTPUTS} {1}
+
+    add_instance reset_bridge_1 altera_reset_bridge 17.1 
+    set_instance_parameter_value reset_bridge_1 {ACTIVE_LOW_RESET} {1}
+    set_instance_parameter_value reset_bridge_1 {SYNCHRONOUS_EDGES} {deassert}
+    set_instance_parameter_value reset_bridge_1 {NUM_RESET_OUTPUTS} {1}
+    
+    # For non-PR: legacy support
+    if {$rom_reconfigure_en != 1} {
+      add_instance sys_description_rom altera_avalon_onchip_memory2 17.1
+      set_instance_parameter_value sys_description_rom {allowInSystemMemoryContentEditor} {0}
+      set_instance_parameter_value sys_description_rom {blockType} {AUTO}
+      set_instance_parameter_value sys_description_rom {dataWidth} {64}
+      set_instance_parameter_value sys_description_rom {dualPort} {0}
+      set_instance_parameter_value sys_description_rom {initMemContent} {1}
+      set_instance_parameter_value sys_description_rom {initializationFileName} {sys_description}
+      set_instance_parameter_value sys_description_rom {instanceID} {NONE}
+      set_instance_parameter_value sys_description_rom {memorySize} {4096.0}
+      set_instance_parameter_value sys_description_rom {readDuringWriteMode} {DONT_CARE}
+      set_instance_parameter_value sys_description_rom {simAllowMRAMContentsFile} {0}
+      set_instance_parameter_value sys_description_rom {simMemInitOnlyFilename} {0}
+      set_instance_parameter_value sys_description_rom {singleClockOperation} {0}
+      set_instance_parameter_value sys_description_rom {slave1Latency} {2}
+      set_instance_parameter_value sys_description_rom {slave2Latency} {1}
+      set_instance_parameter_value sys_description_rom {useNonDefaultInitFile} {1}
+      set_instance_parameter_value sys_description_rom {useShallowMemBlocks} {0}
+      set_instance_parameter_value sys_description_rom {writable} {0}
+      set_instance_parameter_value sys_description_rom {ecc_enabled} {0}
+    }
+    # connections and connection parameters
+    add_connection clock_crosser.master kernel_cra.s0 avalon
+    set_connection_parameter_value clock_crosser.master/kernel_cra.s0 arbitrationPriority {1}
+    set_connection_parameter_value clock_crosser.master/kernel_cra.s0 baseAddress {0x0000}
+    set_connection_parameter_value clock_crosser.master/kernel_cra.s0 defaultConnection {0}
+
+    add_connection address_span_extender_0.expanded_master clock_crosser.slave avalon
+    set_connection_parameter_value address_span_extender_0.expanded_master/clock_crosser.slave arbitrationPriority {1}
+    set_connection_parameter_value address_span_extender_0.expanded_master/clock_crosser.slave baseAddress {0x0000}
+    set_connection_parameter_value address_span_extender_0.expanded_master/clock_crosser.slave defaultConnection {0}
+
+    add_connection ctrl.m0 address_span_extender_0.windowed_slave avalon
+    set_connection_parameter_value ctrl.m0/address_span_extender_0.windowed_slave arbitrationPriority {1}
+    set_connection_parameter_value ctrl.m0/address_span_extender_0.windowed_slave baseAddress {0x1000}
+    set_connection_parameter_value ctrl.m0/address_span_extender_0.windowed_slave defaultConnection {0}
+
+    add_connection ctrl.m0 address_span_extender_0.cntl avalon
+    set_connection_parameter_value ctrl.m0/address_span_extender_0.cntl arbitrationPriority {1}
+    set_connection_parameter_value ctrl.m0/address_span_extender_0.cntl baseAddress {0x0020}
+    set_connection_parameter_value ctrl.m0/address_span_extender_0.cntl defaultConnection {0}
+
+    # For non-PR: legacy support
+    if {$rom_reconfigure_en != 1} {
+      add_connection ctrl.m0 sys_description_rom.s1 avalon
+      set_connection_parameter_value ctrl.m0/sys_description_rom.s1 arbitrationPriority {1}
+      set_connection_parameter_value ctrl.m0/sys_description_rom.s1 baseAddress {0x2000}
+      set_connection_parameter_value ctrl.m0/sys_description_rom.s1 defaultConnection {0}
+    }
+
+    add_connection ctrl.m0 sw_reset.s avalon
+    set_connection_parameter_value ctrl.m0/sw_reset.s arbitrationPriority {1}
+    set_connection_parameter_value ctrl.m0/sw_reset.s baseAddress {0x0030}
+    set_connection_parameter_value ctrl.m0/sw_reset.s defaultConnection {0}
+
+    for { set i 0} { $i < $num_global_mems } {incr i} {
+      add_connection clk_reset.clk mem_org_mode$i.clk clock
+
+      add_connection clk_reset.clk_reset mem_org_mode$i.clk_reset reset
+
+
+      add_connection ctrl.m0 mem_org_mode$i.s avalon
+      set_connection_parameter_value ctrl.m0/mem_org_mode$i.s arbitrationPriority {1}
+      set_connection_parameter_value ctrl.m0/mem_org_mode$i.s baseAddress [get_config_addr $i]
+      set_connection_parameter_value ctrl.m0/mem_org_mode$i.s defaultConnection {0}
+    }
+
+    add_connection clk_reset.clk ctrl.clk clock
+
+    # For non-PR: legacy support
+    if {$rom_reconfigure_en != 1} {
+      add_connection clk_reset.clk sys_description_rom.clk1 clock
+    }
+
+    # hook up clock crosser clocks
+    add_connection kernel_clk.out_clk clock_crosser.master_clk clock
+    add_connection reset_bridge_0.out_reset clock_crosser.master_reset reset
+    add_connection clk_reset.clk clock_crosser.slave_clk clock
+
+    add_connection clk_reset.clk sw_reset.clk clock
+
+    add_connection clk_reset.clk_reset ctrl.reset reset
+
+    add_connection clk_reset.clk_reset address_span_extender_0.reset reset
+
+    # For non-PR: legacy support
+    if {$rom_reconfigure_en != 1} {
+      add_connection clk_reset.clk_reset sys_description_rom.reset1 reset
+    }
+
+    add_connection clk_reset.clk_reset sw_reset.clk_reset reset
+
+    add_connection clk_reset.clk sw_reset_in.clk clock
+
+    add_connection sw_reset_in.out_reset sw_reset.clk_reset reset
+
+    add_connection clk_reset.clk version_id_0.clk clock
+
+    add_connection clk_reset.clk address_span_extender_0.clock clock
+
+    add_connection clk_reset.clk_reset version_id_0.clk_reset reset
+
+    add_connection ctrl.m0 version_id_0.s avalon
+    set_connection_parameter_value ctrl.m0/version_id_0.s arbitrationPriority {1}
+    set_connection_parameter_value ctrl.m0/version_id_0.s baseAddress {0x0000}
+    set_connection_parameter_value ctrl.m0/version_id_0.s defaultConnection {0}
+
+    add_connection clk_reset.clk_reset reset_controller_sw.reset_in0 reset
+
+    add_connection sw_reset.sw_reset reset_controller_sw.reset_in1 reset
+
+    add_connection kernel_clk.out_clk kernel_cra.clk clock
+
+    add_connection kernel_clk.out_clk irq_bridge_0.clk clock
+
+    add_connection kernel_clk.out_clk reset_controller_sw.clk clock
+
+    add_connection kernel_clk.out_clk reset_bridge_0.clk clock
+
+    add_connection clk_reset.clk reset_bridge_1.clk clock
+
+    add_connection sw_reset.sw_reset reset_bridge_1.in_reset reset
+
+    add_connection reset_controller_sw.reset_out reset_bridge_0.in_reset reset
+
+    add_connection reset_controller_sw.reset_out irq_bridge_0.clk_reset reset
+
+    add_connection reset_controller_sw.reset_out kernel_cra.reset reset
+
+    # exported interfaces
+    add_interface clk clock sink
+    set_interface_property clk EXPORT_OF clk_reset.clk_in
+    add_interface reset reset sink
+    set_interface_property reset EXPORT_OF clk_reset.clk_in_reset
+    add_interface ctrl avalon slave
+    set_interface_property ctrl EXPORT_OF ctrl.s0
+    add_interface kernel_clk clock sink
+    set_interface_property kernel_clk EXPORT_OF kernel_clk.in_clk
+    add_interface kernel_cra avalon master
+    set_interface_property kernel_cra EXPORT_OF kernel_cra.m0
+    add_interface sw_reset_in reset sink
+    set_interface_property sw_reset_in EXPORT_OF sw_reset_in.in_reset
+    add_interface kernel_reset reset source
+    set_interface_property kernel_reset EXPORT_OF reset_bridge_0.out_reset
+    add_interface sw_reset_export reset source
+    set_interface_property sw_reset_export EXPORT_OF reset_bridge_1.out_reset
+    for { set i 0} { $i < $num_global_mems } {incr i} {
+      set suffix [get_config_addr $i]
+      ## These will be useful if we can dynamically switch addressing in kernel
+      ## interconnect. For now hide them.
+      #add_interface acl_bsp_memorg_kernel$suffix conduit end
+      #set_interface_property acl_bsp_memorg_kernel$suffix EXPORT_OF mem_org_mode$i.mem_organization_kernel
+      add_interface acl_bsp_memorg_host$suffix conduit end
+      set_interface_property acl_bsp_memorg_host$suffix EXPORT_OF mem_org_mode$i.mem_organization_host
+    }
+    add_interface kernel_irq_from_kernel interrupt receiver
+    set_interface_property kernel_irq_from_kernel EXPORT_OF irq_bridge_0.receiver_irq
+    add_interface kernel_irq_to_host interrupt sender
+    set_interface_property kernel_irq_to_host EXPORT_OF irq_bridge_0.sender0_irq
+
+    # interconnect requirements
+    set_interconnect_requirement {$system} {qsys_mm.clockCrossingAdapter} {FIFO}
+    set_interconnect_requirement {$system} {qsys_mm.maxAdditionalLatency} {4}
+}
+
+# Whitelist Parameters
+set parameter_upgrade_map {
+  {PARAMETER }\
+  {NUM_GLOBAL_MEMS }\
+
+}
+
+proc upgrade {ip_name ip_version old_params param_map } {
+  set declared_param_list [get_parameters]
+
+  set headers       [lindex $param_map 0]
+  set parameter_index [lsearch $headers "PARAMETER"]
+
+  if { [expr {$parameter_index == -1 }] } {
+   send_message Error "Internal Error \[ip_upgrade\] invalid headers in param_map: ${param_map}"
+   return
+  }
+  
+  if {$ip_version < 15.1} {
+    set_parameter_value ENABLE_ROM_RECONFIGURE 0
+  }
+  foreach {param_name param_value} $old_params {
+    for {set i 1 } { $i < [llength $param_map] } { incr i } {
+      set data [lindex $param_map $i]
+      set parameter [lindex $data $parameter_index]
+      if {$parameter == $param_name} {
+        set_parameter_value $param_name $param_value
+      }
+    }
+  }
+}
+proc ip_upgrade {ip_name version old_params} {
+  variable parameter_upgrade_map
+  upgrade $ip_name $version $old_params $parameter_upgrade_map
+}

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/ip/memory_bank_divider_hw.tcl
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/ip/memory_bank_divider_hw.tcl
@@ -1,14 +1,14 @@
 package require -exact qsys 17.0
 
 # module properties
-set_module_property NAME {acl_memory_bank_divider}
-set_module_property DISPLAY_NAME {OpenCL Memory Bank Divider}
+set_module_property NAME {memory_bank_divider}
+set_module_property DISPLAY_NAME {oneAPI Memory Bank Divider}
 
 # default module properties
-set_module_property VERSION {21.3}
-set_module_property GROUP {OpenCL BSP Components}
-set_module_property DESCRIPTION {default description}
-set_module_property AUTHOR {author}
+set_module_property VERSION {23.2}
+set_module_property GROUP {oneAPI ASP Components}
+set_module_property DESCRIPTION {Handles multiple global memory banks}
+set_module_property AUTHOR {OFS}
 
 # Set the name of the procedure to manipulate parameters
 set_module_property COMPOSITION_CALLBACK compose


### PR DESCRIPTION
### Description
This change commonizes the kernel interface and memory bank divider IP use for all D5005 and N6001 board variants.
It also changes removes some references to "OpenCL" and "acl" as well as cleans up the .ip files.

### Collateral (docs, reports, design examples, case IDs):


### Tests added:
none

### Tests run:
- compiled and ran in HW on D5005:

ofs_d5005:
anr
board_test
cholesky
cholesky_inversion
db
decompress
double_buffering
gzip
merge_sort
mvdr_beamforming
qrd
qri

ofs_d5005_usm:
simple_host_streaming
buffered_host_streaming
explicit_data_movement
zero_copy_data_transfer

- compiled and ran in HW on N6001:

ofs_n6001:
anr
board_test
cholesky
cholesky_inversion
db
decompress
double_buffering (known PCIe hang with new FIM, to be investigated)
gzip (known PCIe hang with new FIM, to be investigated)
merge_sort
mvdr_beamforming
qrd (with kernel clock at 450MHz instead of 600MHz)
qri

ofs_n6001_usm:
simple_host_streaming
buffered_host_streaming
explicit_data_movement
zero_copy_data_transfer

