### PR TITLE
[Update] : HSD 14020208380, fixed PCIe Gen3 reference peak speed and added one for PCIe Gen4

### DIFF
--- a/common/source/util/diagnostic/main.cpp
+++ b/common/source/util/diagnostic/main.cpp
@@ -338,7 +338,8 @@ int main(int argc, char *argv[]) {
   printf("\nAs a reference:\n");
   printf("PCIe Gen1 peak speed: 250MB/s/lane\n");
   printf("PCIe Gen2 peak speed: 500MB/s/lane\n");
-  printf("PCIe Gen3 peak speed: 985MB/s/lane\n");
+  printf("PCIe Gen3 peak speed: 1GB/s/lane\n");
+  printf("PCIe Gen4 peak speed: 2GB/s/lane\n");
 
   printf("\n");
   printf("Writing %d KBs with block size (in bytes) below:\n", maxbytes / 1024);


### PR DESCRIPTION
### Description
*Describe the issue, update, change or fix and **why***
HSD 14020208380. Added peak reference speed for PCIe Gen4 for users reference and updated peak speeds for PCIe Gen3.

### Tests added: NA


### Tests run: aocl diagnose all


