### PR TITLE
*[Fix]- Fix a bug in USM tie-off handling*

### DIFF
--- a/common/hardware/common/build/rtl/kernel_wrapper.v
+++ b/common/hardware/common/build/rtl/kernel_wrapper.v
@@ -427,14 +427,18 @@ kernel_system kernel_system_inst (
 );
 
 `ifdef INCLUDE_USM_SUPPORT
-    `ifndef ASP_ENABLE_USM_CH_1
-            assign svm_avmm_kernelsystem[1].burstcount = 0;
-            assign svm_avmm_kernelsystem[1].writedata = 0;
-            assign svm_avmm_kernelsystem[1].address = 0;
-            assign svm_avmm_kernelsystem[1].write = 0;
-            assign svm_avmm_kernelsystem[1].read = 0;
-            assign svm_avmm_kernelsystem[1].byteenable = 0;
-    `endif
+    //Until we sort out the ASP/compiler support for multiple USM channels I'm tying them
+    //off here for channels higher than [0]. 
+    genvar i;
+    generate for (i=1; i<NUM_USM_CHAN; i=i+1) begin: tie_off_extra_usm_chans
+        assign svm_avmm_kernelsystem[i].burstcount = 0;
+        assign svm_avmm_kernelsystem[i].writedata = 0;
+        assign svm_avmm_kernelsystem[i].address = 0;
+        assign svm_avmm_kernelsystem[i].write = 0;
+        assign svm_avmm_kernelsystem[i].read = 0;
+        assign svm_avmm_kernelsystem[i].byteenable = 0;
+    end : tie_off_extra_usm_chans
+    endgenerate
     `ifdef USM_DO_SINGLE_BURST_PARTIAL_WRITES
         genvar uu;
         generate


### PR DESCRIPTION
### Description
There is a bug in kernel-wrapper when no USM channels are included in the ASP, yet the ASP was still trying to tie-off signals that didn't exist.


### Collateral (docs, reports, design examples, case IDs):
None


- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
Compiled shs, bhs, zcdt, edm for D5005 platform.