### PR TITLE
[Update] more cleanup between D5005 and N6001 board variants

### DIFF
--- a/d5005/hardware/ofs_d5005/build/board.qsys
+++ b/d5005/hardware/ofs_d5005/build/board.qsys
@@ -6525,7 +6525,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingReadTransactions&lt;/key&gt;
-                            &lt;value&gt;256&lt;/value&gt;
+                            &lt;value&gt;512&lt;/value&gt;
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingWriteTransactions&lt;/key&gt;
@@ -7048,7 +7048,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingReadTransactions&lt;/key&gt;
-                            &lt;value&gt;256&lt;/value&gt;
+                            &lt;value&gt;512&lt;/value&gt;
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingWriteTransactions&lt;/key&gt;
@@ -7571,7 +7571,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingReadTransactions&lt;/key&gt;
-                            &lt;value&gt;256&lt;/value&gt;
+                            &lt;value&gt;512&lt;/value&gt;
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingWriteTransactions&lt;/key&gt;
@@ -8094,7 +8094,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingReadTransactions&lt;/key&gt;
-                            &lt;value&gt;256&lt;/value&gt;
+                            &lt;value&gt;512&lt;/value&gt;
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingWriteTransactions&lt;/key&gt;

--- a/d5005/hardware/ofs_d5005/build/ddr_board.qsys
+++ b/d5005/hardware/ofs_d5005/build/ddr_board.qsys
@@ -4595,7 +4595,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingReadTransactions&lt;/key&gt;
-                            &lt;value&gt;256&lt;/value&gt;
+                            &lt;value&gt;512&lt;/value&gt;
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingWriteTransactions&lt;/key&gt;
@@ -5862,7 +5862,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingReadTransactions&lt;/key&gt;
-                            &lt;value&gt;16&lt;/value&gt;
+                            &lt;value&gt;512&lt;/value&gt;
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingWriteTransactions&lt;/key&gt;
@@ -7129,7 +7129,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingReadTransactions&lt;/key&gt;
-                            &lt;value&gt;16&lt;/value&gt;
+                            &lt;value&gt;512&lt;/value&gt;
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingWriteTransactions&lt;/key&gt;
@@ -8396,7 +8396,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingReadTransactions&lt;/key&gt;
-                            &lt;value&gt;16&lt;/value&gt;
+                            &lt;value&gt;512&lt;/value&gt;
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingWriteTransactions&lt;/key&gt;

--- a/d5005/hardware/ofs_d5005/build/ddr_channel.qsys
+++ b/d5005/hardware/ofs_d5005/build/ddr_channel.qsys
@@ -277,7 +277,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;suppliedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;CLOCK_DOMAIN&lt;/key&gt;
-                        &lt;value&gt;9&lt;/value&gt;
+                        &lt;value&gt;3&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;CLOCK_RATE&lt;/key&gt;
@@ -285,7 +285,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;RESET_DOMAIN&lt;/key&gt;
-                        &lt;value&gt;9&lt;/value&gt;
+                        &lt;value&gt;3&lt;/value&gt;
                     &lt;/entry&gt;
                 &lt;/suppliedSystemInfos&gt;
                 &lt;consumedSystemInfos/&gt;
@@ -315,7 +315,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;suppliedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;CLOCK_DOMAIN&lt;/key&gt;
-                        &lt;value&gt;13&lt;/value&gt;
+                        &lt;value&gt;6&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;CLOCK_RATE&lt;/key&gt;
@@ -323,7 +323,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;RESET_DOMAIN&lt;/key&gt;
-                        &lt;value&gt;13&lt;/value&gt;
+                        &lt;value&gt;6&lt;/value&gt;
                     &lt;/entry&gt;
                 &lt;/suppliedSystemInfos&gt;
                 &lt;consumedSystemInfos/&gt;
@@ -336,7 +336,7 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;suppliedSystemInfos&gt;
                     &lt;entry&gt;
                         &lt;key&gt;CLOCK_DOMAIN&lt;/key&gt;
