### PR TITLE
update board_spec.xml version with Quartus version needed from FIMs

### DIFF
--- a/d5005/hardware/ofs_d5005/board_spec.xml
+++ b/d5005/hardware/ofs_d5005/board_spec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<board version="2024.0" name="ofs_d5005">
+<board version="23.4" name="ofs_d5005">
 
   <compile name="afu_flat" project="d5005" revision="iofs_pr_afu" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>

--- a/d5005/hardware/ofs_d5005_usm/board_spec.xml
+++ b/d5005/hardware/ofs_d5005_usm/board_spec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<board version="2024.0" name="ofs_d5005_usm">
+<board version="23.4" name="ofs_d5005_usm">
 
   <compile name="afu_flat" project="d5005" revision="iofs_pr_afu" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>

--- a/fseries-dk/hardware/ofs_fseries-dk/board_spec.xml
+++ b/fseries-dk/hardware/ofs_fseries-dk/board_spec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<board version="2024.0" name="ofs_fseries-dk">
+<board version="24.1" name="ofs_fseries-dk">
 
   <compile name="afu_flat" project="ofs_top" revision="ofs_pr_afu" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>

--- a/fseries-dk/hardware/ofs_fseries-dk_usm/board_spec.xml
+++ b/fseries-dk/hardware/ofs_fseries-dk_usm/board_spec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<board version="2024.0" name="ofs_fseries-dk_usm">
+<board version="24.1" name="ofs_fseries-dk_usm">
 
   <compile name="afu_flat" project="ofs_top" revision="ofs_pr_afu" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>

--- a/iseries-dk/hardware/ofs_iseries-dk/board_spec.xml
+++ b/iseries-dk/hardware/ofs_iseries-dk/board_spec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<board version="2024.0" name="ofs_iseries-dk">
+<board version="24.1" name="ofs_iseries-dk">
 
   <compile name="afu_flat" project="ofs_top" revision="ofs_pr_afu" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>

--- a/iseries-dk/hardware/ofs_iseries-dk_usm/board_spec.xml
+++ b/iseries-dk/hardware/ofs_iseries-dk_usm/board_spec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<board version="2024.0" name="ofs_iseries-dk_usm">
+<board version="24.1" name="ofs_iseries-dk_usm">
 
   <compile name="afu_flat" project="ofs_top" revision="ofs_pr_afu" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>

--- a/n6001/hardware/ofs_n6001/board_spec.xml
+++ b/n6001/hardware/ofs_n6001/board_spec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<board version="2024.0" name="ofs_n6001">
+<board version="24.1" name="ofs_n6001">
 
   <compile name="afu_flat" project="ofs_top" revision="ofs_pr_afu" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>

--- a/n6001/hardware/ofs_n6001_iopipes/board_spec.xml
+++ b/n6001/hardware/ofs_n6001_iopipes/board_spec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<board version="2024.0" name="ofs_n6001_iopipes">
+<board version="24.1" name="ofs_n6001_iopipes">
 
   <compile name="afu_flat" project="ofs_top" revision="ofs_pr_afu" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>

--- a/n6001/hardware/ofs_n6001_usm/board_spec.xml
+++ b/n6001/hardware/ofs_n6001_usm/board_spec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<board version="2024.0" name="ofs_n6001_usm">
+<board version="24.1" name="ofs_n6001_usm">
 
   <compile name="afu_flat" project="ofs_top" revision="ofs_pr_afu" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>

--- a/n6001/hardware/ofs_n6001_usm_iopipes/board_spec.xml
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/board_spec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<board version="2024.0" name="ofs_n6001_usm_iopipes">
+<board version="24.1" name="ofs_n6001_usm_iopipes">
 
   <compile name="afu_flat" project="ofs_top" revision="ofs_pr_afu" qsys_file="none" generic_kernel="1">
     <generate cmd="echo"/>


### PR DESCRIPTION
### Description
The version field in board_spec.xml should match the required Quartus version to be used for compilation. It was updated to 24.1 for the 2024.2 ASP release for n6001, iseries-dk and fseries-dk and for 23.4 for d5005 as this FIM is still using Quartus 23.4.


### Collateral (docs, reports, design examples, case IDs):
none

### Tests added:
none

### Tests run:
compile test for n6001, iseries-dk, fseries-dk and d5005

