### PR TITLE
*[Fix] async reset syntax bug*

### DIFF
--- a/common/hardware/common/build/rtl/avmm_wr_ack_gen.sv
+++ b/common/hardware/common/build/rtl/avmm_wr_ack_gen.sv
@@ -41,8 +41,8 @@ import local_mem_cfg_pkg::*;
 logic [1:0] kernel_avmm_reset_d;
 logic kernel_avmm_reset_lcl;
 always_ff @(posedge kernel_avmm_clk or posedge kernel_avmm_reset) begin
-    kernel_avmm_reset_d <= {kernel_avmm_reset_d[0], 1'b0};
     if (kernel_avmm_reset) kernel_avmm_reset_d <= 2'b11;
+    else                   kernel_avmm_reset_d <= {kernel_avmm_reset_d[0], 1'b0};
 end
 assign kernel_avmm_reset_lcl = kernel_avmm_reset_d[1];
 


### PR DESCRIPTION
Earlier versions of Quartus didn't complain, but this asynchronous reset coding is incorrect and should be fixed.

### Description
The syntax for this register's async reset is wrong and the latest version of Quartus complains about it.


### Collateral (docs, reports, design examples, case IDs):
None


- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
Compiled using Quartus 24.3/175 (matching the recent FIM version).