-                        &lt;value&gt;14&lt;/value&gt;
+                        &lt;value&gt;7&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;CLOCK_RATE&lt;/key&gt;
@@ -344,7 +344,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;RESET_DOMAIN&lt;/key&gt;
-                        &lt;value&gt;14&lt;/value&gt;
+                        &lt;value&gt;7&lt;/value&gt;
                     &lt;/entry&gt;
                 &lt;/suppliedSystemInfos&gt;
                 &lt;consumedSystemInfos/&gt;
@@ -3037,18 +3037,6 @@ https://fpgasoftware.intel.com/eula.-->
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_hyper_optimized_ccb_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_hyper_optimized_ccb_0&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_acl_hyper_optimized_ccb_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_acl_hyper_optimized_ccb_0&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC_VHDL&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
     &lt;/fileSets&gt;
     &lt;pinAssignments/&gt;
 &lt;/generationInfoDefinition&gt;</ipxact:value>
@@ -3377,7 +3365,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingReadTransactions&lt;/key&gt;
-                            &lt;value&gt;64&lt;/value&gt;
+                            &lt;value&gt;512&lt;/value&gt;
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingWriteTransactions&lt;/key&gt;
@@ -4026,7 +4014,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;maximumPendingReadTransactions&lt;/key&gt;
-                        &lt;value&gt;64&lt;/value&gt;
+                        &lt;value&gt;512&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;maximumPendingWriteTransactions&lt;/key&gt;
@@ -4371,18 +4359,6 @@ https://fpgasoftware.intel.com/eula.-->
             &lt;fileSetName&gt;ddr4emif_pipe_0&lt;/fileSetName&gt;
             &lt;fileSetFixedName&gt;ddr4emif_pipe_0&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr4emif_pipe_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr4emif_pipe_0&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr4emif_pipe_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr4emif_pipe_0&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
     &lt;/fileSets&gt;
@@ -4766,7 +4742,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingReadTransactions&lt;/key&gt;
-                            &lt;value&gt;256&lt;/value&gt;
+                            &lt;value&gt;512&lt;/value&gt;
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingWriteTransactions&lt;/key&gt;
@@ -5415,7 +5391,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;maximumPendingReadTransactions&lt;/key&gt;
-                        &lt;value&gt;256&lt;/value&gt;
+                        &lt;value&gt;512&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;maximumPendingWriteTransactions&lt;/key&gt;
@@ -5760,18 +5736,6 @@ https://fpgasoftware.intel.com/eula.-->
             &lt;fileSetName&gt;ddr4_pipe_to_bankdiv&lt;/fileSetName&gt;
             &lt;fileSetFixedName&gt;ddr4_pipe_to_bankdiv&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr4_pipe_to_bankdiv&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr4_pipe_to_bankdiv&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr4_pipe_to_bankdiv&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr4_pipe_to_bankdiv&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
     &lt;/fileSets&gt;
@@ -7151,18 +7115,6 @@ https://fpgasoftware.intel.com/eula.-->
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_channel_acl_avalon_mm_bridge_s10_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_channel_acl_avalon_mm_bridge_s10_0&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_channel_acl_avalon_mm_bridge_s10_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_channel_acl_avalon_mm_bridge_s10_0&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC_VHDL&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
     &lt;/fileSets&gt;
     &lt;pinAssignments/&gt;
 &lt;/generationInfoDefinition&gt;</ipxact:value>
@@ -8540,18 +8492,6 @@ https://fpgasoftware.intel.com/eula.-->
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr4_pipe_to_bankdiv_2&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr4_pipe_to_bankdiv_2&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr4_pipe_to_bankdiv_2&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr4_pipe_to_bankdiv_2&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC_VHDL&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
     &lt;/fileSets&gt;
     &lt;pinAssignments/&gt;
 &lt;/generationInfoDefinition&gt;</ipxact:value>
@@ -8933,7 +8873,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingReadTransactions&lt;/key&gt;
-                            &lt;value&gt;256&lt;/value&gt;
+                            &lt;value&gt;512&lt;/value&gt;
                         &lt;/entry&gt;
                         &lt;entry&gt;
                             &lt;key&gt;maximumPendingWriteTransactions&lt;/key&gt;
