### PR TITLE
*[Fix]- Fix typo in memory-interface defines for Agilex-based platforms

### DIFF
--- a/fseries-dk/hardware/ofs_fseries-dk/build/rtl/ofs_asp.vh
+++ b/fseries-dk/hardware/ofs_fseries-dk/build/rtl/ofs_asp.vh
@@ -32,8 +32,8 @@
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_2
         `define ASP_ENABLE_DDR4_BANK_2 1
-    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
-        `define ASP_ENABLE_DDR4_BANK_1 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_2
+        `define ASP_ENABLE_DDR4_BANK_2 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_3
         `define ASP_ENABLE_DDR4_BANK_3 1

--- a/fseries-dk/hardware/ofs_fseries-dk_usm/build/rtl/ofs_asp.vh
+++ b/fseries-dk/hardware/ofs_fseries-dk_usm/build/rtl/ofs_asp.vh
@@ -32,8 +32,8 @@
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_2
         `define ASP_ENABLE_DDR4_BANK_2 1
-    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
-        `define ASP_ENABLE_DDR4_BANK_1 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_2
+        `define ASP_ENABLE_DDR4_BANK_2 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_3
         `define ASP_ENABLE_DDR4_BANK_3 1

--- a/iseries-dk/hardware/ofs_iseries-dk/build/rtl/ofs_asp.vh
+++ b/iseries-dk/hardware/ofs_iseries-dk/build/rtl/ofs_asp.vh
@@ -32,8 +32,8 @@
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_2
         `define ASP_ENABLE_DDR4_BANK_2 1
-    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
-        `define ASP_ENABLE_DDR4_BANK_1 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_2
+        `define ASP_ENABLE_DDR4_BANK_2 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_3
         `define ASP_ENABLE_DDR4_BANK_3 1

--- a/iseries-dk/hardware/ofs_iseries-dk_usm/build/rtl/ofs_asp.vh
+++ b/iseries-dk/hardware/ofs_iseries-dk_usm/build/rtl/ofs_asp.vh
@@ -32,8 +32,8 @@
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_2
         `define ASP_ENABLE_DDR4_BANK_2 1
-    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
-        `define ASP_ENABLE_DDR4_BANK_1 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_2
+        `define ASP_ENABLE_DDR4_BANK_2 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_3
         `define ASP_ENABLE_DDR4_BANK_3 1

--- a/n6001/hardware/ofs_n6001/build/rtl/ofs_asp.vh
+++ b/n6001/hardware/ofs_n6001/build/rtl/ofs_asp.vh
@@ -32,8 +32,8 @@
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_2
         `define ASP_ENABLE_DDR4_BANK_2 1
-    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
-        `define ASP_ENABLE_DDR4_BANK_1 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_2
+        `define ASP_ENABLE_DDR4_BANK_2 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_3
         `define ASP_ENABLE_DDR4_BANK_3 1

--- a/n6001/hardware/ofs_n6001_iopipes/build/rtl/ofs_asp.vh
+++ b/n6001/hardware/ofs_n6001_iopipes/build/rtl/ofs_asp.vh
@@ -32,8 +32,8 @@
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_2
         `define ASP_ENABLE_DDR4_BANK_2 1
-    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
-        `define ASP_ENABLE_DDR4_BANK_1 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_2
+        `define ASP_ENABLE_DDR4_BANK_2 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_3
         `define ASP_ENABLE_DDR4_BANK_3 1

--- a/n6001/hardware/ofs_n6001_usm/build/rtl/ofs_asp.vh
+++ b/n6001/hardware/ofs_n6001_usm/build/rtl/ofs_asp.vh
@@ -32,8 +32,8 @@
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_2
         `define ASP_ENABLE_DDR4_BANK_2 1
-    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
-        `define ASP_ENABLE_DDR4_BANK_1 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_2
+        `define ASP_ENABLE_DDR4_BANK_2 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_3
         `define ASP_ENABLE_DDR4_BANK_3 1

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/ofs_asp.vh
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/ofs_asp.vh
@@ -32,8 +32,8 @@
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_2
         `define ASP_ENABLE_DDR4_BANK_2 1
-    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_1
-        `define ASP_ENABLE_DDR4_BANK_1 1
+    `elsif OFS_FIM_IP_CFG_LOCAL_MEM_EN_MEM_2
+        `define ASP_ENABLE_DDR4_BANK_2 1
     `endif
     `ifdef OFS_FIM_IP_CFG_MEM_SS_EN_MEM_3
         `define ASP_ENABLE_DDR4_BANK_3 1


### PR DESCRIPTION
### Description
In earlier commits a typo was made for the assignment of the local-memory channel 2 interface. This should remedy that typo.

### Tests added:
None

### Tests run:
Visual review, ASE compilation and debugging of a different change.

