### PR TITLE
[Update] Fix a typo in the messages printed in setup_permissions.sh

### DIFF
--- a/d5005/linux64/libexec/setup_permissions.sh
+++ b/d5005/linux64/libexec/setup_permissions.sh
@@ -50,7 +50,7 @@ EOF
 
   lock_limit=$(ulimit -l)
   if [ $lock_limit != "unlimited" ]; then
-    echo "** NOTE:changes to max locked memory setting only take effet with new login session"
+    echo "** NOTE:changes to max locked memory setting only take effect with new login session"
   fi
 }
 

--- a/n6001/linux64/libexec/setup_permissions.sh
+++ b/n6001/linux64/libexec/setup_permissions.sh
@@ -50,7 +50,7 @@ EOF
 
   lock_limit=$(ulimit -l)
   if [ $lock_limit != "unlimited" ]; then
-    echo "** NOTE:changes to max locked memory setting only take effet with new login session"
+    echo "** NOTE:changes to max locked memory setting only take effect with new login session"
   fi
 }
 


### PR DESCRIPTION
### Description
Fixed a simple typo. No functional changes.


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
None.

