### PR TITLE
[Update] use -Xstarget for icpx compiler

### DIFF
--- a/common/scripts/build-default-binaries.sh
+++ b/common/scripts/build-default-binaries.sh
@@ -71,7 +71,7 @@ do
     echo -e "Using oneAPI compiler version:\n$(icpx --version)\n"
     echo -e "Using Quartus version:\n$(quartus_sh --version)"
     echo "---------------------------------------------------------------"
-    this_cmd="icpx -fsycl -fintelfpga -Xshardware -Xsboard-package="$ASP_ROOT" -Xstarget="$this_variant" -Xsbsp-flow="$ASP_FLOW" -Xsno-interleaving=default "$ASP_ROOT/$CPP_FILE" -o "$this_variant".fpga"
+    this_cmd="icpx -fsycl -fintelfpga -Xshardware -Xstarget="$ASP_ROOT":"$this_variant" -Xsbsp-flow="$ASP_FLOW" -Xsno-interleaving=default "$ASP_ROOT/$CPP_FILE" -o "$this_variant".fpga"
     #display the build cmd we'll run
     echo "Running this command: ${this_cmd}"
     #run the command


### PR DESCRIPTION
### Description
The build-default-binaries.sh script did not use the official command line argument -Xstarget for passing in the ASP path and board variant when building the designs. This is fixed with this PR.

### Collateral (docs, reports, design examples, case IDs):
none

### Tests added:
none

### Tests run:
- ran build-default-binaries.sh script after the fix to ensure the default binary files would be correctly built -> passed

