### PR TITLE
[Update] Improve script messaging/status

### DIFF
--- a/d5005/scripts/build-bsp.sh
+++ b/d5005/scripts/build-bsp.sh
@@ -160,4 +160,6 @@ if [ -n "$failed_bsps" ]; then
   # shellcheck disable=SC2086
   printf '    %s\n' $failed_bsps
   exit 1
+else
+  printf '\n\nbuild-bsp.sh (and sub-scripts) completed successfully\n\n'
 fi

--- a/d5005/scripts/setup-bsp.py
+++ b/d5005/scripts/setup-bsp.py
@@ -220,6 +220,8 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     rm_glob(os.path.join(bsp_dir, PR_AFU_QPF_FILENAME))
     OFS_TOP_QPF_SYMLINK_CMD="cd " + bsp_dir + " && ln -s " + QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR + "/" + PR_AFU_QPF_FILENAME + " ."
     run_cmd(OFS_TOP_QPF_SYMLINK_CMD)
+    
+    print("\nsetup-bsp.py completed successfully for variant %s\n" % bsp)
 
 
 # Read environment variables required for script operations

--- a/n6001/scripts/build-bsp.sh
+++ b/n6001/scripts/build-bsp.sh
@@ -160,4 +160,6 @@ if [ -n "$failed_bsps" ]; then
   # shellcheck disable=SC2086
   printf '    %s\n' $failed_bsps
   exit 1
+else
+  printf '\n\nbuild-bsp.sh (and sub-scripts) completed successfully\n\n'
 fi

--- a/n6001/scripts/setup-bsp.py
+++ b/n6001/scripts/setup-bsp.py
@@ -220,6 +220,8 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     rm_glob(os.path.join(bsp_dir, PR_AFU_QPF_FILENAME))
     OFS_TOP_QPF_SYMLINK_CMD="cd " + bsp_dir + " && ln -s " + QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR + "/" + PR_AFU_QPF_FILENAME + " ."
     run_cmd(OFS_TOP_QPF_SYMLINK_CMD)
+    
+    print("\nsetup-bsp.py completed successfully for variant %s\n" % bsp)
 
 
 # Read environment variables required for script operations


### PR DESCRIPTION
### Description
Customer-request to improve build-bsp and setup-bsp messaging - tell the user that the script(s) completed successfully. Currently, the final outputs to the terminal are the outputs from running afu-synth-setup, which isn't particularly useful.


### Collateral (docs, reports, design examples, case IDs):
None.


- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
Ran build-bsp for n6001 and d5005 platforms.