### PR TITLE
fix paths for EMIF clocks

### DIFF
--- a/fseries-dk/hardware/common/build/ofs_asp.sdc
+++ b/fseries-dk/hardware/common/build/ofs_asp.sdc
@@ -2,7 +2,7 @@
 set_clock_groups -asynchronous  -group [get_clocks {sys_pll|iopll_0_clk_sys}] \
                                 -group [get_clocks {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
                                                     afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
-                                -group [get_clocks {mem_ss_top|mem_ss*inst|mem_ss_fm*|intf_0_core_usr_clk \
-                                                    mem_ss_top|mem_ss*inst|mem_ss_fm*|intf_1_core_usr_clk \
-                                                    mem_ss_top|mem_ss*inst|mem_ss_fm*|intf_2_core_usr_clk \
-                                                    mem_ss_top|mem_ss*inst|mem_ss_fm*|intf_3_core_usr_clk}]
+                                -group [get_clocks {mem_ss_top|mem_ss_inst|mem_ss|emif_0|emif_0_core_usr_clk \
+                                                    mem_ss_top|mem_ss_inst|mem_ss|emif_1|emif_1_core_usr_clk \
+                                                    mem_ss_top|mem_ss_inst|mem_ss|emif_2|emif_2_core_usr_clk \
+                                                    mem_ss_top|mem_ss_inst|mem_ss|emif_3|emif_3_core_usr_clk}]

--- a/iseries-dk/hardware/common/build/ofs_asp.sdc
+++ b/iseries-dk/hardware/common/build/ofs_asp.sdc
@@ -2,7 +2,7 @@
 set_clock_groups -asynchronous  -group [get_clocks {sys_pll|iopll_0_clk_sys}] \
                                 -group [get_clocks {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
                                                     afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
-                                -group [get_clocks {mem_ss_top|mem_ss*inst|mem_ss_fm*|intf_0_core_usr_clk \
-                                                    mem_ss_top|mem_ss*inst|mem_ss_fm*|intf_1_core_usr_clk \
-                                                    mem_ss_top|mem_ss*inst|mem_ss_fm*|intf_2_core_usr_clk \
-                                                    mem_ss_top|mem_ss*inst|mem_ss_fm*|intf_3_core_usr_clk}]
+                                -group [get_clocks {mem_ss_top|mem_ss_inst|mem_ss|emif_0|emif_0_core_usr_clk \
+                                                    mem_ss_top|mem_ss_inst|mem_ss|emif_1|emif_1_core_usr_clk \
+                                                    mem_ss_top|mem_ss_inst|mem_ss|emif_2|emif_2_core_usr_clk \
+                                                    mem_ss_top|mem_ss_inst|mem_ss|emif_3|emif_3_core_usr_clk}]

--- a/n6001/hardware/common/build/ofs_asp.sdc
+++ b/n6001/hardware/common/build/ofs_asp.sdc
@@ -2,7 +2,7 @@
 set_clock_groups -asynchronous  -group [get_clocks {sys_pll|iopll_0_clk_sys}] \
                                 -group [get_clocks {afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk1 \
                                                     afu_top|pg_afu.port_gasket|user_clock|qph_user_clk|qph_user_clk_iopll|iopll_0_outclk0}] \
-                                -group [get_clocks {mem_ss_top|mem_ss*inst|mem_ss_fm*|intf_0_core_usr_clk \
-                                                    mem_ss_top|mem_ss*inst|mem_ss_fm*|intf_1_core_usr_clk \
-                                                    mem_ss_top|mem_ss*inst|mem_ss_fm*|intf_2_core_usr_clk \
-                                                    mem_ss_top|mem_ss*inst|mem_ss_fm*|intf_3_core_usr_clk}]
+                                -group [get_clocks {mem_ss_top|mem_ss_inst|mem_ss|emif_0|emif_0_core_usr_clk \
+                                                    mem_ss_top|mem_ss_inst|mem_ss|emif_1|emif_1_core_usr_clk \
+                                                    mem_ss_top|mem_ss_inst|mem_ss|emif_2|emif_2_core_usr_clk \
+                                                    mem_ss_top|mem_ss_inst|mem_ss|emif_3|emif_3_core_usr_clk}]


### PR DESCRIPTION
### Description
The original SDC assignments for the EMIF clocks were wrong and led to timing violations in the analyses because the clock domains weren't set to be asynchronous.

### Collateral (docs, reports, design examples, case IDs):

### Tests added:
none

### Tests run:
ran board_test compile for n6001, iseries-dk and fseries-dk ASPs

