### PR TITLE
[Update] Updates to ASE for latest Quartus and sycl compiler versions

### DIFF
--- a/common/ase/compile-kernel.sh
+++ b/common/ase/compile-kernel.sh
@@ -51,7 +51,7 @@ elif [ -d "$DESIGN_SRC" ]; then
     echo "pwd is $PWD"
     cd ${BOARD}
     echo "pwd is $PWD, cmake is next"
-    cmake "$DESIGN_SRC" -DFPGA_DEVICE=${OFS_ASP_ROOT}:${BOARD} -DIS_BSP=1 -DUSER_HARDWARE_FLAGS="-Xsno-env-check"
+    cmake "$DESIGN_SRC" -DFPGA_DEVICE=${OFS_ASP_ROOT}:${BOARD} -DDEVICE_FLAG=Agilex7 -DIS_BSP=1 -DUSER_HARDWARE_FLAGS="-Xsno-env-check"
     echo "after cmake"
     make fpga
     echo "make fpga is done; break out the aocx file"

--- a/common/ase/setup.sh
+++ b/common/ase/setup.sh
@@ -73,8 +73,10 @@ if ! command -v vcs; then
 fi
 
 export OFS_ASP_ENV_ENABLE_ASE=1
-if [ ! -f "$ASP_ROOT/hardware/ofs_*/*.qpf" ]; then
-  echo "The qpf file doesn't exist, so we need to run build-asp.sh"
+#the qpf files are now symbolic links, so the previous check doesn't work anymore.
+found_qpf_files=$(find $ASP_ROOT/hardware/ -name *.qpf 2>/dev/null)
+if [[ -z "$found_qpf_files" ]]; then
+  echo "The ASP hasn't been set up yet, so we need to run build-asp.sh"
   "$ASP_ROOT/scripts/build-asp.sh"
   set_libopae_c_root
 else

--- a/common/ase/simulate-aocx.sh
+++ b/common/ase/simulate-aocx.sh
@@ -109,8 +109,12 @@ cp -prf vlog_files_base.list vlog_files.list
 sed -i '/.iv$/d' ./vlog_files.list
 sed -i '/.vh$/d' ./vlog_files.list
 sed -i '/.csv$/d' ./vlog_files.list
-sed -i '/inst\.v$/d' ./vlog_files.list
+sed -i '/inst\.*\.\(v\|sv\)$/d' ./vlog_files.list
 sed -i '/.hex$/d' ./vlog_files.list
+
+#find the opae-sim Makefile and add the ' -ignore initializer_driver_checks' flag to SNPS_VCS_OPT
+THIS_MAKEFILE='Makefile'
+sed -i -e 's/SNPS_VCS_OPT+= -j 4/SNPS_VCS_OPT+= -ignore initializer_driver_checks -j 4/' $THIS_MAKEFILE
 
 cp -prf "$ASE_DIR_PATH"/hack_ip_files/* ./qsys_files/
 cp -prf "$ASE_DIR_PATH"/hack_ip_files/* ./sim_files/


### PR DESCRIPTION
### Description
Most recent versions of ACDS, sycl, and OPAE require a few changes to support ASE.


### Collateral (docs, reports, design examples, case IDs):
none


- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:
none

### Tests run:
zero-copy-data-transfer kernel with n6001 usm variant. Test hangs, but at least it compiles. Debugging possible compiler bug since the ASP hasn't really changed and the runtime polls the kernel's status forever.

