### PR TITLE
[Update] Remove -no-env-check from ASE scripts

### DIFF
--- a/d5005/ase/compile-kernel.sh
+++ b/d5005/ase/compile-kernel.sh
@@ -43,7 +43,7 @@ echo "Running ASE for board variant: $BOARD, device: $OPTARG"
 if [ -f "$DESIGN_SRC" ]; then
     echo "Running ASE with design: $DESIGN_SRC"
     echo "aoc command is next"
-    aoc -v -no-env-check -board-package="$BSP_ROOT" -board="$BOARD" "$DESIGN_SRC"
+    aoc -v -board-package="$BSP_ROOT" -board="$BOARD" "$DESIGN_SRC"
 elif [ -d "$DESIGN_SRC" ]; then
     echo "Running ASE with oneAPI design: $DESIGN_SRC"
     echo "pwd is  $PWD"
@@ -51,8 +51,7 @@ elif [ -d "$DESIGN_SRC" ]; then
     echo "pwd is $PWD"
     cd ${BOARD}
     echo "pwd is $PWD, cmake is next"
-    #cmake "$DESIGN_SRC" -DFPGA_DEVICE=${OFS_ASP_ROOT}:${BOARD} -DDEVICE_FLAG=${DEVICE} -DIS_BSP=1 -DUSER_HARDWARE_FLAGS="-Xsno-env-check"
-    cmake "$DESIGN_SRC" -DFPGA_DEVICE=${OFS_ASP_ROOT}:${BOARD} -DIS_BSP=1 -DUSER_HARDWARE_FLAGS="-Xsno-env-check"
+    cmake "$DESIGN_SRC" -DFPGA_DEVICE=${OFS_ASP_ROOT}:${BOARD} -DIS_BSP=1
     echo "after cmake"
     make fpga
     echo "make fpga is done; break out the aocx file"

--- a/n6001/ase/compile-kernel.sh
+++ b/n6001/ase/compile-kernel.sh
@@ -43,7 +43,7 @@ echo "Running ASE for board variant: $BOARD, device: $OPTARG"
 if [ -f "$DESIGN_SRC" ]; then
     echo "Running ASE with design: $DESIGN_SRC"
     echo "aoc command is next"
-    aoc -v -no-env-check -board-package="$BSP_ROOT" -board="$BOARD" "$DESIGN_SRC"
+    aoc -v -board-package="$BSP_ROOT" -board="$BOARD" "$DESIGN_SRC"
 elif [ -d "$DESIGN_SRC" ]; then
     echo "Running ASE with oneAPI design: $DESIGN_SRC"
     echo "pwd is  $PWD"
@@ -51,8 +51,7 @@ elif [ -d "$DESIGN_SRC" ]; then
     echo "pwd is $PWD"
     cd ${BOARD}
     echo "pwd is $PWD, cmake is next"
-    #cmake "$DESIGN_SRC" -DFPGA_DEVICE=${OFS_ASP_ROOT}:${BOARD} -DDEVICE_FLAG=${DEVICE} -DIS_BSP=1 -DUSER_HARDWARE_FLAGS="-Xsno-env-check"
-    cmake "$DESIGN_SRC" -DFPGA_DEVICE=${OFS_ASP_ROOT}:${BOARD} -DIS_BSP=1 -DUSER_HARDWARE_FLAGS="-Xsno-env-check"
+    cmake "$DESIGN_SRC" -DFPGA_DEVICE=${OFS_ASP_ROOT}:${BOARD} -DIS_BSP=1
     echo "after cmake"
     make fpga
     echo "make fpga is done; break out the aocx file"


### PR DESCRIPTION
------------- *Keep everything below this line* -------------------------

### Description
With updates to the aclsycl tool for 2024.0 we don't need the -no-env-check argument anymore.


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
ASE zero-copy-data-transfer passed for D5005 and N6001 platforms.

