### PR TITLE
[Fix] change last pipeline stage to 16 pending read responses (for fixing merge_sort design)

### DIFF
--- a/common/hardware/common/build/ddr_channel_hw.tcl
+++ b/common/hardware/common/build/ddr_channel_hw.tcl
@@ -53,7 +53,7 @@ proc compose { } {
   set_instance_parameter_value ddr4_emif_pipe {ADDRESS_WIDTH} $memory_bank_address_width
   set_instance_parameter_value ddr4_emif_pipe {ADDRESS_UNITS} {SYMBOLS}
   set_instance_parameter_value ddr4_emif_pipe {MAX_BURST_SIZE} {16}
-  set_instance_parameter_value ddr4_emif_pipe {MAX_PENDING_RESPONSES} {64}
+  set_instance_parameter_value ddr4_emif_pipe {MAX_PENDING_RESPONSES} {16}
   set_instance_parameter_value ddr4_emif_pipe {LINEWRAPBURSTS} {0}
   set_instance_parameter_value ddr4_emif_pipe {SYNCHRONIZE_RESET} {1}
   set_instance_parameter_value ddr4_emif_pipe {DISABLE_WAITREQUEST_BUFFERING} {0}


### PR DESCRIPTION
### Description
This change matches the original settings of the last pipeline stage before the DDR subsystem to have 16 pending read responses instead of 64. This was overseen as being the configuration in the original .qsys system and changed when moved to _hw.tcl scripts.

### Collateral (docs, reports, design examples, case IDs):


### Tests added:


### Tests run:
- compiled and ran oneAPI samples design "merge_sort" on N6001 -> passed
- testing all other designs on N6001
