### PR TITLE
[Update] - modify the fseries-dk platform to 2 channels of DDR

### DIFF
--- a/fseries-dk/hardware/ofs_fseries-dk/board_spec.xml
+++ b/fseries-dk/hardware/ofs_fseries-dk/board_spec.xml
@@ -33,8 +33,6 @@
   <global_mem name="DDR" max_bandwidth="76800" interleaved_bytes="4096" config_addr="0x018">
     <interface name="board" port="kernel_ddr4a" type="agent" width="512" maxburst="16" address="0x000000000" size="0x200000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
     <interface name="board" port="kernel_ddr4b" type="agent" width="512" maxburst="16" address="0x200000000" size="0x200000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
-    <interface name="board" port="kernel_ddr4c" type="agent" width="512" maxburst="16" address="0x400000000" size="0x200000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
-    <interface name="board" port="kernel_ddr4d" type="agent" width="512" maxburst="16" address="0x600000000" size="0x200000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
   </global_mem>
     
   <host>

--- a/fseries-dk/hardware/ofs_fseries-dk/build/board_hw.tcl
+++ b/fseries-dk/hardware/ofs_fseries-dk/build/board_hw.tcl
@@ -27,8 +27,8 @@ set_parameter_property IOPIPE_SUPPORT DEFAULT_VALUE false
 set_parameter_property IOPIPE_SUPPORT DISPLAY_NAME "IO Pipe Support"
 set_parameter_property IOPIPE_SUPPORT AFFECTS_ELABORATION true
  
-add_parameter NUMBER_OF_MEMORY_BANKS INTEGER 4
-set_parameter_property NUMBER_OF_MEMORY_BANKS DEFAULT_VALUE 4
+add_parameter NUMBER_OF_MEMORY_BANKS INTEGER 3
+set_parameter_property NUMBER_OF_MEMORY_BANKS DEFAULT_VALUE 3
 set_parameter_property NUMBER_OF_MEMORY_BANKS DISPLAY_NAME "Number of Memory Banks"
 set_parameter_property NUMBER_OF_MEMORY_BANKS AFFECTS_ELABORATION true
 

--- a/fseries-dk/hardware/ofs_fseries-dk/build/board_hw.tcl
+++ b/fseries-dk/hardware/ofs_fseries-dk/build/board_hw.tcl
@@ -27,8 +27,8 @@ set_parameter_property IOPIPE_SUPPORT DEFAULT_VALUE false
 set_parameter_property IOPIPE_SUPPORT DISPLAY_NAME "IO Pipe Support"
 set_parameter_property IOPIPE_SUPPORT AFFECTS_ELABORATION true
  
-add_parameter NUMBER_OF_MEMORY_BANKS INTEGER 3
-set_parameter_property NUMBER_OF_MEMORY_BANKS DEFAULT_VALUE 3
+add_parameter NUMBER_OF_MEMORY_BANKS INTEGER 2
+set_parameter_property NUMBER_OF_MEMORY_BANKS DEFAULT_VALUE 2
 set_parameter_property NUMBER_OF_MEMORY_BANKS DISPLAY_NAME "Number of Memory Banks"
 set_parameter_property NUMBER_OF_MEMORY_BANKS AFFECTS_ELABORATION true
 

--- a/fseries-dk/hardware/ofs_fseries-dk_usm/board_spec.xml
+++ b/fseries-dk/hardware/ofs_fseries-dk_usm/board_spec.xml
@@ -37,8 +37,6 @@
   <global_mem name="device" max_bandwidth="76800" interleaved_bytes="4096" config_addr="0x018" allocation_type="device" default="1">
     <interface name="board" port="kernel_ddr4a" type="agent" width="512" maxburst="16" address="0x1000000000000" size="0x200000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
     <interface name="board" port="kernel_ddr4b" type="agent" width="512" maxburst="16" address="0x1000200000000" size="0x200000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
-    <interface name="board" port="kernel_ddr4c" type="agent" width="512" maxburst="16" address="0x1000400000000" size="0x200000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
-    <interface name="board" port="kernel_ddr4d" type="agent" width="512" maxburst="16" address="0x1000600000000" size="0x200000000" latency="1500" waitrequest_allowance="6" bsp_avmm_write_ack="1"/>
   </global_mem>
     
   <host>

--- a/fseries-dk/hardware/ofs_fseries-dk_usm/build/board_hw.tcl
+++ b/fseries-dk/hardware/ofs_fseries-dk_usm/build/board_hw.tcl
@@ -27,8 +27,8 @@ set_parameter_property IOPIPE_SUPPORT DEFAULT_VALUE false
 set_parameter_property IOPIPE_SUPPORT DISPLAY_NAME "IO Pipe Support"
 set_parameter_property IOPIPE_SUPPORT AFFECTS_ELABORATION true
  
-add_parameter NUMBER_OF_MEMORY_BANKS INTEGER 4
-set_parameter_property NUMBER_OF_MEMORY_BANKS DEFAULT_VALUE 4
+add_parameter NUMBER_OF_MEMORY_BANKS INTEGER 2
+set_parameter_property NUMBER_OF_MEMORY_BANKS DEFAULT_VALUE 2
 set_parameter_property NUMBER_OF_MEMORY_BANKS DISPLAY_NAME "Number of Memory Banks"
 set_parameter_property NUMBER_OF_MEMORY_BANKS AFFECTS_ELABORATION true
 


### PR DESCRIPTION
### Description
The default FIM for fseries-dk provides 2 channels of DDR memory. This PR changes the default number of channels in the ASP from 4 to 2.


### Collateral (docs, reports, design examples, case IDs):
None

### Tests run:
Host crashes following an unsuccessful PR (aocl initialize acl0 mydesign.fpga). So, the fseries-dk platform needs to be debugged.