### PR TITLE
[Fix] Update write-ack definitions

### DIFF
--- a/fseries-dk/hardware/ofs_fseries-dk/build/rtl/ofs_asp.vh
+++ b/fseries-dk/hardware/ofs_fseries-dk/build/rtl/ofs_asp.vh
@@ -80,7 +80,10 @@
     //if this is disabled, you also need to remove the 
     // bsp_avmm_write_ack="1" setting(s) board_spec.xml.
     `define USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES 1
-
+    `define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
     
     //enable UDP offload engine and I/O channels
     //`define INCLUDE_IO_PIPES 1

--- a/fseries-dk/hardware/ofs_fseries-dk_usm/build/rtl/ofs_asp.vh
+++ b/fseries-dk/hardware/ofs_fseries-dk_usm/build/rtl/ofs_asp.vh
@@ -80,7 +80,10 @@
     //if this is disabled, you also need to remove the 
     // bsp_avmm_write_ack="1" setting(s) board_spec.xml.
     `define USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES 1
-
+    `define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
     
     //enable UDP offload engine and I/O channels
     //`define INCLUDE_IO_PIPES 1

--- a/iseries-dk/hardware/ofs_iseries-dk/build/rtl/ofs_asp.vh
+++ b/iseries-dk/hardware/ofs_iseries-dk/build/rtl/ofs_asp.vh
@@ -80,7 +80,10 @@
     //if this is disabled, you also need to remove the 
     // bsp_avmm_write_ack="1" setting(s) board_spec.xml.
     `define USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES 1
-
+    `define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
     
     //enable UDP offload engine and I/O channels
     //`define INCLUDE_IO_PIPES 1

--- a/iseries-dk/hardware/ofs_iseries-dk_usm/build/rtl/ofs_asp.vh
+++ b/iseries-dk/hardware/ofs_iseries-dk_usm/build/rtl/ofs_asp.vh
@@ -80,7 +80,10 @@
     //if this is disabled, you also need to remove the 
     // bsp_avmm_write_ack="1" setting(s) board_spec.xml.
     `define USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES 1
-
+    `define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
     
     //enable UDP offload engine and I/O channels
     //`define INCLUDE_IO_PIPES 1

--- a/n6001/hardware/ofs_n6001/build/rtl/ofs_asp.vh
+++ b/n6001/hardware/ofs_n6001/build/rtl/ofs_asp.vh
@@ -80,7 +80,10 @@
     //if this is disabled, you also need to remove the 
     // bsp_avmm_write_ack="1" setting(s) board_spec.xml.
     `define USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES 1
-
+    `define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
     
     //enable UDP offload engine and I/O channels
     //`define INCLUDE_IO_PIPES 1

--- a/n6001/hardware/ofs_n6001_iopipes/build/rtl/ofs_asp.vh
+++ b/n6001/hardware/ofs_n6001_iopipes/build/rtl/ofs_asp.vh
@@ -80,7 +80,10 @@
     //if this is disabled, you also need to remove the 
     // bsp_avmm_write_ack="1" setting(s) board_spec.xml.
     `define USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES 1
-
+    `define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
     
     //enable UDP offload engine and I/O channels
     `define INCLUDE_IO_PIPES 1

--- a/n6001/hardware/ofs_n6001_usm/build/rtl/ofs_asp.vh
+++ b/n6001/hardware/ofs_n6001_usm/build/rtl/ofs_asp.vh
@@ -80,7 +80,10 @@
     //if this is disabled, you also need to remove the 
     // bsp_avmm_write_ack="1" setting(s) board_spec.xml.
     `define USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES 1
-
+    `define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
     
     //enable UDP offload engine and I/O channels
     //`define INCLUDE_IO_PIPES 1

--- a/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/ofs_asp.vh
+++ b/n6001/hardware/ofs_n6001_usm_iopipes/build/rtl/ofs_asp.vh
@@ -80,7 +80,10 @@
     //if this is disabled, you also need to remove the 
     // bsp_avmm_write_ack="1" setting(s) board_spec.xml.
     `define USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES 1
-
+    `define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
+    //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1
     
     //enable UDP offload engine and I/O channels
     `define INCLUDE_IO_PIPES 1

--- a/oneapi_asp_editor/oneapi_asp_editor_hw.tcl
+++ b/oneapi_asp_editor/oneapi_asp_editor_hw.tcl
@@ -149,6 +149,10 @@ proc generate_vh {} {
     puts $fp "  // if this is disabled, you also need to remove the" 
     puts $fp "  // bsp_avmm_write_ack=\"1\" setting(s) board_spec.xml."
     puts $fp "  `define USE_WRITEACKS_FOR_KERNELSYSTEM_LOCALMEMORY_ACCESSES 1\n"
+    puts $fp "  `define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1\n"
+    puts $fp "  //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1\n"
+    puts $fp "  //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1\n"
+    puts $fp "  //`define USE_WRITEACKS_FOR_KERNELSYSTEM_GLOBAL_MEMORY_0_ACCESSES 1\n"
   }
 
   # IO channels


### PR DESCRIPTION
### Description
The write-ack `defines are not being handled properly - this commit should fix them for the platforms that require write-acks (where the FIM uses AXI rather than AVMM).
In ASE I can see the kernel-system make a write-request that never gets ack'd/completed.

### Collateral (docs, reports, design examples, case IDs):
None


- [N] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:
none

### Tests run:
boardtest 'launch kernel' test in ASE - hangs without the change, passes with it. 