@@ -9582,7 +9522,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;maximumPendingReadTransactions&lt;/key&gt;
-                        &lt;value&gt;256&lt;/value&gt;
+                        &lt;value&gt;512&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;maximumPendingWriteTransactions&lt;/key&gt;
@@ -9929,18 +9869,6 @@ https://fpgasoftware.intel.com/eula.-->
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr4_pipe_to_kernel&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr4_pipe_to_kernel&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr4_pipe_to_kernel&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr4_pipe_to_kernel&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC_VHDL&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
     &lt;/fileSets&gt;
     &lt;pinAssignments/&gt;
 &lt;/generationInfoDefinition&gt;</ipxact:value>
@@ -10285,18 +10213,6 @@ https://fpgasoftware.intel.com/eula.-->
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_clock_bridge_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_clock_bridge_0&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_board_clock_bridge_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_board_clock_bridge_0&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC_VHDL&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
     &lt;/fileSets&gt;
     &lt;pinAssignments/&gt;
 &lt;/generationInfoDefinition&gt;</ipxact:value>
@@ -10620,18 +10536,6 @@ https://fpgasoftware.intel.com/eula.-->
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_channel_reset_bridge_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_channel_reset_bridge_0&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_channel_reset_bridge_0&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_channel_reset_bridge_0&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC_VHDL&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
     &lt;/fileSets&gt;
     &lt;pinAssignments/&gt;
 &lt;/generationInfoDefinition&gt;</ipxact:value>
@@ -10911,18 +10815,6 @@ https://fpgasoftware.intel.com/eula.-->
             &lt;fileSetName&gt;ddr_clk&lt;/fileSetName&gt;
             &lt;fileSetFixedName&gt;ddr_clk&lt;/fileSetFixedName&gt;
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_clk&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_clk&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;ddr_clk&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;ddr_clk&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
     &lt;/fileSets&gt;
@@ -11206,18 +11098,6 @@ https://fpgasoftware.intel.com/eula.-->
             &lt;fileSetKind&gt;SIM_VHDL&lt;/fileSetKind&gt;
             &lt;fileSetFiles/&gt;
         &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;kernel_clk&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;kernel_clk&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
-        &lt;fileSet&gt;
-            &lt;fileSetName&gt;kernel_clk&lt;/fileSetName&gt;
-            &lt;fileSetFixedName&gt;kernel_clk&lt;/fileSetFixedName&gt;
-            &lt;fileSetKind&gt;CDC_VHDL&lt;/fileSetKind&gt;
-            &lt;fileSetFiles/&gt;
-        &lt;/fileSet&gt;
     &lt;/fileSets&gt;
     &lt;pinAssignments/&gt;
 &lt;/generationInfoDefinition&gt;</ipxact:value>
@@ -11418,19 +11298,6 @@ https://fpgasoftware.intel.com/eula.-->
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>ddr4_cross_to_host.master</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
-            <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="ddr4_cross_to_host.master">
-                <ipxact:baseAddress>0x0000_0000_0000_0000</ipxact:baseAddress>
-              </ipxact:addressSpaceRef>
-            </ipxact:master>
-          </ipxact:busInterface>
-          <ipxact:busInterface>
-            <ipxact:name>ddr4_emif_pipe.s0</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
-          </ipxact:busInterface>
-          <ipxact:busInterface>
             <ipxact:name>ddr4_cross_to_kernel.master</ipxact:name>
             <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
             <ipxact:master>
@@ -11438,11 +11305,6 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:baseAddress>0x0000_0000_0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
-          </ipxact:busInterface>
-          <ipxact:busInterface>
-            <ipxact:name>ddr4_emif_pipe.m0</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
-            <ipxact:master></ipxact:master>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>ddr4_cross_to_host.slave</ipxact:name>
@@ -11524,18 +11386,26 @@ https://fpgasoftware.intel.com/eula.-->
               </ipxact:addressSpaceRef>
             </ipxact:master>
           </ipxact:busInterface>
