### PR TITLE
[Update] build-opae.sh to use latest opae-sim

### DIFF
--- a/common/scripts/build-opae.sh
+++ b/common/scripts/build-opae.sh
@@ -121,7 +121,8 @@ if [ -n "$OFS_ASP_ENV_ENABLE_ASE" ]; then
     fi
     # Default branch to 'master' if the branch variable is not set
     if [ -z "${OPAESIM_REPO_BRANCH}" ]; then
-        OPAESIM_REPO_BRANCH="release/2.5.0"
+        #OPAESIM_REPO_BRANCH="release/2.5.0"
+        OPAESIM_REPO_BRANCH="master"
     fi
     # Default location to clone is $BUILD_PREFIX/opae-sim
     if [ -z "${OPAESIM_PATH}" ]; then


### PR DESCRIPTION
### Description
Update the scripts to use opae-sim's master branch by default.


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
ASE boardtest and zcdt.

