### PR TITLE
[Update] Add ini to work around Quartus 'routing preservation' Internal Errors

### DIFF
--- a/n6001/.gitignore
+++ b/n6001/.gitignore
@@ -19,13 +19,7 @@ linux64/include
 linux64/libexec/diagnose
 linux64/libexec/program
 
-# Generated BSP file
-opencl-bsp.tar.gz
-
-# Generated default aocx files
-bringup/aocxs/
-
-# Hardware files that are copied from IOFS build for pac_s10
+# Hardware files that are copied from FIM build
 hardware/*/afu_opencl_kernel.qsf
 hardware/*/bsp_dir_filelist.txt
 hardware/*/build/afu_base.qsf
@@ -48,7 +42,6 @@ hardware/*/build/build_env_db.txt
 hardware/*/build/ofs_pr_afu_sources.tcl
 hardware/*/build/output_files/
 hardware/*/build/platform/
-hardware/*/build/quartus.ini
 hardware/*/build/ofs_partial_reconfig/
 hardware/*/build/scripts/report_timing.tcl
 hardware/*/build/scripts/user_clock_defs.tcl

--- a/n6001/.gitignore
+++ b/n6001/.gitignore
@@ -19,6 +19,11 @@ linux64/include
 linux64/libexec/diagnose
 linux64/libexec/program
 
+# FIM build files
+pr_build_template
+hardware/*/blue_bits
+hardware/*/fim_platform
+
 # Hardware files that are copied from FIM build
 hardware/*/afu_opencl_kernel.qsf
 hardware/*/bsp_dir_filelist.txt

--- a/n6001/.gitignore
+++ b/n6001/.gitignore
@@ -51,7 +51,7 @@ hardware/*/build/scripts/user_clock_defs.tcl
 hardware/*/build/scripts/user_clock_freqs_compute.tcl
 hardware/*/build/scripts/user_clocks.sdc
 hardware/*/build/scripts/syn_top_relpath.tcl
-hardware/*/build/ofs_pr_afu.qsf
+hardware/*/ofs_pr_afu.qsf
 hardware/*/build/tools/
 hardware/*/build/src/
 hardware/*/build/syn/

--- a/n6001/.gitignore
+++ b/n6001/.gitignore
@@ -23,8 +23,6 @@ linux64/libexec/program
 pr_build_template
 hardware/*/blue_bits
 hardware/*/fim_platform
-
-# Hardware files that are copied from FIM build
 hardware/*/afu_opencl_kernel.qsf
 hardware/*/bsp_dir_filelist.txt
 hardware/*/build/afu_base.qsf
@@ -52,6 +50,8 @@ hardware/*/build/scripts/report_timing.tcl
 hardware/*/build/scripts/user_clock_defs.tcl
 hardware/*/build/scripts/user_clock_freqs_compute.tcl
 hardware/*/build/scripts/user_clocks.sdc
+hardware/*/build/scripts/syn_top_relpath.tcl
+hardware/*/build/ofs_pr_afu.qsf
 hardware/*/build/tools/
 hardware/*/build/src/
 hardware/*/build/syn/

--- a/n6001/hardware/ofs_n6001/build/quartus.ini
+++ b/n6001/hardware/ofs_n6001/build/quartus.ini
@@ -1,3 +1,3 @@
 #Work around for rare 'routing preservation failure' Quartus Internal Errors
-bsyn_hold_fix_limit=0
+ini_password = 23.3_3f55ddfcafc6e4bf0a285f647c5990bc4b838593396e04407b51747bfe03e1a2b969edc295852014551077576601531422334300645153312275405406776065454416221202006015337607
 

--- a/n6001/hardware/ofs_n6001/build/quartus.ini
+++ b/n6001/hardware/ofs_n6001/build/quartus.ini
@@ -1,0 +1,3 @@
+#Work around for rare 'routing preservation failure' Quartus Internal Errors
+bsyn_hold_fix_limit=0
+

--- a/n6001/hardware/ofs_n6001_iopipes/build/quartus.ini
+++ b/n6001/hardware/ofs_n6001_iopipes/build/quartus.ini
@@ -1,3 +1,3 @@
 #Work around for rare 'routing preservation failure' Quartus Internal Errors
-bsyn_hold_fix_limit=0
+ini_password = 23.3_3f55ddfcafc6e4bf0a285f647c5990bc4b838593396e04407b51747bfe03e1a2b969edc295852014551077576601531422334300645153312275405406776065454416221202006015337607
 

--- a/n6001/hardware/ofs_n6001_iopipes/build/quartus.ini
+++ b/n6001/hardware/ofs_n6001_iopipes/build/quartus.ini
@@ -1,0 +1,3 @@
+#Work around for rare 'routing preservation failure' Quartus Internal Errors
+bsyn_hold_fix_limit=0
+

--- a/n6001/hardware/ofs_n6001_usm/build/quartus.ini
+++ b/n6001/hardware/ofs_n6001_usm/build/quartus.ini
@@ -1,3 +1,3 @@
 #Work around for rare 'routing preservation failure' Quartus Internal Errors
-bsyn_hold_fix_limit=0
+ini_password = 23.3_3f55ddfcafc6e4bf0a285f647c5990bc4b838593396e04407b51747bfe03e1a2b969edc295852014551077576601531422334300645153312275405406776065454416221202006015337607
 

--- a/n6001/hardware/ofs_n6001_usm/build/quartus.ini
+++ b/n6001/hardware/ofs_n6001_usm/build/quartus.ini
@@ -1,0 +1,3 @@
+#Work around for rare 'routing preservation failure' Quartus Internal Errors
+bsyn_hold_fix_limit=0
+

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/quartus.ini
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/quartus.ini
@@ -1,3 +1,3 @@
 #Work around for rare 'routing preservation failure' Quartus Internal Errors
-bsyn_hold_fix_limit=0
+ini_password = 23.3_3f55ddfcafc6e4bf0a285f647c5990bc4b838593396e04407b51747bfe03e1a2b969edc295852014551077576601531422334300645153312275405406776065454416221202006015337607
 

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/quartus.ini
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/quartus.ini
@@ -1,0 +1,3 @@
+#Work around for rare 'routing preservation failure' Quartus Internal Errors
+bsyn_hold_fix_limit=0
+


### PR DESCRIPTION
### Description
We see some rare 'routing preservation failure' Internal Errors when compiling the IO-Pipes design (there shouldn't be anything specific to the IO-Pipes variants). This ini helps reduce the frequency of the IEs.


### Collateral (docs, reports, design examples, case IDs):


- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:
None

### Tests run:
Compiled the normal suite of OneAPI-samples designs, observed the quartus.ini file is included in quartus_sh_compile.log.

