### PR TITLE
[Fix] Revert recent D5005 changes 

### DIFF
--- a/d5005/hardware/ofs_d5005/build/rtl/bsp_logic.sv
+++ b/d5005/hardware/ofs_d5005/build/rtl/bsp_logic.sv
@@ -93,7 +93,7 @@ board board_inst (
     .kernel_irq_irq                     (kernel_control.kernel_irq),                                //   kernel_irq.irq
     .kernel_reset_reset_n               (kernel_control.kernel_reset_n),                            // kernel_reset.reset_n
     
-    `ifdef ASP_ENABLE_DDR4_BANK_0
+    `ifdef PAC_BSP_ENABLE_DDR4_BANK1
         .emif_ddr4a_clk_clk         (local_mem[0].clk),
         .emif_ddr4a_waitrequest     (local_mem[0].waitrequest),
         .emif_ddr4a_readdata        (local_mem[0].readdata),
@@ -115,7 +115,7 @@ board board_inst (
         .kernel_ddr4a_read          (kernel_mem[0].read),
         .kernel_ddr4a_byteenable    (kernel_mem[0].byteenable),
     `endif
-    `ifdef ASP_ENABLE_DDR4_BANK_1
+    `ifdef PAC_BSP_ENABLE_DDR4_BANK2
         .emif_ddr4b_clk_clk         (local_mem[1].clk),
         .emif_ddr4b_waitrequest     (local_mem[1].waitrequest),
         .emif_ddr4b_readdata        (local_mem[1].readdata),
@@ -137,7 +137,7 @@ board board_inst (
         .kernel_ddr4b_read          (kernel_mem[1].read),
         .kernel_ddr4b_byteenable    (kernel_mem[1].byteenable),
     `endif
-    `ifdef ASP_ENABLE_DDR4_BANK_2
+    `ifdef PAC_BSP_ENABLE_DDR4_BANK3
         .emif_ddr4c_clk_clk         (local_mem[2].clk),
         .emif_ddr4c_waitrequest     (local_mem[2].waitrequest),
         .emif_ddr4c_readdata        (local_mem[2].readdata),
@@ -159,7 +159,7 @@ board board_inst (
         .kernel_ddr4c_read          (kernel_mem[2].read),
         .kernel_ddr4c_byteenable    (kernel_mem[2].byteenable),
     `endif
-    `ifdef ASP_ENABLE_DDR4_BANK_3
+    `ifdef PAC_BSP_ENABLE_DDR4_BANK4
         .emif_ddr4d_clk_clk         (local_mem[3].clk),
         .emif_ddr4d_waitrequest     (local_mem[3].waitrequest),
         .emif_ddr4d_readdata        (local_mem[3].readdata),

--- a/d5005/hardware/ofs_d5005/build/rtl/kernel_wrapper.v
+++ b/d5005/hardware/ofs_d5005/build/rtl/kernel_wrapper.v
@@ -172,7 +172,7 @@ kernel_system kernel_system_inst (
     .clock_reset2x_clk            (clk2x),
     .clock_reset_reset_reset_n    (reset_n),
     
-    `ifdef ASP_ENABLE_DDR4_BANK_0
+    `ifdef PAC_BSP_ENABLE_DDR4_BANK1
         .kernel_ddr4a_waitrequest     (mem_avmm_bridge[0].waitrequest  ),
         .kernel_ddr4a_readdata        (mem_avmm_bridge[0].readdata     ),
         .kernel_ddr4a_readdatavalid   (mem_avmm_bridge[0].readdatavalid),
@@ -182,11 +182,11 @@ kernel_system kernel_system_inst (
         .kernel_ddr4a_write           (mem_avmm_bridge[0].write        ),
         .kernel_ddr4a_read            (mem_avmm_bridge[0].read         ),
         .kernel_ddr4a_byteenable      (mem_avmm_bridge[0].byteenable   ),
-    `ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
-            .kernel_ddr4a_writeack    (mem_avmm_bridge[0].writeack     ),
+	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+	    .kernel_ddr4a_writeack        (mem_avmm_bridge[0].writeack     ),
+	`endif
     `endif
-    `endif
-    `ifdef ASP_ENABLE_DDR4_BANK_1
+    `ifdef PAC_BSP_ENABLE_DDR4_BANK2
         .kernel_ddr4b_waitrequest     (mem_avmm_bridge[1].waitrequest  ),
         .kernel_ddr4b_readdata        (mem_avmm_bridge[1].readdata     ),
         .kernel_ddr4b_readdatavalid   (mem_avmm_bridge[1].readdatavalid),
@@ -196,11 +196,11 @@ kernel_system kernel_system_inst (
         .kernel_ddr4b_write           (mem_avmm_bridge[1].write        ),
         .kernel_ddr4b_read            (mem_avmm_bridge[1].read         ),
         .kernel_ddr4b_byteenable      (mem_avmm_bridge[1].byteenable   ),
-    `ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
-        .kernel_ddr4b_writeack        (mem_avmm_bridge[1].writeack     ),
+    	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+	    .kernel_ddr4b_writeack        (mem_avmm_bridge[1].writeack     ),
+	`endif
     `endif
-    `endif
-    `ifdef ASP_ENABLE_DDR4_BANK_2
+    `ifdef PAC_BSP_ENABLE_DDR4_BANK3
         .kernel_ddr4c_waitrequest     (mem_avmm_bridge[2].waitrequest  ),
         .kernel_ddr4c_readdata        (mem_avmm_bridge[2].readdata     ),
         .kernel_ddr4c_readdatavalid   (mem_avmm_bridge[2].readdatavalid),
@@ -210,11 +210,11 @@ kernel_system kernel_system_inst (
         .kernel_ddr4c_write           (mem_avmm_bridge[2].write        ),
         .kernel_ddr4c_read            (mem_avmm_bridge[2].read         ),
         .kernel_ddr4c_byteenable      (mem_avmm_bridge[2].byteenable   ),
-    `ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
-            .kernel_ddr4c_writeack    (mem_avmm_bridge[2].writeack     ),
+	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+            .kernel_ddr4c_writeack        (mem_avmm_bridge[2].writeack     ),
+	`endif
     `endif
-    `endif
-    `ifdef ASP_ENABLE_DDR4_BANK_3
+    `ifdef PAC_BSP_ENABLE_DDR4_BANK4
         .kernel_ddr4d_waitrequest     (mem_avmm_bridge[3].waitrequest  ),
         .kernel_ddr4d_readdata        (mem_avmm_bridge[3].readdata     ),
         .kernel_ddr4d_readdatavalid   (mem_avmm_bridge[3].readdatavalid),
@@ -224,9 +224,9 @@ kernel_system kernel_system_inst (
         .kernel_ddr4d_write           (mem_avmm_bridge[3].write        ),
         .kernel_ddr4d_read            (mem_avmm_bridge[3].read         ),
         .kernel_ddr4d_byteenable      (mem_avmm_bridge[3].byteenable   ),
-    `ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
-        .kernel_ddr4d_writeack        (mem_avmm_bridge[3].writeack     ),
-    `endif
+	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+	    .kernel_ddr4d_writeack        (mem_avmm_bridge[3].writeack     ),
+    	`endif
     `endif
 
     .kernel_irq_irq                 (kernel_cra_avmm_bridge.kernel_irq),
@@ -254,134 +254,134 @@ kernel_system kernel_system_inst (
     `endif //INCLUDE_USM_SUPPORT
     
     `ifdef INCLUDE_IO_PIPES
-        `ifdef ASP_ENABLE_IOPIPE_0
+        `ifdef ASP_ENABLE_IOPIPE0
             ,.udp_out_valid        (udp_avst_from_kernel[0].valid),
             .udp_out_data          (udp_avst_from_kernel[0].data),
             .udp_out_ready         (udp_avst_from_kernel[0].ready),
             .udp_in_valid          (udp_avst_to_kernel[0].valid),
             .udp_in_data           (udp_avst_to_kernel[0].data),
             .udp_in_ready          (udp_avst_to_kernel[0].ready)
-        `endif //ASP_ENABLE_IOPIPE_0
-        `ifdef ASP_ENABLE_IOPIPE_1
+        `endif //ASP_ENABLE_IOPIPE0
+        `ifdef ASP_ENABLE_IOPIPE1
             ,.udp_out_1_valid        (udp_avst_from_kernel[1].valid),
             .udp_out_1_data          (udp_avst_from_kernel[1].data),
             .udp_out_1_ready         (udp_avst_from_kernel[1].ready),
             .udp_in_1_valid          (udp_avst_to_kernel[1].valid),
             .udp_in_1_data           (udp_avst_to_kernel[1].data),
             .udp_in_1_ready          (udp_avst_to_kernel[1].ready)
-        `endif //ASP_ENABLE_IOPIPE_1
-        `ifdef ASP_ENABLE_IOPIPE_2
+        `endif //ASP_ENABLE_IOPIPE1
+        `ifdef ASP_ENABLE_IOPIPE2
             ,.udp_out_2_valid        (udp_avst_from_kernel[2].valid),
             .udp_out_2_data          (udp_avst_from_kernel[2].data),
             .udp_out_2_ready         (udp_avst_from_kernel[2].ready),
             .udp_in_2_valid          (udp_avst_to_kernel[2].valid),
             .udp_in_2_data           (udp_avst_to_kernel[2].data),
             .udp_in_2_ready          (udp_avst_to_kernel[2].ready)
-        `endif //ASP_ENABLE_IOPIPE_2
-        `ifdef ASP_ENABLE_IOPIPE_3
+        `endif //ASP_ENABLE_IOPIPE2
+        `ifdef ASP_ENABLE_IOPIPE3
             ,.udp_out_3_valid        (udp_avst_from_kernel[3].valid),
             .udp_out_3_data          (udp_avst_from_kernel[3].data),
             .udp_out_3_ready         (udp_avst_from_kernel[3].ready),
             .udp_in_3_valid          (udp_avst_to_kernel[3].valid),
             .udp_in_3_data           (udp_avst_to_kernel[3].data),
             .udp_in_3_ready          (udp_avst_to_kernel[3].ready)
-        `endif //ASP_ENABLE_IOPIPE_3
-        `ifdef ASP_ENABLE_IOPIPE_4
+        `endif //ASP_ENABLE_IOPIPE3
+        `ifdef ASP_ENABLE_IOPIPE4
             ,.udp_out_4_valid        (udp_avst_from_kernel[4].valid),
             .udp_out_4_data          (udp_avst_from_kernel[4].data),
             .udp_out_4_ready         (udp_avst_from_kernel[4].ready),
             .udp_in_4_valid          (udp_avst_to_kernel[4].valid),
             .udp_in_4_data           (udp_avst_to_kernel[4].data),
             .udp_in_4_ready          (udp_avst_to_kernel[4].ready)
-        `endif //ASP_ENABLE_IOPIPE_4
-        `ifdef ASP_ENABLE_IOPIPE_5
+        `endif //ASP_ENABLE_IOPIPE4
+        `ifdef ASP_ENABLE_IOPIPE5
             ,.udp_out_5_valid        (udp_avst_from_kernel[5].valid),
             .udp_out_5_data          (udp_avst_from_kernel[5].data),
             .udp_out_5_ready         (udp_avst_from_kernel[5].ready),
             .udp_in_5_valid          (udp_avst_to_kernel[5].valid),
             .udp_in_5_data           (udp_avst_to_kernel[5].data),
             .udp_in_5_ready          (udp_avst_to_kernel[5].ready)
-        `endif //ASP_ENABLE_IOPIPE_5
-        `ifdef ASP_ENABLE_IOPIPE_6
+        `endif //ASP_ENABLE_IOPIPE5
+        `ifdef ASP_ENABLE_IOPIPE6
             ,.udp_out_6_valid        (udp_avst_from_kernel[6].valid),
             .udp_out_6_data          (udp_avst_from_kernel[6].data),
             .udp_out_6_ready         (udp_avst_from_kernel[6].ready),
             .udp_in_6_valid          (udp_avst_to_kernel[6].valid),
             .udp_in_6_data           (udp_avst_to_kernel[6].data),
             .udp_in_6_ready          (udp_avst_to_kernel[6].ready)
-        `endif //ASP_ENABLE_IOPIPE_6
-        `ifdef ASP_ENABLE_IOPIPE_7
+        `endif //ASP_ENABLE_IOPIPE6
+        `ifdef ASP_ENABLE_IOPIPE7
             ,.udp_out_7_valid        (udp_avst_from_kernel[7].valid),
             .udp_out_7_data          (udp_avst_from_kernel[7].data),
             .udp_out_7_ready         (udp_avst_from_kernel[7].ready),
             .udp_in_7_valid          (udp_avst_to_kernel[7].valid),
             .udp_in_7_data           (udp_avst_to_kernel[7].data),
             .udp_in_7_ready          (udp_avst_to_kernel[7].ready)
-        `endif //ASP_ENABLE_IOPIPE_7
-        `ifdef ASP_ENABLE_IOPIPE_8
+        `endif //ASP_ENABLE_IOPIPE7
+        `ifdef ASP_ENABLE_IOPIPE8
             ,.udp_out_8_valid        (udp_avst_from_kernel[8].valid),
             .udp_out_8_data          (udp_avst_from_kernel[8].data),
             .udp_out_8_ready         (udp_avst_from_kernel[8].ready),
             .udp_in_8_valid          (udp_avst_to_kernel[8].valid),
             .udp_in_8_data           (udp_avst_to_kernel[8].data),
             .udp_in_8_ready          (udp_avst_to_kernel[8].ready)
-        `endif //ASP_ENABLE_IOPIPE_8
-        `ifdef ASP_ENABLE_IOPIPE_9
+        `endif //ASP_ENABLE_IOPIPE8
+        `ifdef ASP_ENABLE_IOPIPE9
             ,.udp_out_9_valid        (udp_avst_from_kernel[9].valid),
             .udp_out_9_data          (udp_avst_from_kernel[9].data),
             .udp_out_9_ready         (udp_avst_from_kernel[9].ready),
             .udp_in_9_valid          (udp_avst_to_kernel[9].valid),
             .udp_in_9_data           (udp_avst_to_kernel[9].data),
             .udp_in_9_ready          (udp_avst_to_kernel[9].ready)
-        `endif //ASP_ENABLE_IOPIPE_9
-        `ifdef ASP_ENABLE_IOPIPE_10
+        `endif //ASP_ENABLE_IOPIPE9
+        `ifdef ASP_ENABLE_IOPIPE10
             ,.udp_out_10_valid        (udp_avst_from_kernel[10].valid),
             .udp_out_10_data          (udp_avst_from_kernel[10].data),
             .udp_out_10_ready         (udp_avst_from_kernel[10].ready),
             .udp_in_10_valid          (udp_avst_to_kernel[10].valid),
             .udp_in_10_data           (udp_avst_to_kernel[10].data),
             .udp_in_10_ready          (udp_avst_to_kernel[10].ready)
-        `endif //ASP_ENABLE_IOPIPE_10
-        `ifdef ASP_ENABLE_IOPIPE_11
+        `endif //ASP_ENABLE_IOPIPE10
+        `ifdef ASP_ENABLE_IOPIPE11
             ,.udp_out_11_valid        (udp_avst_from_kernel[11].valid),
             .udp_out_11_data          (udp_avst_from_kernel[11].data),
             .udp_out_11_ready         (udp_avst_from_kernel[11].ready),
             .udp_in_11_valid          (udp_avst_to_kernel[11].valid),
             .udp_in_11_data           (udp_avst_to_kernel[11].data),
             .udp_in_11_ready          (udp_avst_to_kernel[11].ready)
-        `endif //ASP_ENABLE_IOPIPE_11
-        `ifdef ASP_ENABLE_IOPIPE_12
+        `endif //ASP_ENABLE_IOPIPE11
+        `ifdef ASP_ENABLE_IOPIPE12
             ,.udp_out_12_valid        (udp_avst_from_kernel[12].valid),
             .udp_out_12_data          (udp_avst_from_kernel[12].data),
             .udp_out_12_ready         (udp_avst_from_kernel[12].ready),
             .udp_in_12_valid          (udp_avst_to_kernel[12].valid),
             .udp_in_12_data           (udp_avst_to_kernel[12].data),
             .udp_in_12_ready          (udp_avst_to_kernel[12].ready)
-        `endif //ASP_ENABLE_IOPIPE_12
-        `ifdef ASP_ENABLE_IOPIPE_13
+        `endif //ASP_ENABLE_IOPIPE12
+        `ifdef ASP_ENABLE_IOPIPE13
             ,.udp_out_13_valid        (udp_avst_from_kernel[13].valid),
             .udp_out_13_data          (udp_avst_from_kernel[13].data),
             .udp_out_13_ready         (udp_avst_from_kernel[13].ready),
             .udp_in_13_valid          (udp_avst_to_kernel[13].valid),
             .udp_in_13_data           (udp_avst_to_kernel[13].data),
             .udp_in_13_ready          (udp_avst_to_kernel[13].ready)
-        `endif //ASP_ENABLE_IOPIPE_13
-        `ifdef ASP_ENABLE_IOPIPE_14
+        `endif //ASP_ENABLE_IOPIPE13
+        `ifdef ASP_ENABLE_IOPIPE14
             ,.udp_out_14_valid        (udp_avst_from_kernel[14].valid),
             .udp_out_14_data          (udp_avst_from_kernel[14].data),
             .udp_out_14_ready         (udp_avst_from_kernel[14].ready),
             .udp_in_14_valid          (udp_avst_to_kernel[14].valid),
             .udp_in_14_data           (udp_avst_to_kernel[14].data),
             .udp_in_14_ready          (udp_avst_to_kernel[14].ready)
-        `endif //ASP_ENABLE_IOPIPE_14
-        `ifdef ASP_ENABLE_IOPIPE_15
+        `endif //ASP_ENABLE_IOPIPE14
+        `ifdef ASP_ENABLE_IOPIPE15
             ,.udp_out_15_valid        (udp_avst_from_kernel[15].valid),
             .udp_out_15_data          (udp_avst_from_kernel[15].data),
             .udp_out_15_ready         (udp_avst_from_kernel[15].ready),
             .udp_in_15_valid          (udp_avst_to_kernel[15].valid),
             .udp_in_15_data           (udp_avst_to_kernel[15].data),
             .udp_in_15_ready          (udp_avst_to_kernel[15].ready)
-        `endif //ASP_ENABLE_IOPIPE_15
+        `endif //ASP_ENABLE_IOPIPE15
     `endif
 );
 

--- a/d5005/hardware/ofs_d5005/build/rtl/ofs_asp.vh
+++ b/d5005/hardware/ofs_d5005/build/rtl/ofs_asp.vh
@@ -1,29 +1,37 @@
 // Copyright 2022 Intel Corporation
 // SPDX-License-Identifier: MIT
 
-`include "ofs_ip_cfg_mem_ss.vh"
-`include "ofs_ip_cfg_hssi_ss.vh"
-
 `ifndef ofs_asp_vh
 
     `define ofs_asp_vh
 
-    `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_0
-        `define ASP_ENABLE_DDR4_BANK_0 1
-    `endif
-    `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_1
-        `define ASP_ENABLE_DDR4_BANK_1 1
-    `endif
-    `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_2
-        `define ASP_ENABLE_DDR4_BANK_2 1
-    `endif
-    `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_3
-        `define ASP_ENABLE_DDR4_BANK_3 1
-    `endif
+    `define PAC_BSP_ENABLE_DDR4_BANK1 1
+    `define PAC_BSP_ENABLE_DDR4_BANK2 1
+    `define PAC_BSP_ENABLE_DDR4_BANK3 1
+    `define PAC_BSP_ENABLE_DDR4_BANK4 1
     
     //enable USM-support
     //`define INCLUDE_USM_SUPPORT 1
     //`define USM_DO_SINGLE_BURST_PARTIAL_WRITES 1
+
+    //enable UDP offload engine and I/O channels
+    //`define INCLUDE_IO_PIPES 1
+    //`define ASP_ENABLE_IOPIPE0 1
+    //`define ASP_ENABLE_IOPIPE1 1
+    //`define ASP_ENABLE_IOPIPE2 1
+    //`define ASP_ENABLE_IOPIPE3 1
+    //`define ASP_ENABLE_IOPIPE4 1
+    //`define ASP_ENABLE_IOPIPE5 1
+    //`define ASP_ENABLE_IOPIPE6 1
+    //`define ASP_ENABLE_IOPIPE7 1
+    //`define ASP_ENABLE_IOPIPE8 1
+    //`define ASP_ENABLE_IOPIPE9 1
+    //`define ASP_ENABLE_IOPIPE10 1
+    //`define ASP_ENABLE_IOPIPE11 1
+    //`define ASP_ENABLE_IOPIPE12 1
+    //`define ASP_ENABLE_IOPIPE13 1
+    //`define ASP_ENABLE_IOPIPE14 1
+    //`define ASP_ENABLE_IOPIPE15 1
     
     //enable kernel interrupts
     //`define USE_KERNEL_IRQ 1
@@ -49,62 +57,4 @@
     // bsp_avmm_write_ack="1" setting(s) board_spec.xml.
     //`define USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES 1
 
-    
-    //enable UDP offload engine and I/O channels
-    //`define INCLUDE_IO_PIPES 1
-    `ifdef INCLUDE_HSSI_PORT_0
-        `define ASP_ENABLE_IOPIPE_0 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_1
-        `define ASP_ENABLE_IOPIPE_1 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_2
-        `define ASP_ENABLE_IOPIPE_2 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_3
-        `define ASP_ENABLE_IOPIPE_3 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_4
-        `define ASP_ENABLE_IOPIPE_4 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_5
-        `define ASP_ENABLE_IOPIPE_5 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_6
-        `define ASP_ENABLE_IOPIPE_6 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_7
-        `define ASP_ENABLE_IOPIPE_7 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_8
-        `define ASP_ENABLE_IOPIPE_8 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_9
-        `define ASP_ENABLE_IOPIPE_9 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_10
-        `define ASP_ENABLE_IOPIPE_10 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_11
-        `define ASP_ENABLE_IOPIPE_11 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_12
-        `define ASP_ENABLE_IOPIPE_12 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_12
-        `define ASP_ENABLE_IOPIPE_12 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_13
-        `define ASP_ENABLE_IOPIPE_13 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_13
-        `define ASP_ENABLE_IOPIPE_13 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_14
-        `define ASP_ENABLE_IOPIPE_14 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_15
-        `define ASP_ENABLE_IOPIPE_15 1
-    `endif
-    
 `endif

--- a/d5005/hardware/ofs_d5005/build/rtl/ofs_asp_pkg.sv
+++ b/d5005/hardware/ofs_d5005/build/rtl/ofs_asp_pkg.sv
@@ -102,11 +102,7 @@ package ofs_asp_pkg;
     parameter USM_CCB_COMMAND_ALMFULL_THRESHOLD = 16;
     
     //number of IO Channels/Pipes enabled in the ASP.
-    `ifdef INCLUDE_IO_PIPES
-        parameter IO_PIPES_NUM_CHAN = `OFS_FIM_IP_CFG_HSSI_SS_NUM_ETH_PORTS;
-    `else
-        parameter IO_PIPES_NUM_CHAN = 0;
-    `endif
+    parameter IO_PIPES_NUM_CHAN = 5'h00;
     //Avalon Streaming data width - I/O Pipe connection to kernel-system
     parameter ASP_ETH_PKT_DATA_WIDTH = ofs_fim_eth_if_pkg::ETH_PACKET_WIDTH;
     

--- a/d5005/hardware/ofs_d5005_usm/build/rtl/bsp_logic.sv
+++ b/d5005/hardware/ofs_d5005_usm/build/rtl/bsp_logic.sv
@@ -93,7 +93,7 @@ board board_inst (
     .kernel_irq_irq                     (kernel_control.kernel_irq),                                //   kernel_irq.irq
     .kernel_reset_reset_n               (kernel_control.kernel_reset_n),                            // kernel_reset.reset_n
     
-    `ifdef ASP_ENABLE_DDR4_BANK_0
+    `ifdef PAC_BSP_ENABLE_DDR4_BANK1
         .emif_ddr4a_clk_clk         (local_mem[0].clk),
         .emif_ddr4a_waitrequest     (local_mem[0].waitrequest),
         .emif_ddr4a_readdata        (local_mem[0].readdata),
@@ -115,7 +115,7 @@ board board_inst (
         .kernel_ddr4a_read          (kernel_mem[0].read),
         .kernel_ddr4a_byteenable    (kernel_mem[0].byteenable),
     `endif
-    `ifdef ASP_ENABLE_DDR4_BANK_1
+    `ifdef PAC_BSP_ENABLE_DDR4_BANK2
         .emif_ddr4b_clk_clk         (local_mem[1].clk),
         .emif_ddr4b_waitrequest     (local_mem[1].waitrequest),
         .emif_ddr4b_readdata        (local_mem[1].readdata),
@@ -137,7 +137,7 @@ board board_inst (
         .kernel_ddr4b_read          (kernel_mem[1].read),
         .kernel_ddr4b_byteenable    (kernel_mem[1].byteenable),
     `endif
-    `ifdef ASP_ENABLE_DDR4_BANK_2
+    `ifdef PAC_BSP_ENABLE_DDR4_BANK3
         .emif_ddr4c_clk_clk         (local_mem[2].clk),
         .emif_ddr4c_waitrequest     (local_mem[2].waitrequest),
         .emif_ddr4c_readdata        (local_mem[2].readdata),
@@ -159,7 +159,7 @@ board board_inst (
         .kernel_ddr4c_read          (kernel_mem[2].read),
         .kernel_ddr4c_byteenable    (kernel_mem[2].byteenable),
     `endif
-    `ifdef ASP_ENABLE_DDR4_BANK_3
+    `ifdef PAC_BSP_ENABLE_DDR4_BANK4
         .emif_ddr4d_clk_clk         (local_mem[3].clk),
         .emif_ddr4d_waitrequest     (local_mem[3].waitrequest),
         .emif_ddr4d_readdata        (local_mem[3].readdata),

--- a/d5005/hardware/ofs_d5005_usm/build/rtl/kernel_wrapper.v
+++ b/d5005/hardware/ofs_d5005_usm/build/rtl/kernel_wrapper.v
@@ -172,7 +172,7 @@ kernel_system kernel_system_inst (
     .clock_reset2x_clk            (clk2x),
     .clock_reset_reset_reset_n    (reset_n),
     
-    `ifdef ASP_ENABLE_DDR4_BANK_0
+    `ifdef PAC_BSP_ENABLE_DDR4_BANK1
         .kernel_ddr4a_waitrequest     (mem_avmm_bridge[0].waitrequest  ),
         .kernel_ddr4a_readdata        (mem_avmm_bridge[0].readdata     ),
         .kernel_ddr4a_readdatavalid   (mem_avmm_bridge[0].readdatavalid),
@@ -182,11 +182,11 @@ kernel_system kernel_system_inst (
         .kernel_ddr4a_write           (mem_avmm_bridge[0].write        ),
         .kernel_ddr4a_read            (mem_avmm_bridge[0].read         ),
         .kernel_ddr4a_byteenable      (mem_avmm_bridge[0].byteenable   ),
-    `ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
-            .kernel_ddr4a_writeack    (mem_avmm_bridge[0].writeack     ),
+	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+	    .kernel_ddr4a_writeack        (mem_avmm_bridge[0].writeack     ),
+	`endif
     `endif
-    `endif
-    `ifdef ASP_ENABLE_DDR4_BANK_1
+    `ifdef PAC_BSP_ENABLE_DDR4_BANK2
         .kernel_ddr4b_waitrequest     (mem_avmm_bridge[1].waitrequest  ),
         .kernel_ddr4b_readdata        (mem_avmm_bridge[1].readdata     ),
         .kernel_ddr4b_readdatavalid   (mem_avmm_bridge[1].readdatavalid),
@@ -196,11 +196,11 @@ kernel_system kernel_system_inst (
         .kernel_ddr4b_write           (mem_avmm_bridge[1].write        ),
         .kernel_ddr4b_read            (mem_avmm_bridge[1].read         ),
         .kernel_ddr4b_byteenable      (mem_avmm_bridge[1].byteenable   ),
-    `ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
-        .kernel_ddr4b_writeack        (mem_avmm_bridge[1].writeack     ),
+    	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+	    .kernel_ddr4b_writeack        (mem_avmm_bridge[1].writeack     ),
+	`endif
     `endif
-    `endif
-    `ifdef ASP_ENABLE_DDR4_BANK_2
+    `ifdef PAC_BSP_ENABLE_DDR4_BANK3
         .kernel_ddr4c_waitrequest     (mem_avmm_bridge[2].waitrequest  ),
         .kernel_ddr4c_readdata        (mem_avmm_bridge[2].readdata     ),
         .kernel_ddr4c_readdatavalid   (mem_avmm_bridge[2].readdatavalid),
@@ -210,11 +210,11 @@ kernel_system kernel_system_inst (
         .kernel_ddr4c_write           (mem_avmm_bridge[2].write        ),
         .kernel_ddr4c_read            (mem_avmm_bridge[2].read         ),
         .kernel_ddr4c_byteenable      (mem_avmm_bridge[2].byteenable   ),
-    `ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
-            .kernel_ddr4c_writeack    (mem_avmm_bridge[2].writeack     ),
+	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+            .kernel_ddr4c_writeack        (mem_avmm_bridge[2].writeack     ),
+	`endif
     `endif
-    `endif
-    `ifdef ASP_ENABLE_DDR4_BANK_3
+    `ifdef PAC_BSP_ENABLE_DDR4_BANK4
         .kernel_ddr4d_waitrequest     (mem_avmm_bridge[3].waitrequest  ),
         .kernel_ddr4d_readdata        (mem_avmm_bridge[3].readdata     ),
         .kernel_ddr4d_readdatavalid   (mem_avmm_bridge[3].readdatavalid),
@@ -224,9 +224,9 @@ kernel_system kernel_system_inst (
         .kernel_ddr4d_write           (mem_avmm_bridge[3].write        ),
         .kernel_ddr4d_read            (mem_avmm_bridge[3].read         ),
         .kernel_ddr4d_byteenable      (mem_avmm_bridge[3].byteenable   ),
-    `ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
-        .kernel_ddr4d_writeack        (mem_avmm_bridge[3].writeack     ),
-    `endif
+	`ifdef USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES
+	    .kernel_ddr4d_writeack        (mem_avmm_bridge[3].writeack     ),
+    	`endif
     `endif
 
     .kernel_irq_irq                 (kernel_cra_avmm_bridge.kernel_irq),
@@ -254,134 +254,134 @@ kernel_system kernel_system_inst (
     `endif //INCLUDE_USM_SUPPORT
     
     `ifdef INCLUDE_IO_PIPES
-        `ifdef ASP_ENABLE_IOPIPE_0
+        `ifdef ASP_ENABLE_IOPIPE0
             ,.udp_out_valid        (udp_avst_from_kernel[0].valid),
             .udp_out_data          (udp_avst_from_kernel[0].data),
             .udp_out_ready         (udp_avst_from_kernel[0].ready),
             .udp_in_valid          (udp_avst_to_kernel[0].valid),
             .udp_in_data           (udp_avst_to_kernel[0].data),
             .udp_in_ready          (udp_avst_to_kernel[0].ready)
-        `endif //ASP_ENABLE_IOPIPE_0
-        `ifdef ASP_ENABLE_IOPIPE_1
+        `endif //ASP_ENABLE_IOPIPE0
+        `ifdef ASP_ENABLE_IOPIPE1
             ,.udp_out_1_valid        (udp_avst_from_kernel[1].valid),
             .udp_out_1_data          (udp_avst_from_kernel[1].data),
             .udp_out_1_ready         (udp_avst_from_kernel[1].ready),
             .udp_in_1_valid          (udp_avst_to_kernel[1].valid),
             .udp_in_1_data           (udp_avst_to_kernel[1].data),
             .udp_in_1_ready          (udp_avst_to_kernel[1].ready)
-        `endif //ASP_ENABLE_IOPIPE_1
-        `ifdef ASP_ENABLE_IOPIPE_2
+        `endif //ASP_ENABLE_IOPIPE1
+        `ifdef ASP_ENABLE_IOPIPE2
             ,.udp_out_2_valid        (udp_avst_from_kernel[2].valid),
             .udp_out_2_data          (udp_avst_from_kernel[2].data),
             .udp_out_2_ready         (udp_avst_from_kernel[2].ready),
             .udp_in_2_valid          (udp_avst_to_kernel[2].valid),
             .udp_in_2_data           (udp_avst_to_kernel[2].data),
             .udp_in_2_ready          (udp_avst_to_kernel[2].ready)
-        `endif //ASP_ENABLE_IOPIPE_2
-        `ifdef ASP_ENABLE_IOPIPE_3
+        `endif //ASP_ENABLE_IOPIPE2
+        `ifdef ASP_ENABLE_IOPIPE3
             ,.udp_out_3_valid        (udp_avst_from_kernel[3].valid),
             .udp_out_3_data          (udp_avst_from_kernel[3].data),
             .udp_out_3_ready         (udp_avst_from_kernel[3].ready),
             .udp_in_3_valid          (udp_avst_to_kernel[3].valid),
             .udp_in_3_data           (udp_avst_to_kernel[3].data),
             .udp_in_3_ready          (udp_avst_to_kernel[3].ready)
-        `endif //ASP_ENABLE_IOPIPE_3
-        `ifdef ASP_ENABLE_IOPIPE_4
+        `endif //ASP_ENABLE_IOPIPE3
+        `ifdef ASP_ENABLE_IOPIPE4
             ,.udp_out_4_valid        (udp_avst_from_kernel[4].valid),
             .udp_out_4_data          (udp_avst_from_kernel[4].data),
             .udp_out_4_ready         (udp_avst_from_kernel[4].ready),
             .udp_in_4_valid          (udp_avst_to_kernel[4].valid),
             .udp_in_4_data           (udp_avst_to_kernel[4].data),
             .udp_in_4_ready          (udp_avst_to_kernel[4].ready)
-        `endif //ASP_ENABLE_IOPIPE_4
-        `ifdef ASP_ENABLE_IOPIPE_5
+        `endif //ASP_ENABLE_IOPIPE4
+        `ifdef ASP_ENABLE_IOPIPE5
             ,.udp_out_5_valid        (udp_avst_from_kernel[5].valid),
             .udp_out_5_data          (udp_avst_from_kernel[5].data),
             .udp_out_5_ready         (udp_avst_from_kernel[5].ready),
             .udp_in_5_valid          (udp_avst_to_kernel[5].valid),
             .udp_in_5_data           (udp_avst_to_kernel[5].data),
             .udp_in_5_ready          (udp_avst_to_kernel[5].ready)
-        `endif //ASP_ENABLE_IOPIPE_5
-        `ifdef ASP_ENABLE_IOPIPE_6
+        `endif //ASP_ENABLE_IOPIPE5
+        `ifdef ASP_ENABLE_IOPIPE6
             ,.udp_out_6_valid        (udp_avst_from_kernel[6].valid),
             .udp_out_6_data          (udp_avst_from_kernel[6].data),
             .udp_out_6_ready         (udp_avst_from_kernel[6].ready),
             .udp_in_6_valid          (udp_avst_to_kernel[6].valid),
             .udp_in_6_data           (udp_avst_to_kernel[6].data),
             .udp_in_6_ready          (udp_avst_to_kernel[6].ready)
-        `endif //ASP_ENABLE_IOPIPE_6
-        `ifdef ASP_ENABLE_IOPIPE_7
+        `endif //ASP_ENABLE_IOPIPE6
+        `ifdef ASP_ENABLE_IOPIPE7
             ,.udp_out_7_valid        (udp_avst_from_kernel[7].valid),
             .udp_out_7_data          (udp_avst_from_kernel[7].data),
             .udp_out_7_ready         (udp_avst_from_kernel[7].ready),
             .udp_in_7_valid          (udp_avst_to_kernel[7].valid),
             .udp_in_7_data           (udp_avst_to_kernel[7].data),
             .udp_in_7_ready          (udp_avst_to_kernel[7].ready)
-        `endif //ASP_ENABLE_IOPIPE_7
-        `ifdef ASP_ENABLE_IOPIPE_8
+        `endif //ASP_ENABLE_IOPIPE7
+        `ifdef ASP_ENABLE_IOPIPE8
             ,.udp_out_8_valid        (udp_avst_from_kernel[8].valid),
             .udp_out_8_data          (udp_avst_from_kernel[8].data),
             .udp_out_8_ready         (udp_avst_from_kernel[8].ready),
             .udp_in_8_valid          (udp_avst_to_kernel[8].valid),
             .udp_in_8_data           (udp_avst_to_kernel[8].data),
             .udp_in_8_ready          (udp_avst_to_kernel[8].ready)
-        `endif //ASP_ENABLE_IOPIPE_8
-        `ifdef ASP_ENABLE_IOPIPE_9
+        `endif //ASP_ENABLE_IOPIPE8
+        `ifdef ASP_ENABLE_IOPIPE9
             ,.udp_out_9_valid        (udp_avst_from_kernel[9].valid),
             .udp_out_9_data          (udp_avst_from_kernel[9].data),
             .udp_out_9_ready         (udp_avst_from_kernel[9].ready),
             .udp_in_9_valid          (udp_avst_to_kernel[9].valid),
             .udp_in_9_data           (udp_avst_to_kernel[9].data),
             .udp_in_9_ready          (udp_avst_to_kernel[9].ready)
-        `endif //ASP_ENABLE_IOPIPE_9
-        `ifdef ASP_ENABLE_IOPIPE_10
+        `endif //ASP_ENABLE_IOPIPE9
+        `ifdef ASP_ENABLE_IOPIPE10
             ,.udp_out_10_valid        (udp_avst_from_kernel[10].valid),
             .udp_out_10_data          (udp_avst_from_kernel[10].data),
             .udp_out_10_ready         (udp_avst_from_kernel[10].ready),
             .udp_in_10_valid          (udp_avst_to_kernel[10].valid),
             .udp_in_10_data           (udp_avst_to_kernel[10].data),
             .udp_in_10_ready          (udp_avst_to_kernel[10].ready)
-        `endif //ASP_ENABLE_IOPIPE_10
-        `ifdef ASP_ENABLE_IOPIPE_11
+        `endif //ASP_ENABLE_IOPIPE10
+        `ifdef ASP_ENABLE_IOPIPE11
             ,.udp_out_11_valid        (udp_avst_from_kernel[11].valid),
             .udp_out_11_data          (udp_avst_from_kernel[11].data),
             .udp_out_11_ready         (udp_avst_from_kernel[11].ready),
             .udp_in_11_valid          (udp_avst_to_kernel[11].valid),
             .udp_in_11_data           (udp_avst_to_kernel[11].data),
             .udp_in_11_ready          (udp_avst_to_kernel[11].ready)
-        `endif //ASP_ENABLE_IOPIPE_11
-        `ifdef ASP_ENABLE_IOPIPE_12
+        `endif //ASP_ENABLE_IOPIPE11
+        `ifdef ASP_ENABLE_IOPIPE12
             ,.udp_out_12_valid        (udp_avst_from_kernel[12].valid),
             .udp_out_12_data          (udp_avst_from_kernel[12].data),
             .udp_out_12_ready         (udp_avst_from_kernel[12].ready),
             .udp_in_12_valid          (udp_avst_to_kernel[12].valid),
             .udp_in_12_data           (udp_avst_to_kernel[12].data),
             .udp_in_12_ready          (udp_avst_to_kernel[12].ready)
-        `endif //ASP_ENABLE_IOPIPE_12
-        `ifdef ASP_ENABLE_IOPIPE_13
+        `endif //ASP_ENABLE_IOPIPE12
+        `ifdef ASP_ENABLE_IOPIPE13
             ,.udp_out_13_valid        (udp_avst_from_kernel[13].valid),
             .udp_out_13_data          (udp_avst_from_kernel[13].data),
             .udp_out_13_ready         (udp_avst_from_kernel[13].ready),
             .udp_in_13_valid          (udp_avst_to_kernel[13].valid),
             .udp_in_13_data           (udp_avst_to_kernel[13].data),
             .udp_in_13_ready          (udp_avst_to_kernel[13].ready)
-        `endif //ASP_ENABLE_IOPIPE_13
-        `ifdef ASP_ENABLE_IOPIPE_14
+        `endif //ASP_ENABLE_IOPIPE13
+        `ifdef ASP_ENABLE_IOPIPE14
             ,.udp_out_14_valid        (udp_avst_from_kernel[14].valid),
             .udp_out_14_data          (udp_avst_from_kernel[14].data),
             .udp_out_14_ready         (udp_avst_from_kernel[14].ready),
             .udp_in_14_valid          (udp_avst_to_kernel[14].valid),
             .udp_in_14_data           (udp_avst_to_kernel[14].data),
             .udp_in_14_ready          (udp_avst_to_kernel[14].ready)
-        `endif //ASP_ENABLE_IOPIPE_14
-        `ifdef ASP_ENABLE_IOPIPE_15
+        `endif //ASP_ENABLE_IOPIPE14
+        `ifdef ASP_ENABLE_IOPIPE15
             ,.udp_out_15_valid        (udp_avst_from_kernel[15].valid),
             .udp_out_15_data          (udp_avst_from_kernel[15].data),
             .udp_out_15_ready         (udp_avst_from_kernel[15].ready),
             .udp_in_15_valid          (udp_avst_to_kernel[15].valid),
             .udp_in_15_data           (udp_avst_to_kernel[15].data),
             .udp_in_15_ready          (udp_avst_to_kernel[15].ready)
-        `endif //ASP_ENABLE_IOPIPE_15
+        `endif //ASP_ENABLE_IOPIPE15
     `endif
 );
 

--- a/d5005/hardware/ofs_d5005_usm/build/rtl/ofs_asp.vh
+++ b/d5005/hardware/ofs_d5005_usm/build/rtl/ofs_asp.vh
@@ -1,29 +1,37 @@
 // Copyright 2022 Intel Corporation
 // SPDX-License-Identifier: MIT
 
-`include "ofs_ip_cfg_mem_ss.vh"
-`include "ofs_ip_cfg_hssi_ss.vh"
-
 `ifndef ofs_asp_vh
 
     `define ofs_asp_vh
 
-    `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_0
-        `define ASP_ENABLE_DDR4_BANK_0 1
-    `endif
-    `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_1
-        `define ASP_ENABLE_DDR4_BANK_1 1
-    `endif
-    `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_2
-        `define ASP_ENABLE_DDR4_BANK_2 1
-    `endif
-    `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_3
-        `define ASP_ENABLE_DDR4_BANK_3 1
-    `endif
+    `define PAC_BSP_ENABLE_DDR4_BANK1 1
+    `define PAC_BSP_ENABLE_DDR4_BANK2 1
+    `define PAC_BSP_ENABLE_DDR4_BANK3 1
+    `define PAC_BSP_ENABLE_DDR4_BANK4 1
     
     //enable USM-support
     `define INCLUDE_USM_SUPPORT 1
     `define USM_DO_SINGLE_BURST_PARTIAL_WRITES 1
+
+    //enable UDP offload engine and I/O channels
+    //`define INCLUDE_IO_PIPES 1
+    //`define ASP_ENABLE_IOPIPE0 1
+    //`define ASP_ENABLE_IOPIPE1 1
+    //`define ASP_ENABLE_IOPIPE2 1
+    //`define ASP_ENABLE_IOPIPE3 1
+    //`define ASP_ENABLE_IOPIPE4 1
+    //`define ASP_ENABLE_IOPIPE5 1
+    //`define ASP_ENABLE_IOPIPE6 1
+    //`define ASP_ENABLE_IOPIPE7 1
+    //`define ASP_ENABLE_IOPIPE8 1
+    //`define ASP_ENABLE_IOPIPE9 1
+    //`define ASP_ENABLE_IOPIPE10 1
+    //`define ASP_ENABLE_IOPIPE11 1
+    //`define ASP_ENABLE_IOPIPE12 1
+    //`define ASP_ENABLE_IOPIPE13 1
+    //`define ASP_ENABLE_IOPIPE14 1
+    //`define ASP_ENABLE_IOPIPE15 1
     
     //enable kernel interrupts
     //`define USE_KERNEL_IRQ 1
@@ -49,62 +57,4 @@
     // bsp_avmm_write_ack="1" setting(s) board_spec.xml.
     //`define USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES 1
 
-    
-    //enable UDP offload engine and I/O channels
-    //`define INCLUDE_IO_PIPES 1
-    `ifdef INCLUDE_HSSI_PORT_0
-        `define ASP_ENABLE_IOPIPE_0 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_1
-        `define ASP_ENABLE_IOPIPE_1 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_2
-        `define ASP_ENABLE_IOPIPE_2 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_3
-        `define ASP_ENABLE_IOPIPE_3 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_4
-        `define ASP_ENABLE_IOPIPE_4 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_5
-        `define ASP_ENABLE_IOPIPE_5 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_6
-        `define ASP_ENABLE_IOPIPE_6 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_7
-        `define ASP_ENABLE_IOPIPE_7 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_8
-        `define ASP_ENABLE_IOPIPE_8 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_9
-        `define ASP_ENABLE_IOPIPE_9 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_10
-        `define ASP_ENABLE_IOPIPE_10 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_11
-        `define ASP_ENABLE_IOPIPE_11 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_12
-        `define ASP_ENABLE_IOPIPE_12 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_12
-        `define ASP_ENABLE_IOPIPE_12 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_13
-        `define ASP_ENABLE_IOPIPE_13 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_13
-        `define ASP_ENABLE_IOPIPE_13 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_14
-        `define ASP_ENABLE_IOPIPE_14 1
-    `endif
-    `ifdef INCLUDE_HSSI_PORT_15
-        `define ASP_ENABLE_IOPIPE_15 1
-    `endif
-    
 `endif

--- a/d5005/hardware/ofs_d5005_usm/build/rtl/ofs_asp_pkg.sv
+++ b/d5005/hardware/ofs_d5005_usm/build/rtl/ofs_asp_pkg.sv
@@ -102,11 +102,7 @@ package ofs_asp_pkg;
     parameter USM_CCB_COMMAND_ALMFULL_THRESHOLD = 16;
     
     //number of IO Channels/Pipes enabled in the ASP.
-    `ifdef INCLUDE_IO_PIPES
-        parameter IO_PIPES_NUM_CHAN = `OFS_FIM_IP_CFG_HSSI_SS_NUM_ETH_PORTS;
-    `else
-        parameter IO_PIPES_NUM_CHAN = 0;
-    `endif
+    parameter IO_PIPES_NUM_CHAN = 5'h00;
     //Avalon Streaming data width - I/O Pipe connection to kernel-system
     parameter ASP_ETH_PKT_DATA_WIDTH = ofs_fim_eth_if_pkg::ETH_PACKET_WIDTH;
     


### PR DESCRIPTION
### Description
The previous PR to leverage more FIM defines/parameters didn't work for the D5005 platform. This change reverts the D5005 platform to an earlier state.


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
Compilation of some oneapi kernels, a few minutes into synthesis (past where the failures previously occurred). 

