### PR TITLE
*[Fix]- Fix the tie-off assignment parameter for host-channels

### DIFF
--- a/common/hardware/common/build/rtl/ofs_plat_afu.sv
+++ b/common/hardware/common/build/rtl/ofs_plat_afu.sv
@@ -180,7 +180,7 @@ module ofs_plat_afu
         // This way, the AFU does not need to know about every available
         // device. By default, devices are tied off.
         .HOST_CHAN_IN_USE_MASK({NUM_HOSTMEM_CHAN{1'b1}}),
-	//.HOST_CHAN_IN_USE_MASK(6'b001001), //for 2xGen5x8 iseries-dk
+	    //.HOST_CHAN_IN_USE_MASK(6'b001001), //for 2xGen5x8 iseries-dk
         .LOCAL_MEM_IN_USE_MASK({ASP_LOCALMEM_NUM_CHANNELS{1'b1}})
         `ifdef INCLUDE_IO_PIPES
             // The argument to each parameter is a bit mask of channels used.

--- a/common/hardware/common/build/rtl/ofs_plat_afu.sv
+++ b/common/hardware/common/build/rtl/ofs_plat_afu.sv
@@ -179,8 +179,8 @@ module ofs_plat_afu
         // Set a bit in the mask when a port is IN USE by the design.
         // This way, the AFU does not need to know about every available
         // device. By default, devices are tied off.
-        //.HOST_CHAN_IN_USE_MASK({NUM_HOSTMEM_CHAN{1'b1}}),
-        .HOST_CHAN_IN_USE_MASK(6'b001001),
+        .HOST_CHAN_IN_USE_MASK({NUM_HOSTMEM_CHAN{1'b1}}),
+	//.HOST_CHAN_IN_USE_MASK(6'b001001), //for 2xGen5x8 iseries-dk
         .LOCAL_MEM_IN_USE_MASK({ASP_LOCALMEM_NUM_CHANNELS{1'b1}})
         `ifdef INCLUDE_IO_PIPES
             // The argument to each parameter is a bit mask of channels used.


### PR DESCRIPTION
### Description
The host-channel tie-off parameter was accidentally included in a previous PR. For single-link the value should simply remain 'b1. For multiple links it needs to be changed to match the aggregated VF channels.


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:


