### PR TITLE
*[Fix]- Update header files to match changes to FIM

### DIFF
--- a/fseries-dk/hardware/ofs_fseries-dk/build/rtl/ofs_asp.vh
+++ b/fseries-dk/hardware/ofs_fseries-dk/build/rtl/ofs_asp.vh
@@ -17,16 +17,27 @@
     //`define ASP_ENABLE_HOSTMEM_CH_2 1
     //`define ASP_ENABLE_HOSTMEM_CH_3 1
 
+    //the FIM changed the 'mem_ss' define name to
+    // 'local_mem'; make it backward compatible (at 
+    // the expense of being verbose and ugly)
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_0
+        `define ASP_ENABLE_DDR4_BANK_0 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_0
         `define ASP_ENABLE_DDR4_BANK_0 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_1
         `define ASP_ENABLE_DDR4_BANK_1 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
+        `define ASP_ENABLE_DDR4_BANK_1 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_2
         `define ASP_ENABLE_DDR4_BANK_2 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
+        `define ASP_ENABLE_DDR4_BANK_1 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_3
+        `define ASP_ENABLE_DDR4_BANK_3 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_3
         `define ASP_ENABLE_DDR4_BANK_3 1
     `endif
     

--- a/fseries-dk/hardware/ofs_fseries-dk_usm/build/rtl/ofs_asp.vh
+++ b/fseries-dk/hardware/ofs_fseries-dk_usm/build/rtl/ofs_asp.vh
@@ -17,16 +17,27 @@
     //`define ASP_ENABLE_HOSTMEM_CH_2 1
     //`define ASP_ENABLE_HOSTMEM_CH_3 1
 
+    //the FIM changed the 'mem_ss' define name to
+    // 'local_mem'; make it backward compatible (at 
+    // the expense of being verbose and ugly)
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_0
+        `define ASP_ENABLE_DDR4_BANK_0 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_0
         `define ASP_ENABLE_DDR4_BANK_0 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_1
         `define ASP_ENABLE_DDR4_BANK_1 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
+        `define ASP_ENABLE_DDR4_BANK_1 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_2
         `define ASP_ENABLE_DDR4_BANK_2 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
+        `define ASP_ENABLE_DDR4_BANK_1 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_3
+        `define ASP_ENABLE_DDR4_BANK_3 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_3
         `define ASP_ENABLE_DDR4_BANK_3 1
     `endif
     

--- a/iseries-dk/hardware/ofs_iseries-dk/build/rtl/ofs_asp.vh
+++ b/iseries-dk/hardware/ofs_iseries-dk/build/rtl/ofs_asp.vh
@@ -17,16 +17,27 @@
     //`define ASP_ENABLE_HOSTMEM_CH_2 1
     //`define ASP_ENABLE_HOSTMEM_CH_3 1
 
+    //the FIM changed the 'mem_ss' define name to
+    // 'local_mem'; make it backward compatible (at 
+    // the expense of being verbose and ugly)
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_0
+        `define ASP_ENABLE_DDR4_BANK_0 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_0
         `define ASP_ENABLE_DDR4_BANK_0 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_1
         `define ASP_ENABLE_DDR4_BANK_1 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
+        `define ASP_ENABLE_DDR4_BANK_1 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_2
         `define ASP_ENABLE_DDR4_BANK_2 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
+        `define ASP_ENABLE_DDR4_BANK_1 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_3
+        `define ASP_ENABLE_DDR4_BANK_3 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_3
         `define ASP_ENABLE_DDR4_BANK_3 1
     `endif
     

--- a/iseries-dk/hardware/ofs_iseries-dk_usm/build/rtl/ofs_asp.vh
+++ b/iseries-dk/hardware/ofs_iseries-dk_usm/build/rtl/ofs_asp.vh
@@ -17,16 +17,27 @@
     //`define ASP_ENABLE_HOSTMEM_CH_2 1
     //`define ASP_ENABLE_HOSTMEM_CH_3 1
 
+    //the FIM changed the 'mem_ss' define name to
+    // 'local_mem'; make it backward compatible (at 
+    // the expense of being verbose and ugly)
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_0
+        `define ASP_ENABLE_DDR4_BANK_0 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_0
         `define ASP_ENABLE_DDR4_BANK_0 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_1
         `define ASP_ENABLE_DDR4_BANK_1 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
+        `define ASP_ENABLE_DDR4_BANK_1 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_2
         `define ASP_ENABLE_DDR4_BANK_2 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
+        `define ASP_ENABLE_DDR4_BANK_1 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_3
+        `define ASP_ENABLE_DDR4_BANK_3 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_3
         `define ASP_ENABLE_DDR4_BANK_3 1
     `endif
     

--- a/n6001/hardware/ofs_n6001_iopipes/build/rtl/ofs_asp.vh
+++ b/n6001/hardware/ofs_n6001_iopipes/build/rtl/ofs_asp.vh
@@ -17,16 +17,27 @@
     //`define ASP_ENABLE_HOSTMEM_CH_2 1
     //`define ASP_ENABLE_HOSTMEM_CH_3 1
 
+    //the FIM changed the 'mem_ss' define name to
+    // 'local_mem'; make it backward compatible (at 
+    // the expense of being verbose and ugly)
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_0
+        `define ASP_ENABLE_DDR4_BANK_0 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_0
         `define ASP_ENABLE_DDR4_BANK_0 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_1
         `define ASP_ENABLE_DDR4_BANK_1 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
+        `define ASP_ENABLE_DDR4_BANK_1 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_2
         `define ASP_ENABLE_DDR4_BANK_2 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
+        `define ASP_ENABLE_DDR4_BANK_1 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_3
+        `define ASP_ENABLE_DDR4_BANK_3 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_3
         `define ASP_ENABLE_DDR4_BANK_3 1
     `endif
     

--- a/n6001/hardware/ofs_n6001_usm/build/rtl/ofs_asp.vh
+++ b/n6001/hardware/ofs_n6001_usm/build/rtl/ofs_asp.vh
@@ -17,16 +17,27 @@
     //`define ASP_ENABLE_HOSTMEM_CH_2 1
     //`define ASP_ENABLE_HOSTMEM_CH_3 1
 
+    //the FIM changed the 'mem_ss' define name to
+    // 'local_mem'; make it backward compatible (at 
+    // the expense of being verbose and ugly)
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_0
+        `define ASP_ENABLE_DDR4_BANK_0 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_0
         `define ASP_ENABLE_DDR4_BANK_0 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_1
         `define ASP_ENABLE_DDR4_BANK_1 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
+        `define ASP_ENABLE_DDR4_BANK_1 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_2
         `define ASP_ENABLE_DDR4_BANK_2 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
+        `define ASP_ENABLE_DDR4_BANK_1 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_3
+        `define ASP_ENABLE_DDR4_BANK_3 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_3
         `define ASP_ENABLE_DDR4_BANK_3 1
     `endif
     

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/ofs_asp.vh
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/ofs_asp.vh
@@ -17,16 +17,27 @@
     //`define ASP_ENABLE_HOSTMEM_CH_2 1
     //`define ASP_ENABLE_HOSTMEM_CH_3 1
 
+    //the FIM changed the 'mem_ss' define name to
+    // 'local_mem'; make it backward compatible (at 
+    // the expense of being verbose and ugly)
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_0
+        `define ASP_ENABLE_DDR4_BANK_0 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_0
         `define ASP_ENABLE_DDR4_BANK_0 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_1
         `define ASP_ENABLE_DDR4_BANK_1 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
+        `define ASP_ENABLE_DDR4_BANK_1 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_2
         `define ASP_ENABLE_DDR4_BANK_2 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
+        `define ASP_ENABLE_DDR4_BANK_1 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_3
+        `define ASP_ENABLE_DDR4_BANK_3 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_3
         `define ASP_ENABLE_DDR4_BANK_3 1
     `endif
     


### PR DESCRIPTION
### Description
A recent change to the FIM's defines caused the local-memory defines in the ASP to be mishandled. This will hopefully go away with the move to qprs/ip files, but this is a fix for the rest of the Agilex variants for now. I accidentally only fixed one of the vh files with my earlier commit, while the rest of the vh files were only partially fixed (I moved the bug around instead of resolving it for those incomplete changes). I noticed this while using ASE with iseries-dk and the memory-interfaces in board.sv were weird.

### Tests run:
Compilation of a few designs for each variant. Opening the database in the Quartus GUI shows me that the ddr_board and ddr_channel IPs consume resources, whereas without the change those IPs were either missing or tiny. Also, the build-time increased drastically (it doesn't take much time to compile a kernel with no access to local memory).