+          <ipxact:busInterface>
+            <ipxact:name>ddr4_emif_pipe.m0</ipxact:name>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:master></ipxact:master>
+          </ipxact:busInterface>
+          <ipxact:busInterface>
+            <ipxact:name>ddr4_emif_pipe.s0</ipxact:name>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+          </ipxact:busInterface>
+          <ipxact:busInterface>
+            <ipxact:name>ddr4_cross_to_host.master</ipxact:name>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="22.3"></ipxact:busType>
+            <ipxact:master>
+              <ipxact:addressSpaceRef addressSpaceRef="ddr4_cross_to_host.master">
+                <ipxact:baseAddress>0x0000_0000_0000_0000</ipxact:baseAddress>
+              </ipxact:addressSpaceRef>
+            </ipxact:master>
+          </ipxact:busInterface>
         </ipxact:busInterfaces>
         <ipxact:addressSpaces>
-          <ipxact:addressSpace>
-            <ipxact:name>ddr4_cross_to_host.master</ipxact:name>
-            <ipxact:segments>
-              <ipxact:segment>
-                <ipxact:name>ddr4_emif_pipe.s0</ipxact:name>
-                <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
-                <ipxact:range>0x0000_0002_0000_0000</ipxact:range>
-              </ipxact:segment>
-            </ipxact:segments>
-          </ipxact:addressSpace>
           <ipxact:addressSpace>
             <ipxact:name>ddr4_cross_to_kernel.master</ipxact:name>
             <ipxact:segments>
@@ -11616,6 +11486,16 @@ https://fpgasoftware.intel.com/eula.-->
               </ipxact:segment>
               <ipxact:segment>
                 <ipxact:name>ddr4_emif_pipe.s0 via ddr4_cross_to_kernel</ipxact:name>
+                <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
+                <ipxact:range>0x0000_0002_0000_0000</ipxact:range>
+              </ipxact:segment>
+            </ipxact:segments>
+          </ipxact:addressSpace>
+          <ipxact:addressSpace>
+            <ipxact:name>ddr4_cross_to_host.master</ipxact:name>
+            <ipxact:segments>
+              <ipxact:segment>
+                <ipxact:name>ddr4_emif_pipe.s0</ipxact:name>
                 <ipxact:addressOffset>0x0000_0000_0000_0000</ipxact:addressOffset>
                 <ipxact:range>0x0000_0002_0000_0000</ipxact:range>
               </ipxact:segment>

--- a/d5005/hardware/ofs_d5005/build/ip/ddr_board/ddr4_pipe_to_bankdiv.ip
+++ b/d5005/hardware/ofs_d5005/build/ip/ddr_board/ddr4_pipe_to_bankdiv.ip
@@ -287,7 +287,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="maximumPendingReadTransactions" type="int">
           <ipxact:name>maximumPendingReadTransactions</ipxact:name>
           <ipxact:displayName>Maximum pending read transactions</ipxact:displayName>
-          <ipxact:value>256</ipxact:value>
+          <ipxact:value>512</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="maximumPendingWriteTransactions" type="int">
           <ipxact:name>maximumPendingWriteTransactions</ipxact:name>
@@ -1097,7 +1097,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="MAX_PENDING_RESPONSES" type="int">
           <ipxact:name>MAX_PENDING_RESPONSES</ipxact:name>
           <ipxact:displayName>Maximum pending read transactions</ipxact:displayName>
-          <ipxact:value>256</ipxact:value>
+          <ipxact:value>512</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="LINEWRAPBURSTS" type="int">
           <ipxact:name>LINEWRAPBURSTS</ipxact:name>
@@ -1431,7 +1431,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;maximumPendingReadTransactions&lt;/key&gt;
-                        &lt;value&gt;256&lt;/value&gt;
+                        &lt;value&gt;512&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;maximumPendingWriteTransactions&lt;/key&gt;

--- a/d5005/hardware/ofs_d5005/build/ip/ddr_board/ddr4_pipe_to_kernel.ip
+++ b/d5005/hardware/ofs_d5005/build/ip/ddr_board/ddr4_pipe_to_kernel.ip
@@ -287,7 +287,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="maximumPendingReadTransactions" type="int">
           <ipxact:name>maximumPendingReadTransactions</ipxact:name>
           <ipxact:displayName>Maximum pending read transactions</ipxact:displayName>
