### PR TITLE
[Fix]- Update n6001/iseries/fseries header assignments

### DIFF
--- a/fseries-dk/hardware/common/build/rtl/ofs_asp_pkg.sv
+++ b/fseries-dk/hardware/common/build/rtl/ofs_asp_pkg.sv
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 `include "ofs_asp.vh"
-`include "ofs_ip_cfg_hssi_ss.vh"
 
 package ofs_asp_pkg;
 

--- a/fseries-dk/hardware/ofs_fseries-dk/build/rtl/ofs_asp.vh
+++ b/fseries-dk/hardware/ofs_fseries-dk/build/rtl/ofs_asp.vh
@@ -1,8 +1,8 @@
 // Copyright 2022 Intel Corporation
 // SPDX-License-Identifier: MIT
 
-`include "ofs_ip_cfg_mem_ss.vh"
-`include "ofs_ip_cfg_hssi_ss.vh"
+//This is the database of header files included in the FIM-build.
+`include "ofs_ip_cfg_db.vh"
 
 `ifndef ofs_asp_vh
 

--- a/fseries-dk/hardware/ofs_fseries-dk_usm/build/rtl/ofs_asp.vh
+++ b/fseries-dk/hardware/ofs_fseries-dk_usm/build/rtl/ofs_asp.vh
@@ -1,8 +1,8 @@
 // Copyright 2022 Intel Corporation
 // SPDX-License-Identifier: MIT
 
-`include "ofs_ip_cfg_mem_ss.vh"
-`include "ofs_ip_cfg_hssi_ss.vh"
+//This is the database of header files included in the FIM-build.
+`include "ofs_ip_cfg_db.vh"
 
 `ifndef ofs_asp_vh
 

--- a/iseries-dk/hardware/common/build/rtl/ofs_asp_pkg.sv
+++ b/iseries-dk/hardware/common/build/rtl/ofs_asp_pkg.sv
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 `include "ofs_asp.vh"
-`include "ofs_ip_cfg_hssi_ss.vh"
 
 package ofs_asp_pkg;
 

--- a/iseries-dk/hardware/ofs_iseries-dk/build/rtl/ofs_asp.vh
+++ b/iseries-dk/hardware/ofs_iseries-dk/build/rtl/ofs_asp.vh
@@ -1,8 +1,8 @@
 // Copyright 2022 Intel Corporation
 // SPDX-License-Identifier: MIT
 
-`include "ofs_ip_cfg_mem_ss.vh"
-`include "ofs_ip_cfg_hssi_ss.vh"
+//This is the database of header files included in the FIM-build.
+`include "ofs_ip_cfg_db.vh"
 
 `ifndef ofs_asp_vh
 

--- a/iseries-dk/hardware/ofs_iseries-dk_usm/build/rtl/ofs_asp.vh
+++ b/iseries-dk/hardware/ofs_iseries-dk_usm/build/rtl/ofs_asp.vh
@@ -1,8 +1,8 @@
 // Copyright 2022 Intel Corporation
 // SPDX-License-Identifier: MIT
 
-`include "ofs_ip_cfg_mem_ss.vh"
-`include "ofs_ip_cfg_hssi_ss.vh"
+//This is the database of header files included in the FIM-build.
+`include "ofs_ip_cfg_db.vh"
 
 `ifndef ofs_asp_vh
 

--- a/n6001/hardware/common/build/rtl/ofs_asp_pkg.sv
+++ b/n6001/hardware/common/build/rtl/ofs_asp_pkg.sv
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 `include "ofs_asp.vh"
-`include "ofs_ip_cfg_hssi_ss.vh"
 
 package ofs_asp_pkg;
 

--- a/n6001/hardware/ofs_n6001/build/rtl/ofs_asp.vh
+++ b/n6001/hardware/ofs_n6001/build/rtl/ofs_asp.vh
@@ -1,8 +1,8 @@
 // Copyright 2022 Intel Corporation
 // SPDX-License-Identifier: MIT
 
-`include "ofs_ip_cfg_mem_ss.vh"
-`include "ofs_ip_cfg_hssi_ss.vh"
+//This is the database of header files included in the FIM-build.
+`include "ofs_ip_cfg_db.vh"
 
 `ifndef ofs_asp_vh
 
@@ -17,16 +17,27 @@
     //`define ASP_ENABLE_HOSTMEM_CH_2 1
     //`define ASP_ENABLE_HOSTMEM_CH_3 1
 
+    //the FIM changed the 'mem_ss' define name to
+    // 'local_mem'; make it backward compatible (at 
+    // the expense of being verbose and ugly)
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_0
+        `define ASP_ENABLE_DDR4_BANK_0 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_0
         `define ASP_ENABLE_DDR4_BANK_0 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_1
         `define ASP_ENABLE_DDR4_BANK_1 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
+        `define ASP_ENABLE_DDR4_BANK_1 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_2
         `define ASP_ENABLE_DDR4_BANK_2 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
+        `define ASP_ENABLE_DDR4_BANK_1 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_3
+        `define ASP_ENABLE_DDR4_BANK_3 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_3
         `define ASP_ENABLE_DDR4_BANK_3 1
     `endif
     

--- a/n6001/hardware/ofs_n6001_iopipes/build/rtl/ofs_asp.vh
+++ b/n6001/hardware/ofs_n6001_iopipes/build/rtl/ofs_asp.vh
@@ -1,8 +1,8 @@
 // Copyright 2022 Intel Corporation
 // SPDX-License-Identifier: MIT
 
-`include "ofs_ip_cfg_mem_ss.vh"
-`include "ofs_ip_cfg_hssi_ss.vh"
+//This is the database of header files included in the FIM-build.
+`include "ofs_ip_cfg_db.vh"
 
 `ifndef ofs_asp_vh
 

--- a/n6001/hardware/ofs_n6001_usm/build/rtl/ofs_asp.vh
+++ b/n6001/hardware/ofs_n6001_usm/build/rtl/ofs_asp.vh
@@ -1,8 +1,8 @@
 // Copyright 2022 Intel Corporation
 // SPDX-License-Identifier: MIT
 
-`include "ofs_ip_cfg_mem_ss.vh"
-`include "ofs_ip_cfg_hssi_ss.vh"
+//This is the database of header files included in the FIM-build.
+`include "ofs_ip_cfg_db.vh"
 
 `ifndef ofs_asp_vh
 

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/ofs_asp.vh
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/ofs_asp.vh
@@ -1,8 +1,8 @@
 // Copyright 2022 Intel Corporation
 // SPDX-License-Identifier: MIT
 
-`include "ofs_ip_cfg_mem_ss.vh"
-`include "ofs_ip_cfg_hssi_ss.vh"
+//This is the database of header files included in the FIM-build.
+`include "ofs_ip_cfg_db.vh"
 
 `ifndef ofs_asp_vh
 


### PR DESCRIPTION
### Description
A recent change to the header files used in the FIM broke ASP builds. ASP was explicitly including specific vh files, as well as explicit defines from them. This change leverages the single FIM vh file that already `includes the necessarily vh files. We will need to find a better way to access the `define assignments, though - preferably something within the PIM's pkg/vh files since those should abstract the details away from the ASP while retaining the same names.

### Tests run:
Compilation of n6001 sample designs using nightly base FIM (5pf/3vf) have all progressed further than the nightly builds did. 

