### PR TITLE
[Fix] oneapi_asp_editor_hw.tcl: remove trailing whitespace after backsl...

### DIFF
--- a/oneapi_asp_editor/oneapi_asp_editor_hw.tcl
+++ b/oneapi_asp_editor/oneapi_asp_editor_hw.tcl
@@ -1051,7 +1051,7 @@ namespace eval oneapi_asp_editor::global_mem {
       [list MEM_${i}_LATENCY "Latency (for oneAPI compiler)" "Global Memory $i" INTEGER 1500 "" "" "" \
         "" "" "" "" "" "" \
         "" "" "The latency of the global memory system in clock cycles" \
-      ] \     
+      ] \
   }
 
   ::add_param $::parameter_properties $mem_dynamic_param


### PR DESCRIPTION
…ash to avoid appending an empty element

### Description
*Describe the issue, update, change or fix and **why***

Because of these trailing whitespaces, `$mem_dynamic_param` gets an extra empty list.
This results in a failure with a cryptic error message.
Removing whitespaces fix it.

```
Error: add_parameter:  Bad parameter name. Parameter names are case sensitive. Parameter names should start with letters and they can end with letters or numbers. Use of special characters except underscore in parameter names are not allowed.
    while executing
"add_parameter $i [lindex $val [lsearch -exact $prop_list "TYPE"]]"
    (procedure "::add_param" line 6)
    invoked from within
"::add_param $::parameter_properties $mem_dynamic_param"
    (in namespace eval "::oneapi_asp_editor::global_mem" script line 29)
    invoked from within
"namespace eval oneapi_asp_editor::global_mem {
  namespace export mem_elab
  namespace export mem_dynamic_param
  set GLOBAL_MEM_MAX 4
  # Maximum num..."
```

### Collateral (docs, reports, design examples, case IDs):

none

- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:

none

### Tests run:

none