-          <ipxact:value>256</ipxact:value>
+          <ipxact:value>512</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="maximumPendingWriteTransactions" type="int">
           <ipxact:name>maximumPendingWriteTransactions</ipxact:name>
@@ -1097,7 +1097,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="MAX_PENDING_RESPONSES" type="int">
           <ipxact:name>MAX_PENDING_RESPONSES</ipxact:name>
           <ipxact:displayName>Maximum pending read transactions</ipxact:displayName>
-          <ipxact:value>256</ipxact:value>
+          <ipxact:value>512</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="LINEWRAPBURSTS" type="int">
           <ipxact:name>LINEWRAPBURSTS</ipxact:name>
@@ -1431,7 +1431,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;maximumPendingReadTransactions&lt;/key&gt;
-                        &lt;value&gt;256&lt;/value&gt;
+                        &lt;value&gt;512&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;maximumPendingWriteTransactions&lt;/key&gt;

--- a/d5005/hardware/ofs_d5005/build/ip/ddr_board/ddr4emif_pipe_0.ip
+++ b/d5005/hardware/ofs_d5005/build/ip/ddr_board/ddr4emif_pipe_0.ip
@@ -287,7 +287,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="maximumPendingReadTransactions" type="int">
           <ipxact:name>maximumPendingReadTransactions</ipxact:name>
           <ipxact:displayName>Maximum pending read transactions</ipxact:displayName>
-          <ipxact:value>64</ipxact:value>
+          <ipxact:value>512</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="maximumPendingWriteTransactions" type="int">
           <ipxact:name>maximumPendingWriteTransactions</ipxact:name>
@@ -1097,7 +1097,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="MAX_PENDING_RESPONSES" type="int">
           <ipxact:name>MAX_PENDING_RESPONSES</ipxact:name>
           <ipxact:displayName>Maximum pending read transactions</ipxact:displayName>
-          <ipxact:value>64</ipxact:value>
+          <ipxact:value>512</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="LINEWRAPBURSTS" type="int">
           <ipxact:name>LINEWRAPBURSTS</ipxact:name>
@@ -1431,7 +1431,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;maximumPendingReadTransactions&lt;/key&gt;
-                        &lt;value&gt;64&lt;/value&gt;
+                        &lt;value&gt;512&lt;/value&gt;
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;maximumPendingWriteTransactions&lt;/key&gt;

--- a/d5005/hardware/ofs_d5005/build/make_ipx.sh
+++ b/d5005/hardware/ofs_d5005/build/make_ipx.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: MIT
 

--- a/n6001/hardware/ofs_n6001/build/ip/board/board_kernel_clk_export.ip
+++ b/n6001/hardware/ofs_n6001/build/ip/board/board_kernel_clk_export.ip
@@ -16,14 +16,14 @@ https://fpgasoftware.intel.com/eula.-->
   <ipxact:vendor>Altera Corporation</ipxact:vendor>
   <ipxact:library>board_kernel_clk_export</ipxact:library>
   <ipxact:name>kernel_clk_export</ipxact:name>
-  <ipxact:version>21.3</ipxact:version>
+  <ipxact:version>23.1</ipxact:version>
   <ipxact:busInterfaces>
     <ipxact:busInterface>
       <ipxact:name>clk_in</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="23.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="23.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -67,10 +67,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>clk_in_reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="23.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="23.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -109,10 +109,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="23.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="23.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -156,10 +156,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>clk_reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="23.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="23.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -275,7 +275,7 @@ https://fpgasoftware.intel.com/eula.-->
       <ipxact:vendor>Altera Corporation</ipxact:vendor>
       <ipxact:library>board_kernel_clk_export</ipxact:library>
       <ipxact:name>clock_source</ipxact:name>
-      <ipxact:version>21.3</ipxact:version>
+      <ipxact:version>23.1</ipxact:version>
     </altera:entity_info>
     <altera:altera_module_parameters>
       <ipxact:parameters>
