### PR TITLE
[Update] Commonize setup-bsp.py to find default qpf and qsf files

### DIFF
--- a/d5005/scripts/setup-bsp.py
+++ b/d5005/scripts/setup-bsp.py
@@ -174,6 +174,8 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     #find the Quartus-build folder expected by the FIM
     #use syn_top for now, but it might change depending on FIM board/variant/etc
     QUARTUS_SYN_DIR=get_dir_path("syn_top",bsp_dir)
+    if verbose:
+        print("QUARTUS_SYN_DIR is %s" % (QUARTUS_SYN_DIR))
     ASP_BASE_DIR_ABS=bsp_dir
     
     QUARTUS_BUILD_DIR_RELATIVE_TO_ASP_BUILD_DIR=os.path.relpath(QUARTUS_SYN_DIR,bsp_qsf_dir)
@@ -205,8 +207,8 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     ASP_BUILD_DIR_SYMLINK_CMD="cd " + QUARTUS_SYN_DIR + " && ln -sf " + ASP_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR + "/* ."
     run_cmd(ASP_BUILD_DIR_SYMLINK_CMD)
     
-    PR_AFU_QPF_FILENAME=os.path.basename(glob.glob(bsp_dir + '/*.qpf')[0])
-    PR_AFU_QSF_FILENAME=os.path.basename(glob.glob(bsp_dir + '/*pr_afu.qsf')[0])
+    PR_AFU_QPF_FILENAME=os.path.basename(glob.glob(QUARTUS_SYN_DIR + "/*.qpf")[0])
+    PR_AFU_QSF_FILENAME=os.path.basename(glob.glob(QUARTUS_SYN_DIR + "/*pr_afu.qsf")[0])
     if verbose:
         print("PR_AFU_QPF_FILENAME is %s" % PR_AFU_QPF_FILENAME)
     if verbose:

--- a/d5005/scripts/setup-bsp.py
+++ b/d5005/scripts/setup-bsp.py
@@ -202,23 +202,22 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     
     #symlink the contents of bsp_dir/build into syn_top
     BSP_BUILD_DIR_FILES=os.path.join(bsp_qsf_dir, '*')
-    ASP_BUILD_DIR_SYMLINK_CMD="cd " + QUARTUS_SYN_DIR + " && ln -s " + ASP_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR + "/* ."
+    ASP_BUILD_DIR_SYMLINK_CMD="cd " + QUARTUS_SYN_DIR + " && ln -sf " + ASP_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR + "/* ."
     run_cmd(ASP_BUILD_DIR_SYMLINK_CMD)
     
-    #symlink the (i)ofs_top.qpf and (i)ofs_pr_afu.qsf file to bsp_dir
-    if "n6001" in bsp:
-        PR_AFU_QSF_FILENAME="ofs_pr_afu.qsf"
-        PR_AFU_QPF_FILENAME="ofs_top.qpf"
-    else:
-        PR_AFU_QSF_FILENAME="iofs_pr_afu.qsf"
-        PR_AFU_QPF_FILENAME="d5005.qpf"
-        
-    rm_glob(os.path.join(bsp_dir, PR_AFU_QSF_FILENAME))
-    OFS_PR_AFU_QSF_SYMLINK_CMD="cd " + bsp_dir + " && ln -s " + QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR + "/" + PR_AFU_QSF_FILENAME + " ."
+    PR_AFU_QPF_FILENAME=os.path.basename(glob.glob(bsp_dir + '/*.qpf')[0])
+    PR_AFU_QSF_FILENAME=os.path.basename(glob.glob(bsp_dir + '/*pr_afu.qsf')[0])
+    if verbose:
+        print("PR_AFU_QPF_FILENAME is %s" % PR_AFU_QPF_FILENAME)
+    if verbose:
+        print("PR_AFU_QSF_FILENAME is %s" % PR_AFU_QSF_FILENAME)
+    
+    rm_glob(os.path.join(bsp_dir, PR_AFU_QSF_FILENAME)) 
+    OFS_PR_AFU_QSF_SYMLINK_CMD="cd " + bsp_dir + " && ln -sf " + QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR + "/" + PR_AFU_QSF_FILENAME + " ."
     run_cmd(OFS_PR_AFU_QSF_SYMLINK_CMD)
 
     rm_glob(os.path.join(bsp_dir, PR_AFU_QPF_FILENAME))
-    OFS_TOP_QPF_SYMLINK_CMD="cd " + bsp_dir + " && ln -s " + QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR + "/" + PR_AFU_QPF_FILENAME + " ."
+    OFS_TOP_QPF_SYMLINK_CMD="cd " + bsp_dir + " && ln -sf " + QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR + "/" + PR_AFU_QPF_FILENAME + " ."
     run_cmd(OFS_TOP_QPF_SYMLINK_CMD)
     
     print("\nsetup-bsp.py completed successfully for variant %s\n" % bsp)

--- a/n6001/scripts/setup-bsp.py
+++ b/n6001/scripts/setup-bsp.py
@@ -174,6 +174,8 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     #find the Quartus-build folder expected by the FIM
     #use syn_top for now, but it might change depending on FIM board/variant/etc
     QUARTUS_SYN_DIR=get_dir_path("syn_top",bsp_dir)
