### PR TITLE
setup_permissions.sh: configure 2048 2M hugepages

### DIFF
--- a/common/linux64/libexec/setup_permissions.sh
+++ b/common/linux64/libexec/setup_permissions.sh
@@ -98,7 +98,7 @@ EOF
 ################################################################################
 set_hugepages()
 {
-  NUM_HUGE_PAGES=${OFS_ASP_ENV_NUM_HUGEPAGES:-1024}
+  NUM_HUGE_PAGES=${OFS_ASP_ENV_NUM_HUGEPAGES:-2048}
   echo "Configuring system with $NUM_HUGE_PAGES 2M hugepages"
   sudo sh -c "cat > /etc/sysctl.d/intel-fpga-opencl-sysctl.conf" << EOF
 vm.nr_hugepages = $NUM_HUGE_PAGES


### PR DESCRIPTION
Set NUM_HUGE_PAGES according to comment for a total of 4G of host memory.

Closes: https://github.com/OFS/oneapi-asp/issues/141