@@ -303,6 +303,11 @@ https://fpgasoftware.intel.com/eula.-->
     </altera:altera_module_parameters>
     <altera:altera_system_parameters>
       <ipxact:parameters>
+        <ipxact:parameter parameterId="board" type="string">
+          <ipxact:name>board</ipxact:name>
+          <ipxact:displayName>Board</ipxact:displayName>
+          <ipxact:value>default</ipxact:value>
+        </ipxact:parameter>
         <ipxact:parameter parameterId="device" type="string">
           <ipxact:name>device</ipxact:name>
           <ipxact:displayName>Device</ipxact:displayName>
@@ -311,7 +316,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="deviceFamily" type="string">
           <ipxact:name>deviceFamily</ipxact:name>
           <ipxact:displayName>Device family</ipxact:displayName>
-          <ipxact:value>Agilex</ipxact:value>
+          <ipxact:value>Agilex 7</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="deviceSpeedGrade" type="string">
           <ipxact:name>deviceSpeedGrade</ipxact:name>
@@ -332,7 +337,7 @@ https://fpgasoftware.intel.com/eula.-->
    {
       datum _originalDeviceFamily
       {
-         value = "Agilex";
+         value = "Agilex 7";
          type = "String";
       }
    }
@@ -340,7 +345,7 @@ https://fpgasoftware.intel.com/eula.-->
    {
       datum _originalVersion
       {
-         value = "21.1";
+         value = "21.3";
          type = "String";
       }
    }

--- a/n6001/hardware/ofs_n6001/build/ip/board/board_kernel_interface.ip
+++ b/n6001/hardware/ofs_n6001/build/ip/board/board_kernel_interface.ip
@@ -1409,7 +1409,7 @@ https://fpgasoftware.intel.com/eula.-->
       <ipxact:vendor>author</ipxact:vendor>
       <ipxact:library>board_kernel_interface</ipxact:library>
       <ipxact:name>kernel_interface</ipxact:name>
-      <ipxact:version>17.1</ipxact:version>
+      <ipxact:version>23.2</ipxact:version>
     </altera:entity_info>
     <altera:altera_module_parameters>
       <ipxact:parameters>

--- a/n6001/hardware/ofs_n6001/build/make_ipx.sh
+++ b/n6001/hardware/ofs_n6001/build/make_ipx.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: MIT
 

--- a/n6001/hardware/ofs_n6001/build/opencl_bsp.sdc
+++ b/n6001/hardware/ofs_n6001/build/opencl_bsp.sdc
@@ -6,4 +6,3 @@ set_clock_groups -asynchronous  -group [get_clocks {sys_pll|iopll_0_clk_sys}] \
                                                     mem_ss_top|mem_ss*inst|mem_ss_fm*|intf_1_core_usr_clk \
                                                     mem_ss_top|mem_ss*inst|mem_ss_fm*|intf_2_core_usr_clk \
                                                     mem_ss_top|mem_ss*inst|mem_ss_fm*|intf_3_core_usr_clk}]
-

--- a/n6001/hardware/ofs_n6001/build/rtl/dma/dma.vh
+++ b/n6001/hardware/ofs_n6001/build/rtl/dma/dma.vh
@@ -10,5 +10,5 @@
     `define DO_F2H_MAGIC_NUMBER_WRITE 1
     
     `define DMA_DO_SINGLE_BURST_PARTIAL_WRITES 1