+    if verbose:
+        print("QUARTUS_SYN_DIR is %s" % (QUARTUS_SYN_DIR))
     ASP_BASE_DIR_ABS=bsp_dir
     
     QUARTUS_BUILD_DIR_RELATIVE_TO_ASP_BUILD_DIR=os.path.relpath(QUARTUS_SYN_DIR,bsp_qsf_dir)
@@ -205,8 +207,8 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     ASP_BUILD_DIR_SYMLINK_CMD="cd " + QUARTUS_SYN_DIR + " && ln -sf " + ASP_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR + "/* ."
     run_cmd(ASP_BUILD_DIR_SYMLINK_CMD)
     
-    PR_AFU_QPF_FILENAME=os.path.basename(glob.glob(bsp_dir + '/*.qpf')[0])
-    PR_AFU_QSF_FILENAME=os.path.basename(glob.glob(bsp_dir + '/*pr_afu.qsf')[0])
+    PR_AFU_QPF_FILENAME=os.path.basename(glob.glob(QUARTUS_SYN_DIR + "/*.qpf")[0])
+    PR_AFU_QSF_FILENAME=os.path.basename(glob.glob(QUARTUS_SYN_DIR + "/*pr_afu.qsf")[0])
     if verbose:
         print("PR_AFU_QPF_FILENAME is %s" % PR_AFU_QPF_FILENAME)
     if verbose:

--- a/n6001/scripts/setup-bsp.py
+++ b/n6001/scripts/setup-bsp.py
@@ -202,23 +202,22 @@ def setup_bsp(bsp_root, env_vars, bsp, verbose):
     
     #symlink the contents of bsp_dir/build into syn_top
     BSP_BUILD_DIR_FILES=os.path.join(bsp_qsf_dir, '*')
-    ASP_BUILD_DIR_SYMLINK_CMD="cd " + QUARTUS_SYN_DIR + " && ln -s " + ASP_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR + "/* ."
+    ASP_BUILD_DIR_SYMLINK_CMD="cd " + QUARTUS_SYN_DIR + " && ln -sf " + ASP_BUILD_DIR_RELATIVE_TO_QUARTUS_BUILD_DIR + "/* ."
     run_cmd(ASP_BUILD_DIR_SYMLINK_CMD)
     
-    #symlink the (i)ofs_top.qpf and (i)ofs_pr_afu.qsf file to bsp_dir
-    if "n6001" in bsp:
-        PR_AFU_QSF_FILENAME="ofs_pr_afu.qsf"
-        PR_AFU_QPF_FILENAME="ofs_top.qpf"
-    else:
-        PR_AFU_QSF_FILENAME="iofs_pr_afu.qsf"
-        PR_AFU_QPF_FILENAME="d5005.qpf"
-        
-    rm_glob(os.path.join(bsp_dir, PR_AFU_QSF_FILENAME))
-    OFS_PR_AFU_QSF_SYMLINK_CMD="cd " + bsp_dir + " && ln -s " + QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR + "/" + PR_AFU_QSF_FILENAME + " ."
+    PR_AFU_QPF_FILENAME=os.path.basename(glob.glob(bsp_dir + '/*.qpf')[0])
+    PR_AFU_QSF_FILENAME=os.path.basename(glob.glob(bsp_dir + '/*pr_afu.qsf')[0])
+    if verbose:
+        print("PR_AFU_QPF_FILENAME is %s" % PR_AFU_QPF_FILENAME)
+    if verbose:
+        print("PR_AFU_QSF_FILENAME is %s" % PR_AFU_QSF_FILENAME)
+    
+    rm_glob(os.path.join(bsp_dir, PR_AFU_QSF_FILENAME)) 
+    OFS_PR_AFU_QSF_SYMLINK_CMD="cd " + bsp_dir + " && ln -sf " + QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR + "/" + PR_AFU_QSF_FILENAME + " ."
     run_cmd(OFS_PR_AFU_QSF_SYMLINK_CMD)
 
     rm_glob(os.path.join(bsp_dir, PR_AFU_QPF_FILENAME))
-    OFS_TOP_QPF_SYMLINK_CMD="cd " + bsp_dir + " && ln -s " + QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR + "/" + PR_AFU_QPF_FILENAME + " ."
+    OFS_TOP_QPF_SYMLINK_CMD="cd " + bsp_dir + " && ln -sf " + QUARTUS_BUILD_DIR_RELATIVE_TO_KERNEL_BUILD_DIR + "/" + PR_AFU_QPF_FILENAME + " ."
     run_cmd(OFS_TOP_QPF_SYMLINK_CMD)
     
     print("\nsetup-bsp.py completed successfully for variant %s\n" % bsp)


### PR DESCRIPTION
### Description
This change adds some intelligence to the setup-bsp.py script to find the appropriate qpf and qsf files from the pr-build-template folder and symlink them where the OneAPI build-flow expects them to be. Previously these files were hardcoded depending on whether the platform was d5005 or n6001, but that wasn't helpful when porting FIMs. This should simplify porting the ASP to different platforms (as long as the filenames are somewhat consistent).


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
Ran build-bsp.py for both n6001 and d5005, and then successfully compiled many oneapi-samples designs.