-    
+
 `endif

--- a/n6001/hardware/ofs_n6001_iopipes/build/opencl_bsp.sdc
+++ b/n6001/hardware/ofs_n6001_iopipes/build/opencl_bsp.sdc
@@ -6,4 +6,3 @@ set_clock_groups -asynchronous  -group [get_clocks {sys_pll|iopll_0_clk_sys}] \
                                                     mem_ss_top|mem_ss*inst|mem_ss_fm*|intf_1_core_usr_clk \
                                                     mem_ss_top|mem_ss*inst|mem_ss_fm*|intf_2_core_usr_clk \
                                                     mem_ss_top|mem_ss*inst|mem_ss_fm*|intf_3_core_usr_clk}]
-

--- a/n6001/hardware/ofs_n6001_usm/build/ip/board/board_kernel_clk_export.ip
+++ b/n6001/hardware/ofs_n6001_usm/build/ip/board/board_kernel_clk_export.ip
@@ -16,14 +16,14 @@ https://fpgasoftware.intel.com/eula.-->
   <ipxact:vendor>Altera Corporation</ipxact:vendor>
   <ipxact:library>board_kernel_clk_export</ipxact:library>
   <ipxact:name>kernel_clk_export</ipxact:name>
-  <ipxact:version>21.3</ipxact:version>
+  <ipxact:version>23.1</ipxact:version>
   <ipxact:busInterfaces>
     <ipxact:busInterface>
       <ipxact:name>clk_in</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="23.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="23.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -67,10 +67,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>clk_in_reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="23.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="23.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -109,10 +109,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="23.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="23.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -156,10 +156,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>clk_reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="21.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="23.1"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="21.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="23.1"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -275,7 +275,7 @@ https://fpgasoftware.intel.com/eula.-->
       <ipxact:vendor>Altera Corporation</ipxact:vendor>
       <ipxact:library>board_kernel_clk_export</ipxact:library>
       <ipxact:name>clock_source</ipxact:name>
-      <ipxact:version>21.3</ipxact:version>
+      <ipxact:version>23.1</ipxact:version>
     </altera:entity_info>
     <altera:altera_module_parameters>
       <ipxact:parameters>
@@ -303,6 +303,11 @@ https://fpgasoftware.intel.com/eula.-->
     </altera:altera_module_parameters>
     <altera:altera_system_parameters>
       <ipxact:parameters>
+        <ipxact:parameter parameterId="board" type="string">
+          <ipxact:name>board</ipxact:name>
+          <ipxact:displayName>Board</ipxact:displayName>
+          <ipxact:value>default</ipxact:value>
+        </ipxact:parameter>
         <ipxact:parameter parameterId="device" type="string">
           <ipxact:name>device</ipxact:name>
           <ipxact:displayName>Device</ipxact:displayName>
@@ -311,7 +316,7 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="deviceFamily" type="string">
           <ipxact:name>deviceFamily</ipxact:name>
           <ipxact:displayName>Device family</ipxact:displayName>
-          <ipxact:value>Agilex</ipxact:value>
+          <ipxact:value>Agilex 7</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="deviceSpeedGrade" type="string">
           <ipxact:name>deviceSpeedGrade</ipxact:name>
@@ -332,7 +337,7 @@ https://fpgasoftware.intel.com/eula.-->
    {
       datum _originalDeviceFamily
       {
-         value = "Agilex";
+         value = "Agilex 7";
          type = "String";
       }
    }
@@ -340,7 +345,7 @@ https://fpgasoftware.intel.com/eula.-->
    {
       datum _originalVersion
       {
-         value = "21.1";
+         value = "21.3";
          type = "String";
       }
    }


### PR DESCRIPTION
### Description
Commonizing more files between board variants of D5005 and N6001
This change makes more files common between the D5005 and N6001 ASPs as well as between board variants.
It cleans up differences between the ofs_d5005 and ofs_d5005_usm .qsys and .ip files, cleans up differences to the make_ipx.sh files as well as opencl_bsp.sdc file differences in the N6001 ASPs.

### Collateral (docs, reports, design examples, case IDs):
none

### Tests added:
none

### Tests run:
- compiled and ran the following designs in HW on N6001:

ofs_n6001:
anr
board_test
cholesky
cholesky_inversion
db
decompress
merge_sort
qri

ofs_n6001_usm:
simple_host_streaming
buffered_host_streaming
explicit_data_movement
zero_copy_data_transfer

- compiled and ran the following designs in HW on D5005:

ofs_d5005:
anr
board_test
cholesky
cholesky_inversion
db
decompress
double_buffering
gzip
merge_sort
qrd
qri

ofs_d5005_usm:
simple_host_streaming
buffered_host_streaming
explicit_data_movement
zero_copy_data_transfer

